### PR TITLE
docs: fix npm install command to use GitHub source

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Bridge listens locally on:
 ### Option A — npm (recommended)
 
 ```bash
-npm install -g protonmail-agentic-mcp
+npm install -g github:chandshy/protonmail-agentic-mcp
 ```
 
 ### Option B — From source


### PR DESCRIPTION
## Summary

- The README's **Option A** shows `npm install -g protonmail-agentic-mcp`, but the package is not published to the npm registry under that name
- Users must install directly from GitHub: `npm install -g github:chandshy/protonmail-agentic-mcp`
- This PR corrects the install command in the Installation section

## Test plan

- [ ] Verify `npm install -g github:chandshy/protonmail-agentic-mcp` installs successfully
- [x] Confirm `npm install -g protonmail-agentic-mcp` fails (or installs a different package) to validate the fix is necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)