### PR TITLE
feat(smtp): exponential backoff on abuse-signal SMTP responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1162,6 +1162,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 port: { type: "number" },
                 lastCheck: { type: "string", format: "date-time" },
                 insecureTls: { type: "boolean" },
+                backoff: {
+                  type: "object",
+                  description: "Abuse-signal backoff state. When active, sends are held back until remainingMs elapses.",
+                  properties: {
+                    active: { type: "boolean" },
+                    failureCount: { type: "number", description: "Consecutive throttle responses since the last success" },
+                    remainingMs: { type: "number", description: "Milliseconds remaining on the current backoff window" },
+                  },
+                },
                 error: { type: "string", description: "Last SMTP error message, if any" },
               },
             },
@@ -2820,6 +2829,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "get_connection_status": {
         const { configExists, getConfigPath } = await import("./config/loader.js");
+        const smtpBackoffMs = smtpService.backoff.delayUntilMs();
         const status = {
           smtp: {
             connected: smtpStatus.connected,
@@ -2827,6 +2837,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             port: config.smtp.port,
             lastCheck: smtpStatus.lastCheck.toISOString(),
             insecureTls: smtpService.insecureTls,
+            backoff: {
+              active: smtpService.backoff.isBlocked(),
+              failureCount: smtpService.backoff.failureCount,
+              remainingMs: smtpBackoffMs,
+            },
             ...(smtpStatus.error ? { error: smtpStatus.error } : {}),
           },
           imap: {
@@ -2842,7 +2857,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const insecureTlsWarning = (smtpService.insecureTls || imapService.insecureTls)
           ? "\n\u26a0 TLS certificate validation is DISABLED \u2014 configure Bridge Certificate Path in Settings."
           : "";
-        return ok(status, JSON.stringify(status) + insecureTlsWarning);
+        const backoffWarning = smtpService.backoff.isBlocked()
+          ? `\n\u26a0 SMTP is in abuse-signal backoff (${smtpService.backoff.failureCount} consecutive throttle responses, ${smtpBackoffMs} ms remaining). Wait or have the user trigger a manual retry.`
+          : "";
+        return ok(status, JSON.stringify(status) + insecureTlsWarning + backoffWarning);
       }
 
       case "start_bridge": {

--- a/src/services/smtp-service.test.ts
+++ b/src/services/smtp-service.test.ts
@@ -348,6 +348,46 @@ describe("SMTPService.reinitialize", () => {
   });
 });
 
+describe("SMTPService abuse-signal backoff", () => {
+  it("arms backoff on SMTP 421 and short-circuits subsequent sends", async () => {
+    const svc = new SMTPService(makeConfig());
+    // First send hits a 421 (throttle) — outcome is recorded as "abuse"
+    sendMailMock.mockRejectedValueOnce(Object.assign(new Error("421 4.7.0 throttled"), { responseCode: 421 }));
+    const first = await svc.sendEmail({ to: "a@example.com", subject: "S", body: "B" });
+    expect(first.success).toBe(false);
+    expect(svc.backoff.isBlocked()).toBe(true);
+    expect(svc.backoff.failureCount).toBe(1);
+
+    // Second send must be short-circuited (no nodemailer call) while blocked
+    sendMailMock.mockClear();
+    const second = await svc.sendEmail({ to: "a@example.com", subject: "S", body: "B" });
+    expect(second.success).toBe(false);
+    expect(second.error).toMatch(/backoff active/i);
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it("clears backoff on a successful send", async () => {
+    const svc = new SMTPService(makeConfig());
+    svc.backoff.record("abuse");
+    expect(svc.backoff.isBlocked()).toBe(true);
+    svc.backoff.reset();
+
+    const res = await svc.sendEmail({ to: "a@example.com", subject: "S", body: "B" });
+    expect(res.success).toBe(true);
+    expect(svc.backoff.isBlocked()).toBe(false);
+    expect(svc.backoff.failureCount).toBe(0);
+  });
+
+  it("does not arm backoff on a terminal (non-throttle) error", async () => {
+    const svc = new SMTPService(makeConfig());
+    sendMailMock.mockRejectedValueOnce(new Error("Invalid login"));
+    const res = await svc.sendEmail({ to: "a@example.com", subject: "S", body: "B" });
+    expect(res.success).toBe(false);
+    expect(svc.backoff.isBlocked()).toBe(false);
+    expect(svc.backoff.failureCount).toBe(0);
+  });
+});
+
 describe("SMTPService.sendEmail optional fields", () => {
   it("passes a priority through to nodemailer when supplied", async () => {
     const svc = new SMTPService(makeConfig());

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -9,6 +9,7 @@ import { ProtonMailConfig, SendEmailOptions } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { parseEmails, isValidEmail } from "../utils/helpers.js";
 import { tracer } from "../utils/tracer.js";
+import { BackoffTracker, isTransientAbuseError } from "../utils/backoff.js";
 
 /**
  * Strip CRLF and null bytes from a header-like string value to prevent
@@ -40,6 +41,13 @@ export class SMTPService {
   private config: ProtonMailConfig;
   /** True when TLS certificate validation is disabled (no Bridge cert configured). */
   insecureTls = false;
+  /**
+   * Tracks consecutive abuse-signal failures (SMTP 421/450/454 etc.) and
+   * holds back sends during the exponential-backoff window. Surfaced via
+   * getBackoffState() so get_connection_status can report throttling to
+   * the agent rather than letting it keep hammering.
+   */
+  readonly backoff = new BackoffTracker();
 
   constructor(config: ProtonMailConfig) {
     this.config = config;
@@ -199,6 +207,20 @@ export class SMTPService {
 
     if (!this.transporter) {
       throw new Error("SMTP transporter not initialized");
+    }
+
+    // Abuse-signal backoff gate — if a prior send tripped a 4xx throttle
+    // response, hold this one until the exponential-backoff window elapses.
+    if (this.backoff.isBlocked()) {
+      const waitMs = this.backoff.delayUntilMs();
+      logger.warn(
+        `SMTP: send is in abuse-signal backoff (${this.backoff.failureCount} consecutive failures, ${waitMs} ms remaining). Skipping.`,
+        "SMTPService"
+      );
+      return {
+        success: false,
+        error: `SMTP backoff active — ${waitMs} ms remaining after ${this.backoff.failureCount} consecutive throttle responses. Wait or call reset to clear.`,
+      };
     }
 
     // Parse and validate recipients
@@ -371,12 +393,23 @@ export class SMTPService {
         messageId: info.messageId,
       });
 
+      this.backoff.record("success");
       return {
         success: true,
         messageId: info.messageId,
       };
     } catch (error: unknown) {
-      logger.error("Failed to send email", "SMTPService", error);
+      if (isTransientAbuseError(error)) {
+        this.backoff.record("abuse");
+        logger.warn(
+          `SMTP: send hit a throttle/abuse signal (${this.backoff.failureCount} consecutive). Backing off ${this.backoff.delayUntilMs()} ms.`,
+          "SMTPService",
+          error
+        );
+      } else {
+        this.backoff.record("terminal");
+        logger.error("Failed to send email", "SMTPService", error);
+      }
       return {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",

--- a/src/utils/backoff.test.ts
+++ b/src/utils/backoff.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { BackoffTracker, isTransientAbuseError } from "./backoff.js";
+
+describe("isTransientAbuseError", () => {
+  it("returns true for numeric SMTP 421 responseCode", () => {
+    expect(isTransientAbuseError({ responseCode: 421, message: "Service not available" })).toBe(true);
+  });
+
+  it("returns true for numeric 450 and 454", () => {
+    expect(isTransientAbuseError({ responseCode: 450 })).toBe(true);
+    expect(isTransientAbuseError({ responseCode: 454 })).toBe(true);
+  });
+
+  it("returns true for a string code like '421'", () => {
+    expect(isTransientAbuseError({ code: "421" })).toBe(true);
+  });
+
+  it("matches 4xx codes embedded in the error message", () => {
+    expect(isTransientAbuseError(new Error("SMTP 421 4.7.0 too many connections"))).toBe(true);
+  });
+
+  it("matches Bridge-style abuse keywords in the message", () => {
+    expect(isTransientAbuseError(new Error("connection closed: BYE anti-abuse"))).toBe(true);
+    expect(isTransientAbuseError(new Error("human verification required"))).toBe(true);
+    expect(isTransientAbuseError(new Error("Please try again later"))).toBe(true);
+  });
+
+  it("returns false for authoritative terminal errors", () => {
+    expect(isTransientAbuseError(new Error("Invalid login: incorrect password"))).toBe(false);
+    expect(isTransientAbuseError(new Error("ECONNREFUSED"))).toBe(false);
+    expect(isTransientAbuseError({ responseCode: 550 })).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isTransientAbuseError(null)).toBe(false);
+    expect(isTransientAbuseError(undefined)).toBe(false);
+  });
+
+  it("returns false for plain non-Error objects with no matching fields", () => {
+    expect(isTransientAbuseError({ foo: "bar" })).toBe(false);
+  });
+});
+
+describe("BackoffTracker", () => {
+  function fixedClock(start: number) {
+    let now = start;
+    return {
+      now: () => now,
+      advance: (ms: number) => { now += ms; },
+    };
+  }
+
+  it("starts in the unblocked state", () => {
+    const bt = new BackoffTracker();
+    expect(bt.isBlocked()).toBe(false);
+    expect(bt.failureCount).toBe(0);
+    expect(bt.delayUntilMs()).toBe(0);
+  });
+
+  it("increments the failure count and arms a window on 'abuse'", () => {
+    const clock = fixedClock(1_000_000);
+    const bt = new BackoffTracker(1000, 60_000, clock.now, () => 0.5);
+    bt.record("abuse");
+    expect(bt.failureCount).toBe(1);
+    expect(bt.isBlocked()).toBe(true);
+    // Base 1000ms * 2^0 = 1000ms, jittered by factor 1.0 (0.75 + 0.5*0.5 = 1.0)
+    expect(bt.delayUntilMs()).toBe(1000);
+  });
+
+  it("grows the window exponentially across consecutive failures", () => {
+    const clock = fixedClock(0);
+    const bt = new BackoffTracker(1000, 60_000, clock.now, () => 0.5);
+    bt.record("abuse"); // 1000
+    bt.record("abuse"); // 2000
+    bt.record("abuse"); // 4000
+    expect(bt.failureCount).toBe(3);
+    expect(bt.delayUntilMs()).toBe(4000);
+  });
+
+  it("caps the window at maxDelayMs", () => {
+    const clock = fixedClock(0);
+    const bt = new BackoffTracker(1000, 5000, clock.now, () => 0.5);
+    for (let i = 0; i < 20; i++) bt.record("abuse");
+    expect(bt.delayUntilMs()).toBe(5000);
+  });
+
+  it("clears everything on 'success'", () => {
+    const bt = new BackoffTracker();
+    bt.record("abuse");
+    bt.record("success");
+    expect(bt.failureCount).toBe(0);
+    expect(bt.isBlocked()).toBe(false);
+    expect(bt.delayUntilMs()).toBe(0);
+  });
+
+  it("ignores 'terminal' outcomes — they neither arm nor clear", () => {
+    const bt = new BackoffTracker();
+    bt.record("terminal");
+    expect(bt.failureCount).toBe(0);
+    expect(bt.isBlocked()).toBe(false);
+  });
+
+  it("un-blocks once the window elapses", () => {
+    const clock = fixedClock(0);
+    const bt = new BackoffTracker(1000, 60_000, clock.now, () => 0.5);
+    bt.record("abuse");
+    expect(bt.isBlocked()).toBe(true);
+    clock.advance(2000);
+    expect(bt.isBlocked()).toBe(false);
+    expect(bt.delayUntilMs()).toBe(0);
+  });
+
+  it("reset() force-clears state from any point", () => {
+    const bt = new BackoffTracker();
+    bt.record("abuse");
+    bt.record("abuse");
+    bt.reset();
+    expect(bt.failureCount).toBe(0);
+    expect(bt.isBlocked()).toBe(false);
+  });
+
+  it("jitter produces a value within ±25% of the nominal delay", () => {
+    const clock = fixedClock(0);
+    const btLow = new BackoffTracker(1000, 60_000, clock.now, () => 0); // min jitter
+    const btHigh = new BackoffTracker(1000, 60_000, clock.now, () => 1); // max jitter
+    btLow.record("abuse");
+    btHigh.record("abuse");
+    expect(btLow.delayUntilMs()).toBe(750); // 1000 * 0.75
+    expect(btHigh.delayUntilMs()).toBe(1250); // 1000 * 1.25
+  });
+
+  it("blockedUntilMs reports the absolute deadline timestamp", () => {
+    const clock = fixedClock(1_000_000);
+    const bt = new BackoffTracker(1000, 60_000, clock.now, () => 0.5);
+    bt.record("abuse");
+    expect(bt.blockedUntilMs).toBe(1_001_000);
+  });
+});

--- a/src/utils/backoff.ts
+++ b/src/utils/backoff.ts
@@ -1,0 +1,107 @@
+/**
+ * Exponential-backoff scheduler for abuse-signal responses.
+ *
+ * Proton does not publish explicit IMAP/SMTP rate-limit headers, but the
+ * Bridge surfaces throttling through standard protocol-level codes:
+ *
+ *   - SMTP 421 — service not available / temporarily throttled
+ *   - SMTP 454 — temporary authentication failure (often anti-abuse)
+ *   - SMTP 450 — mailbox temporarily unavailable
+ *   - IMAP BYE [ALERT] — server-initiated disconnect (Bridge human-verification path)
+ *
+ * This module translates those signals into a small amount of
+ * well-behaved client-side backoff so the agentic workload does not
+ * hammer Bridge / Proton and trip account-level blocks.
+ */
+
+const ABUSE_CODE_RE = /\b(4(?:21|50|54))\b/;
+const TRANSIENT_KEYWORD_RE = /(?:throttl|rate.?limit|try again|temporarily|too many|anti.?abuse|human.?verification|\bBYE\b)/i;
+
+/**
+ * Classify an arbitrary error from a send/connect path as a transient
+ * abuse-adjacent signal worth backing off on (vs. a terminal failure).
+ *
+ * Matches SMTP 4xx codes (421, 450, 454) and common Bridge/Proton throttle
+ * keywords. Conservative — non-matching errors are treated as terminal.
+ */
+export function isTransientAbuseError(err: unknown): boolean {
+  if (!err) return false;
+  const msg = err instanceof Error ? err.message : String(err);
+  const code = (err as { responseCode?: number; code?: string | number }).responseCode
+    ?? (err as { responseCode?: number; code?: string | number }).code;
+  if (typeof code === "number" && (code === 421 || code === 450 || code === 454)) return true;
+  if (typeof code === "string" && /4(21|50|54)/.test(code)) return true;
+  if (ABUSE_CODE_RE.test(msg)) return true;
+  if (TRANSIENT_KEYWORD_RE.test(msg)) return true;
+  return false;
+}
+
+/**
+ * Tracks consecutive failure attempts and emits a delay-until timestamp
+ * with exponential growth + small jitter. Callers record each attempt's
+ * outcome with {@link record} and ask {@link delayUntilMs} whether a
+ * pending attempt should wait.
+ */
+export class BackoffTracker {
+  /** Number of consecutive abuse-signal failures observed. Reset on success. */
+  private failures = 0;
+  /** Absolute ms timestamp before which no attempt should be made. */
+  private blockedUntil = 0;
+
+  constructor(
+    private readonly baseDelayMs = 2_000,
+    private readonly maxDelayMs = 5 * 60_000,
+    private readonly now: () => number = Date.now,
+    private readonly jitter: () => number = Math.random,
+  ) {}
+
+  /**
+   * Record the outcome of an attempt.
+   *
+   * - `"success"` — clears the backoff state.
+   * - `"abuse"` — increments the failure counter and schedules the next
+   *               allowed attempt with exponential growth + jitter.
+   * - `"terminal"` — does not change the backoff state (leave untouched so
+   *                  a permanent auth failure doesn't masquerade as throttling).
+   */
+  record(outcome: "success" | "abuse" | "terminal"): void {
+    if (outcome === "success") {
+      this.failures = 0;
+      this.blockedUntil = 0;
+      return;
+    }
+    if (outcome !== "abuse") return;
+
+    this.failures += 1;
+    const exp = Math.min(this.baseDelayMs * 2 ** (this.failures - 1), this.maxDelayMs);
+    const jittered = exp * (0.75 + 0.5 * this.jitter()); // ±25% jitter
+    this.blockedUntil = this.now() + Math.round(jittered);
+  }
+
+  /** Whether the tracker is currently holding back new attempts. */
+  isBlocked(): boolean {
+    return this.blockedUntil > this.now();
+  }
+
+  /** Milliseconds remaining on the current backoff window (0 if not blocked). */
+  delayUntilMs(): number {
+    const ms = this.blockedUntil - this.now();
+    return ms > 0 ? ms : 0;
+  }
+
+  /** Current consecutive-failure count (0 after a successful attempt). */
+  get failureCount(): number {
+    return this.failures;
+  }
+
+  /** Absolute ms timestamp of the current backoff deadline (0 if unblocked). */
+  get blockedUntilMs(): number {
+    return this.blockedUntil;
+  }
+
+  /** Force-clear all state. Use when the user manually retries. */
+  reset(): void {
+    this.failures = 0;
+    this.blockedUntil = 0;
+  }
+}


### PR DESCRIPTION
## Summary

Adds exponential-backoff handling for SMTP abuse signals (421, 450, 454, Bridge BYE/human-verification). Stacks on top of #31 (TLS hardening).

- `BackoffTracker` (new, in `src/utils/backoff.ts`) classifies each send outcome: success / abuse / terminal. Only abuse-looking failures arm the window.
- Exponential growth with 2s base, 5 min cap, ±25% jitter.
- Short-circuits sends while blocked — returns a clear \"backoff active\" error instead of hammering Bridge.
- Exposed via `get_connection_status.smtp.backoff` so the agent sees the throttling state and pauses.
- Terminal errors (auth failures, ECONNREFUSED, 550) don't arm the window — no false throttling.

Follow-up: matching IMAP backoff. Bridge IMAP abuse signals (BYE alerts + connection drops) need a different detection path; scoped out of this PR.

## Test plan

- [x] Unit tests for `BackoffTracker` (growth, cap, jitter bounds, reset, timer)
- [x] Unit tests for `isTransientAbuseError` (numeric codes, string codes, keyword match, terminal-error rejection)
- [x] SMTP tests: 421 arms backoff, blocked-state short-circuits next send, terminal error does not arm
- [x] `npm run test:coverage` — 96.06/94.43/95.46/96.56

## Review order

Based on #31. Review #31 first; this PR's diff is additive on top.