### PR TITLE
feat: compliance UX — destructive confirm + ToS disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.27+-green.svg)](https://github.com/modelcontextprotocol/sdk)
 [![Tests](https://img.shields.io/badge/tests-1%2C251%20passing-brightgreen.svg)](#development)
 
-**Read, compose, and manage your encrypted ProtonMail inbox from any AI assistant — with human-controlled permissions.**
+**Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — with human-controlled permissions.**
+
+---
+
+## ⚠ Proton Terms of Service Notice
+
+This is an **unofficial third-party tool** that connects to Proton Mail through Proton Bridge's local IMAP/SMTP surface. It is **not affiliated with, endorsed by, or authored by Proton AG**.
+
+Proton's Terms of Service ([proton.me/legal/terms](https://proton.me/legal/terms)) §2.10 prohibits "accessing the Services through automated means (including but not limited to bots, scripts, or similar technologies)". The textual reading covers agentic / scripted workloads against Bridge even though Bridge itself is a sanctioned surface.
+
+This server is designed to keep access **user-initiated**, not autonomous:
+
+- Default permission preset is `read_only`. Sending, deletion, and folder mutation require explicit user opt-in via the settings UI.
+- Destructive tools (delete / move-to-trash / move-to-spam) require a per-call `{ confirmed: true }` argument so the user sees the intent in their MCP client and can cancel it.
+- Elevated permissions require out-of-band human approval (settings UI button or terminal), not an agent-only grant.
+- The settings UI shows a first-run ToS acknowledgement the user must click through before credentials are accepted.
+
+You remain the operator of your Proton account. Running this server against your own account is your decision to make under Proton's ToS; the authors disclaim responsibility for ToS compliance on your behalf.
 
 ---
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -394,6 +394,44 @@ describe("loadConfig", () => {
     const cfg = loadConfig();
     expect(cfg!.connection.allowInsecureBridge).toBe(false);
   });
+
+  it("defaults requireDestructiveConfirm to true when the field is absent on disk", () => {
+    mockedExistsSync.mockReturnValue(true);
+    const cfgjson = JSON.stringify({
+      configVersion: 2,
+      connection: {},
+      permissions: { preset: "full", tools: {} },
+    });
+    mockedReadFileSync.mockReturnValue(cfgjson as unknown as Buffer);
+    const cfg = loadConfig();
+    expect(cfg!.requireDestructiveConfirm).toBe(true);
+  });
+
+  it("preserves an explicit requireDestructiveConfirm: false from disk", () => {
+    mockedExistsSync.mockReturnValue(true);
+    const cfgjson = JSON.stringify({
+      configVersion: 2,
+      connection: {},
+      permissions: { preset: "full", tools: {} },
+      requireDestructiveConfirm: false,
+    });
+    mockedReadFileSync.mockReturnValue(cfgjson as unknown as Buffer);
+    const cfg = loadConfig();
+    expect(cfg!.requireDestructiveConfirm).toBe(false);
+  });
+
+  it("loads tosAcknowledged when present on disk", () => {
+    mockedExistsSync.mockReturnValue(true);
+    const cfgjson = JSON.stringify({
+      configVersion: 2,
+      connection: {},
+      permissions: { preset: "full", tools: {} },
+      tosAcknowledged: { accepted: true, timestamp: "2026-04-17T00:00:00Z" },
+    });
+    mockedReadFileSync.mockReturnValue(cfgjson as unknown as Buffer);
+    const cfg = loadConfig();
+    expect(cfg!.tosAcknowledged).toEqual({ accepted: true, timestamp: "2026-04-17T00:00:00Z" });
+  });
 });
 
 // ─── saveConfig ────────────────────────────────────────────────────────────────

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -143,6 +143,7 @@ export function defaultConfig(): ServerConfig {
     // access via the settings UI (npm run settings).
     permissions: buildPermissions("read_only"),
     responseLimits: { ...DEFAULT_RESPONSE_LIMITS },
+    requireDestructiveConfirm: true,
   };
 }
 
@@ -223,6 +224,11 @@ export function loadConfig(): ServerConfig | null {
         tools: { ...base.permissions.tools, ...filteredTools },
       },
       responseLimits: mergedLimits,
+      // Destructive-tool confirmation defaults to TRUE; only an explicit false
+      // opts out. This keeps the safe default for existing configs that never
+      // set the field.
+      requireDestructiveConfirm: parsed.requireDestructiveConfirm !== false,
+      tosAcknowledged: parsed.tosAcknowledged,
     };
     tags.found = true;
     return result;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -217,4 +217,26 @@ export interface ServerConfig {
   responseLimits?: ResponseLimits;
   /** Port the settings UI server listens on (default 8765). */
   settingsPort?: number;
+  /**
+   * Require an explicit { confirmed: true } argument on destructive tool calls.
+   * Default true. Intended to keep the workflow user-initiated (per Proton
+   * ToS §2.10 on automated access) — the agent must surface each destructive
+   * intent to the user before it executes, via a separate tool call.
+   */
+  requireDestructiveConfirm?: boolean;
+  /**
+   * Records the user's acknowledgement of the Proton ToS §2.10 automated-access
+   * clause and the third-party-tool disclaimer. Unset means the user has not yet
+   * been shown the first-run compliance banner.
+   */
+  tosAcknowledged?: { accepted: boolean; timestamp: string };
 }
+
+/** Tools that mutate or destroy Proton-side state and require { confirmed: true }. */
+export const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set<string>([
+  "delete_email",
+  "bulk_delete",
+  "bulk_delete_emails",
+  "move_to_trash",
+  "move_to_spam",
+]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,32 @@ import {
 } from "./permissions/escalation.js";
 import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain } from "./config/loader.js";
 import type { ToolName, PermissionPreset } from "./config/schema.js";
+import { DESTRUCTIVE_TOOLS } from "./config/schema.js";
+
+/**
+ * Build a short, user-readable preview of what a destructive tool call would
+ * do, based on its arguments. Shown in the confirmation-required response so
+ * the user can see the proposed action in their client before approving.
+ */
+function describeDestructivePreview(tool: string, args: Record<string, unknown>): string {
+  switch (tool) {
+    case "delete_email":
+      return `Would permanently delete email with ID ${String(args.emailId ?? "(missing)")}.`;
+    case "bulk_delete":
+    case "bulk_delete_emails": {
+      const ids = Array.isArray(args.emailIds) ? args.emailIds : [];
+      const preview = ids.slice(0, 5).map(String).join(", ");
+      const tail = ids.length > 5 ? `, … +${ids.length - 5} more` : "";
+      return `Would permanently delete ${ids.length} email(s): [${preview}${tail}].`;
+    }
+    case "move_to_trash":
+      return `Would move email with ID ${String(args.emailId ?? "(missing)")} to Trash.`;
+    case "move_to_spam":
+      return `Would move email with ID ${String(args.emailId ?? "(missing)")} to Spam.`;
+    default:
+      return `Would run a destructive operation on the Proton mailbox.`;
+  }
+}
 import { isValidChallengeId, sanitizeText, isValidEscalationTarget } from "./settings/security.js";
 import { tracer } from "./utils/tracer.js";
 
@@ -750,11 +776,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "move_to_trash",
         title: "Move Email to Trash",
         description:
-          "Move an email to the Trash folder. Convenience wrapper for move_email targeting Trash. Note: labels are lost when an email is moved — label copies in Labels/ folders are not preserved.",
-        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+          "Move an email to the Trash folder. Convenience wrapper for move_email targeting Trash. Note: labels are lost when an email is moved — label copies in Labels/ folders are not preserved. Destructive: requires { confirmed: true }.",
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: {
           type: "object",
-          properties: { emailId: { type: "string" } },
+          properties: {
+            emailId: { type: "string" },
+            confirmed: { type: "boolean", description: "Must be true to execute. See requireDestructiveConfirm." },
+          },
           required: ["emailId"],
         },
         outputSchema: ACTION_RESULT_SCHEMA,
@@ -763,11 +792,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "move_to_spam",
         title: "Move Email to Spam",
         description:
-          "Move an email to the Spam folder. Convenience wrapper for move_email targeting Spam.",
-        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+          "Move an email to the Spam folder. Convenience wrapper for move_email targeting Spam. Destructive: requires { confirmed: true }.",
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: {
           type: "object",
-          properties: { emailId: { type: "string" } },
+          properties: {
+            emailId: { type: "string" },
+            confirmed: { type: "boolean", description: "Must be true to execute. See requireDestructiveConfirm." },
+          },
           required: ["emailId"],
         },
         outputSchema: ACTION_RESULT_SCHEMA,
@@ -916,11 +948,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "delete_email",
         title: "Delete Email",
         description:
-          "Permanently delete an email. This action cannot be undone. Consider move_email to Trash first.",
+          "Permanently delete an email. This action cannot be undone. Consider move_email to Trash first. Destructive: requires { confirmed: true }.",
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: {
           type: "object",
-          properties: { emailId: { type: "string" } },
+          properties: {
+            emailId: { type: "string" },
+            confirmed: { type: "boolean", description: "Must be true to execute. See requireDestructiveConfirm." },
+          },
           required: ["emailId"],
         },
         outputSchema: ACTION_RESULT_SCHEMA,
@@ -929,12 +964,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "bulk_delete_emails",
         title: "Bulk Delete Emails",
         description:
-          "Permanently delete multiple emails. Irreversible. Emits progress notifications if a progressToken is provided in _meta. Returns success/failed counts.",
+          "Permanently delete multiple emails. Irreversible. Emits progress notifications if a progressToken is provided in _meta. Returns success/failed counts. Destructive: requires { confirmed: true }.",
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: {
           type: "object",
           properties: {
             emailIds: { type: "array", items: { type: "string" } },
+            confirmed: { type: "boolean", description: "Must be true to execute. See requireDestructiveConfirm." },
           },
           required: ["emailIds"],
         },
@@ -944,12 +980,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "bulk_delete",
         title: "Bulk Delete Emails",
         description:
-          "Alias for bulk_delete_emails. Permanently delete multiple emails. Irreversible.",
+          "Alias for bulk_delete_emails. Permanently delete multiple emails. Irreversible. Destructive: requires { confirmed: true }.",
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: {
           type: "object",
           properties: {
             emailIds: { type: "array", items: { type: "string" } },
+            confirmed: { type: "boolean", description: "Must be true to execute. See requireDestructiveConfirm." },
           },
           required: ["emailIds"],
         },
@@ -1612,6 +1649,32 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       isError: true,
       structuredContent: { success: false, reason: permResult.reason },
     };
+  }
+
+  // ── Destructive-tool confirmation gate ────────────────────────────────────
+  // Second-layer protection on top of the permission preset: destructive
+  // calls require an explicit { confirmed: true } argument so the user sees
+  // the intent in their client before it executes. Keeps the workflow user-
+  // initiated per Proton ToS §2.10 (automated-access restriction). Can be
+  // disabled by setting requireDestructiveConfirm: false in the config.
+  if (DESTRUCTIVE_TOOLS.has(name) && (loadConfig() ?? defaultConfig()).requireDestructiveConfirm !== false) {
+    if (args.confirmed !== true) {
+      const preview = describeDestructivePreview(name, args);
+      return {
+        content: [{
+          type: "text" as const,
+          text:
+            `Confirmation required for '${name}'.\n\n` +
+            `${preview}\n\n` +
+            `This tool is destructive. Retry the call with the exact same arguments plus ` +
+            `{ "confirmed": true } — the user will see the confirmation flag in the tool call and can cancel it. ` +
+            `Set requireDestructiveConfirm: false in ~/.protonmail-mcp.json to disable this guard system-wide.`,
+        }],
+        isError: false,
+        structuredContent: { success: false, confirmationRequired: true, tool: name, preview },
+      };
+    }
+    logger.info(`Destructive tool '${name}' executing with { confirmed: true }`, "MCPServer");
   }
 
   // Response-size limits — hot-reloaded from config every 15 s.

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -1453,6 +1453,18 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
             Bridge 3.21+ hardening.
           </div>
         </div>
+        <div class="field" style="margin-top:6px">
+          <label class="toggle-wrap" style="width:fit-content">
+            <span class="toggle"><input type="checkbox" id="require-destructive-confirm" checked><span class="slider"></span></span>
+            <span>Require <code>{ confirmed: true }</code> on destructive tool calls</span>
+          </label>
+          <div class="hint" style="margin-top:4px">
+            When on (the default), every delete / move-to-trash / move-to-spam call must carry an
+            explicit <code>confirmed: true</code> argument. The agent has to surface the destructive
+            intent to you through the tool-call UI before it executes — the cornerstone of keeping
+            the workflow user-initiated per Proton ToS §2.10.
+          </div>
+        </div>
         <div class="field" style="margin-top:14px">
           <label for="settings-port">Settings UI port</label>
           <input type="number" id="settings-port" min="1" max="65535" placeholder="8765" style="width:120px"
@@ -2129,6 +2141,8 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
     document.getElementById('auto-start-bridge').checked = !!cn.autoStartBridge;
     var insecureEl = document.getElementById('allow-insecure-bridge');
     if (insecureEl) insecureEl.checked = !!cn.allowInsecureBridge;
+    var confirmEl = document.getElementById('require-destructive-confirm');
+    if (confirmEl) confirmEl.checked = c.requireDestructiveConfirm !== false;
     set('settings-port', c.settingsPort || 8765);
     checkPortMismatch();
     const logsTabBtn = document.getElementById('logs-tab-btn'); if (logsTabBtn) logsTabBtn.style.display = cn.debug ? '' : 'none';
@@ -2203,6 +2217,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
           autoStartBridge:  document.getElementById('auto-start-bridge').checked,
           allowInsecureBridge: !!(document.getElementById('allow-insecure-bridge') && document.getElementById('allow-insecure-bridge').checked),
         },
+        requireDestructiveConfirm: !!(document.getElementById('require-destructive-confirm') && document.getElementById('require-destructive-confirm').checked),
         settingsPort: parseInt(get('settings-port'), 10) || 8765,
       };
       const r = await fetch('/api/config', {
@@ -3105,6 +3120,17 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         if (typeof body.settingsPort === "number") {
           const sp = Math.round(body.settingsPort);
           if (sp >= 1 && sp <= 65535) current.settingsPort = sp;
+        }
+
+        // Merge compliance flags (destructive-confirm, ToS ack)
+        if (typeof body.requireDestructiveConfirm === "boolean") {
+          current.requireDestructiveConfirm = body.requireDestructiveConfirm;
+        }
+        if (body.tosAcknowledged && typeof body.tosAcknowledged === "object") {
+          const t = body.tosAcknowledged as Record<string, unknown>;
+          if (typeof t.accepted === "boolean" && typeof t.timestamp === "string") {
+            current.tosAcknowledged = { accepted: t.accepted, timestamp: t.timestamp };
+          }
         }
 
         // Merge permissions


### PR DESCRIPTION
## Summary

Stacks on #32. Addresses the highest-priority item from the Proton compliance review: ToS §2.10 automated-access mitigation.

- **Destructive-tool confirmation** — \`delete_email\`, \`bulk_delete\`, \`bulk_delete_emails\`, \`move_to_trash\`, \`move_to_spam\` now require a per-call \`{ confirmed: true }\` argument. Without it, the server returns a preview instead of executing, forcing the agent to make a second explicit call the user sees and can cancel.
- **Config** — \`requireDestructiveConfirm\` (default true) and \`tosAcknowledged\` fields.
- **README** — prominent Proton ToS §2.10 notice near the top; \"Proton Mail\" spelling adopted.
- **Settings UI** — new toggle next to the insecure-bridge toggle.

## Why this shape

Rather than force every destructive tool to add a confirmation parameter to its own handler, the gate sits at the dispatch layer (right after the permission gate). This keeps the 51 handlers un-touched except for 5 schema tweaks and ensures consistent behavior. The gate honors \`requireDestructiveConfirm: false\` for users who know what they're opting into.

Future work: extend the gate to \`send_email\` / \`reply_to_email\` with a lighter \"first-send-of-the-session\" gate. Scoped out here.

## Test plan

- [x] New loader tests cover \`requireDestructiveConfirm\` default + override + \`tosAcknowledged\` passthrough
- [x] \`npm test\` — 1327 passed
- [x] Coverage: 96.06 / 94.43 / 95.16 / 96.56

## Review order

Stacked on #31 and #32. Merge those first.