### PR TITLE
rename: drop 'ProtonMail' from product identity → pm-bridge-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# ProtonMail Agentic MCP
+# pm-bridge-mcp
+
+**MCP server for Proton Mail via Proton Bridge.** An unofficial, user-initiated bridge between agentic MCP clients and Proton Bridge's local IMAP/SMTP surface.
 
 [![CI](https://github.com/chandshy/protonmail-agentic-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/protonmail-agentic-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v2.0.4-blue.svg)](https://www.npmjs.com/package/protonmail-agentic-mcp)
+[![npm version](https://img.shields.io/badge/npm-v2.1.0-blue.svg)](https://www.npmjs.com/package/pm-bridge-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
@@ -118,7 +120,7 @@ npm run build
 Run the settings server to complete first-time setup:
 
 ```bash
-npx protonmail-agentic-mcp-settings
+npx pm-bridge-mcp-settings
 # Then open http://localhost:8765
 ```
 
@@ -152,7 +154,7 @@ The generated entry looks like this (your path will differ):
   "mcpServers": {
     "protonmail": {
       "command": "node",
-      "args": ["/path/to/node_modules/protonmail-agentic-mcp/dist/index.js"]
+      "args": ["/path/to/node_modules/pm-bridge-mcp/dist/index.js"]
     }
   }
 }
@@ -330,7 +332,7 @@ The escalation system lets an agent request broader permissions without permanen
 - CSRF-protected: the approval API requires a session token embedded only in the rendered HTML page
 - Rate-limited: max 5 escalation requests per hour, max 1 pending at a time
 - Audit trail: every request, approval, and denial is appended to `~/.protonmail-mcp.audit.jsonl`
-- Approve from another device: `npx protonmail-agentic-mcp-settings --lan`
+- Approve from another device: `npx pm-bridge-mcp-settings --lan`
 
 ---
 
@@ -341,13 +343,13 @@ The settings UI starts automatically on `http://localhost:8765` whenever Claude 
 To run the settings UI standalone (useful for initial setup before Claude Desktop is configured, or on headless/SSH systems):
 
 ```bash
-npx protonmail-agentic-mcp-settings           # auto-detects display; opens browser if available
-npx protonmail-agentic-mcp-settings --port 9000   # custom port (default: 8765)
-npx protonmail-agentic-mcp-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
-npx protonmail-agentic-mcp-settings --browser     # force browser UI even if no display detected
-npx protonmail-agentic-mcp-settings --tui         # force interactive terminal UI
-npx protonmail-agentic-mcp-settings --plain       # plain readline menus (no ANSI colors/escapes)
-npx protonmail-agentic-mcp-settings --no-open     # start server but don't auto-open browser
+npx pm-bridge-mcp-settings           # auto-detects display; opens browser if available
+npx pm-bridge-mcp-settings --port 9000   # custom port (default: 8765)
+npx pm-bridge-mcp-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
+npx pm-bridge-mcp-settings --browser     # force browser UI even if no display detected
+npx pm-bridge-mcp-settings --tui         # force interactive terminal UI
+npx pm-bridge-mcp-settings --plain       # plain readline menus (no ANSI colors/escapes)
+npx pm-bridge-mcp-settings --no-open     # start server but don't auto-open browser
 ```
 
 The port can also be overridden with the `PORT` environment variable, or saved persistently via the settings UI itself.
@@ -429,7 +431,7 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 - Confirm the `mcpServers` block is valid JSON (no trailing commas).
 - Fully quit and reopen Claude Desktop.
 - Check MCP logs: **Help → Show Logs**.
-- Verify the server starts manually: `npx protonmail-agentic-mcp` — it should stay running silently.
+- Verify the server starts manually: `npx pm-bridge-mcp` — it should stay running silently.
 
 ### Analytics show zero or empty data
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "protonmail-agentic-mcp",
-  "version": "2.0.4",
-  "description": "ProtonMail Agentic MCP — 51 tools, Resources, and Prompts for agentic email management, folder operations, analytics, and Proton Bridge integration.",
+  "name": "pm-bridge-mcp",
+  "version": "2.1.0",
+  "description": "MCP server that exposes Proton Mail via Proton Bridge — 51 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "protonmail-agentic-mcp": "dist/index.js",
-    "protonmail-agentic-mcp-settings": "dist/settings-main.js"
+    "pm-bridge-mcp": "dist/index.js",
+    "pm-bridge-mcp-settings": "dist/settings-main.js"
   },
   "scripts": {
     "build": "tsc",
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
-    "protonmail",
-    "proton",
+    "proton-mail",
+    "proton-bridge",
     "mcp",
     "model-context-protocol",
     "email",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -169,15 +169,36 @@ describe("defaultConfig", () => {
 });
 
 describe("getConfigPath", () => {
-  it("returns default path when no env var is set", () => {
+  it("returns default path when no env var is set and no legacy file exists", () => {
+    const existsMock = vi.mocked(existsSync);
     const saved = process.env.PROTONMAIL_MCP_CONFIG;
+    const saved2 = process.env.PM_BRIDGE_MCP_CONFIG;
     delete process.env.PROTONMAIL_MCP_CONFIG;
+    delete process.env.PM_BRIDGE_MCP_CONFIG;
+    existsMock.mockReturnValue(false);
     try {
-      expect(getConfigPath()).toBe(join(homedir(), ".protonmail-mcp.json"));
+      expect(getConfigPath()).toBe(join(homedir(), ".pm-bridge-mcp.json"));
     } finally {
-      if (saved !== undefined) {
-        process.env.PROTONMAIL_MCP_CONFIG = saved;
-      }
+      if (saved !== undefined) process.env.PROTONMAIL_MCP_CONFIG = saved;
+      if (saved2 !== undefined) process.env.PM_BRIDGE_MCP_CONFIG = saved2;
+      existsMock.mockReset();
+    }
+  });
+
+  it("falls back to the legacy ~/.protonmail-mcp.json when the new path doesn't exist and the legacy one does", () => {
+    const existsMock = vi.mocked(existsSync);
+    const saved = process.env.PROTONMAIL_MCP_CONFIG;
+    const saved2 = process.env.PM_BRIDGE_MCP_CONFIG;
+    delete process.env.PROTONMAIL_MCP_CONFIG;
+    delete process.env.PM_BRIDGE_MCP_CONFIG;
+    const legacy = join(homedir(), ".protonmail-mcp.json");
+    existsMock.mockImplementation((p: unknown) => p === legacy);
+    try {
+      expect(getConfigPath()).toBe(legacy);
+    } finally {
+      if (saved !== undefined) process.env.PROTONMAIL_MCP_CONFIG = saved;
+      if (saved2 !== undefined) process.env.PM_BRIDGE_MCP_CONFIG = saved2;
+      existsMock.mockReset();
     }
   });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -41,7 +41,7 @@ function clamp(value: number, min: number, max: number): number {
 // ─── Config path ───────────────────────────────────────────────────────────────
 
 export function getConfigPath(): string {
-  const envPath = process.env.PROTONMAIL_MCP_CONFIG;
+  const envPath = process.env.PM_BRIDGE_MCP_CONFIG ?? process.env.PROTONMAIL_MCP_CONFIG;
   if (envPath) {
     // Resolve to absolute path and ensure it stays within the user's home
     // directory — prevents path-traversal attacks (e.g. "../../etc/passwd").
@@ -49,12 +49,17 @@ export function getConfigPath(): string {
     const home = homedir();
     if (!resolved.startsWith(home + "/") && !resolved.startsWith(home + "\\") && resolved !== home) {
       throw new Error(
-        `PROTONMAIL_MCP_CONFIG must point to a path within the home directory (${home}). Got: ${resolved}`
+        `PM_BRIDGE_MCP_CONFIG must point to a path within the home directory (${home}). Got: ${resolved}`
       );
     }
     return resolved;
   }
-  return join(homedir(), ".protonmail-mcp.json");
+  // Prefer the new path, but fall back to the legacy ~/.protonmail-mcp.json
+  // if it exists and the new one doesn't — keeps existing installs working.
+  const preferred = join(homedir(), ".pm-bridge-mcp.json");
+  const legacy = join(homedir(), ".protonmail-mcp.json");
+  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  return preferred;
 }
 
 // ─── Default values ────────────────────────────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,7 +335,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "send_email",
         title: "Send Email",
         description:
-          "Send an email via ProtonMail SMTP. Supports To/CC/BCC (comma-separated), plain text or HTML body, priority (high/normal/low), reply-to, and base64-encoded attachments. Returns messageId on success.",
+          "Send an email via Proton Mail SMTP (through Proton Bridge). Supports To/CC/BCC (comma-separated), plain text or HTML body, priority (high/normal/low), reply-to, and base64-encoded attachments. Returns messageId on success.",
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
         inputSchema: {
           type: "object",
@@ -572,7 +572,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         name: "list_labels",
         title: "List Labels",
         description:
-          "List all ProtonMail labels with message counts. Returns only labels (Labels/ prefix), not regular folders.",
+          "List all Proton Mail labels with message counts. Returns only labels (Labels/ prefix), not regular folders.",
         annotations: { readOnlyHint: true, openWorldHint: true },
         inputSchema: { type: "object", properties: {} },
         outputSchema: {
@@ -3218,7 +3218,7 @@ server.setRequestHandler(GetPromptRequestSchema, async (request) => {
             role: "user" as const,
             content: {
               type: "text" as const,
-              text: `You are managing a ProtonMail inbox. ${focus ? `Prioritise emails from/about: ${focus}.` : ""}
+              text: `You are managing a Proton Mail inbox. ${focus ? `Prioritise emails from/about: ${focus}.` : ""}
 
 ${unread.length > 0
   ? `Here are ${unread.length} unread emails to review:\n\n${JSON.stringify(
@@ -3645,7 +3645,7 @@ function startBridgeWatchdog(): void {
         "MCPServer"
       );
       process.stderr.write(
-        `[ProtonMail MCP] CRITICAL: Proton Bridge did not recover after ${BRIDGE_MAX_RESTARTS} restart attempts. ` +
+        `[pm-bridge-mcp] CRITICAL: Proton Bridge did not recover after ${BRIDGE_MAX_RESTARTS} restart attempts. ` +
         "Start Bridge manually and restart the MCP server.\n"
       );
       if (bridgeWatchdogTimer) { clearInterval(bridgeWatchdogTimer); bridgeWatchdogTimer = null; }
@@ -3801,7 +3801,7 @@ function _buildTrayMenu(): SysTrayMenu {
   const statusLabel   = smtpStatus.connected ? "\u25CF Connected" : "\u25CB Disconnected";
   const emailLabel    = config.smtp.username || "Not configured";
   const items: MenuItem[] = [
-    { title: "ProtonMail MCP", tooltip: "ProtonMail MCP Daemon", enabled: false, checked: false },
+    { title: "pm-bridge-mcp", tooltip: "pm-bridge-mcp daemon", enabled: false, checked: false },
     sep,
     { title: statusLabel, tooltip: "", enabled: false, checked: false },
     { title: emailLabel,  tooltip: "", enabled: false, checked: false },
@@ -3819,7 +3819,7 @@ function _buildTrayMenu(): SysTrayMenu {
     sep,
     { title: "Quit", tooltip: "Stop the MCP daemon", enabled: true, checked: false },
   ];
-  return { icon: TRAY_ICON_B64, title: "", tooltip: "ProtonMail MCP", items };
+  return { icon: TRAY_ICON_B64, title: "", tooltip: "pm-bridge-mcp", items };
 }
 
 async function _rebuildTray(): Promise<void> {
@@ -3989,7 +3989,7 @@ async function main() {
       }).catch((e: unknown) => {
         smtpStatus = { connected: false, lastCheck: new Date(), error: diagnosticErrorMessage(e) };
         logger.warn("SMTP connection failed — sending features limited", "MCPServer", e);
-        logger.info("Use your Proton Bridge password (not your ProtonMail account password)", "MCPServer");
+        logger.info("Use your Proton Bridge password (not your Proton Mail account password)", "MCPServer");
       }),
       imapService.connect(
         config.imap.host,

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -430,12 +430,12 @@ export class SMTPService {
   ): Promise<{ success: boolean; messageId?: string; error?: string }> {
     logger.debug("Sending test email", "SMTPService", { to });
 
-    const subject = "Test Email from ProtonMail MCP";
+    const subject = "Test Email from pm-bridge-mcp";
     const body =
       customMessage ||
       `
       <h2>Test Email Successful</h2>
-      <p>This is a test email from the ProtonMail MCP Server.</p>
+      <p>This is a test email from the pm-bridge-mcp server.</p>
       <p><strong>Timestamp:</strong> ${new Date().toISOString()}</p>
       <p><strong>From:</strong> ${escapeHtml(this.config.smtp.username)}</p>
       <p>If you received this email, your SMTP configuration is working correctly.</p>

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -134,7 +134,7 @@ switch (mode) {
       if (!noOpen) {
         const opened = openBrowser(url);
         if (!opened) {
-          process.stdout.write(`\n  ProtonMail MCP Settings\n`);
+          process.stdout.write(`\n  pm-bridge-mcp Settings\n`);
           process.stdout.write(`  Could not auto-open browser. Open manually:\n`);
           process.stdout.write(`  ${url}\n\n`);
         }

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -157,7 +157,7 @@ function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): s
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="csrf-token" content="${csrfToken}">
-<title>ProtonMail MCP — Settings</title>
+<title>pm-bridge-mcp — Settings</title>
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -836,7 +836,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
   <div class="logo-wrap">
     <div class="logo-icon">✉</div>
     <div>
-      <div class="header-title">ProtonMail MCP</div>
+      <div class="header-title">pm-bridge-mcp</div>
       <div class="header-subtitle">Settings</div>
     </div>
   </div>
@@ -909,9 +909,9 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
       <!-- ══ Step 1: Welcome ══ -->
       <div class="wiz-panel active" id="wpanel-0" role="tabpanel" aria-label="Welcome">
-        <div class="wiz-title">Welcome to ProtonMail MCP</div>
+        <div class="wiz-title">Welcome to pm-bridge-mcp</div>
         <div class="wiz-subtitle">
-          Give Claude secure, permission-controlled access to your ProtonMail inbox
+          Give Claude secure, permission-controlled access to your Proton Mail inbox
           via Proton Bridge. Setup takes about 3 minutes.
         </div>
 
@@ -1065,12 +1065,12 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
       <div class="wiz-panel" id="wpanel-2" role="tabpanel" aria-label="Account credentials">
         <div class="wiz-title">Connect Your Account</div>
         <div class="wiz-subtitle">
-          Enter your ProtonMail address and your <strong style="color:var(--text)">Bridge password</strong>
-          — this is shown inside the Proton Bridge app, not your ProtonMail login password.
+          Enter your Proton Mail address and your <strong style="color:var(--text)">Bridge password</strong>
+          — this is shown inside the Proton Bridge app, not your Proton Mail login password.
         </div>
 
         <div class="field">
-          <label for="wiz-username">ProtonMail email address</label>
+          <label for="wiz-username">Proton Mail email address</label>
           <input type="email" id="wiz-username" placeholder="you@proton.me"
             autocomplete="username" aria-required="true"
             oninput="wizClearError('wiz-username')">
@@ -1247,7 +1247,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
         <div class="done-hero">
           <div class="done-check">✓</div>
           <h2>You're all set!</h2>
-          <p>ProtonMail MCP is configured. The last step is registering it with your MCP host.</p>
+          <p>pm-bridge-mcp is configured. The last step is registering it with your MCP host.</p>
         </div>
 
         <div id="done-write-section">
@@ -1294,7 +1294,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
         <div id="done-complete" style="display:none" class="done-complete-msg">
           <div class="done-check-small">✓</div>
-          <strong>Done!</strong> Claude Desktop is restarting. Open it in a few seconds and ProtonMail will be available.
+          <strong>Done!</strong> Claude Desktop is restarting. Open it in a few seconds and Proton Mail tools will be available.
         </div>
 
         <div class="wiz-actions" style="margin-top:24px">
@@ -1339,7 +1339,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
         <legend>Account</legend>
         <div class="row-2">
           <div class="field">
-            <label for="username">ProtonMail username / email</label>
+            <label for="username">Proton Mail username / email</label>
             <input type="email" id="username" placeholder="user@proton.me" autocomplete="username">
             <div class="hint">Use your full Proton address (e.g. user@proton.me or user@protonmail.com). The @proton.me and @protonmail.com forms are not interchangeable — use the exact primary address shown in your Proton account.</div>
             <div class="hint" style="margin-top:4px">
@@ -2098,7 +2098,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
     document.getElementById('done-write-section').style.display = 'none';
     document.getElementById('done-complete').style.display = 'flex';
     document.getElementById('done-complete').querySelector('strong').textContent = 'Done!';
-    document.getElementById('done-complete').querySelector('strong').nextSibling.textContent = ' Restart Claude Desktop when you\\'re ready — ProtonMail will be available after it loads.';
+    document.getElementById('done-complete').querySelector('strong').nextSibling.textContent = ' Restart Claude Desktop when you\\'re ready — Proton Mail tools will be available after it loads.';
   };
 
   // ── Shutdown server ───────────────────────────────────────────────────────
@@ -3797,7 +3797,7 @@ export async function startSettingsServer(
 
     console.log("");
     console.log(`  ┌${"─".repeat(w + 2)}┐`);
-    line("ProtonMail MCP — Settings UI");
+    line("pm-bridge-mcp — Settings UI");
     blank();
     line(`Local:   ${localUrl}`);
 

--- a/src/settings/tui.ts
+++ b/src/settings/tui.ts
@@ -186,7 +186,7 @@ export function printNonInteractive(): void {
   const cfg = loadConfig();
   const path = getConfigPath();
 
-  process.stdout.write("\nProtonMail MCP Server — Settings\n");
+  process.stdout.write("\npm-bridge-mcp — Settings\n");
   process.stdout.write("─".repeat(48) + "\n");
 
   if (cfg) {
@@ -317,7 +317,7 @@ function ansiDraw(st: AnsiState): void {
   out.push(C.clrScr + C.hideCur);
 
   // Header
-  const title = "  ✉  ProtonMail MCP — Settings";
+  const title = "  ✉  pm-bridge-mcp — Settings";
   out.push(C.bgNav + C.bCyan + C.bold + title.padEnd(w) + C.reset + "\n");
 
   const cfgExists = configExists();
@@ -739,7 +739,7 @@ export async function runPlainTUI(serverPort: number, startServerFn: (port: numb
   function hr() { process.stdout.write("─".repeat(48) + "\n"); }
 
   function printHeader() {
-    process.stdout.write("\nProtonMail MCP Server — Settings\n");
+    process.stdout.write("\npm-bridge-mcp — Settings\n");
     hr();
     const cfg = loadConfig();
     const path = getConfigPath();

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
     // systray2 not installed — start server and open browser, no tray icon
     openBrowser(settingsUrl);
     process.stdout.write(
-      `\nProtonMail MCP Settings: ${settingsUrl}\nPress Ctrl+C to stop.\n\n`
+      `\npm-bridge-mcp Settings: ${settingsUrl}\nPress Ctrl+C to stop.\n\n`
     );
     return;
   }
@@ -176,9 +176,9 @@ async function main(): Promise<void> {
     menu: {
       icon:    ICON_B64,
       title:   "",
-      tooltip: "ProtonMail MCP",
+      tooltip: "pm-bridge-mcp",
       items: [
-        item("ProtonMail MCP", "ProtonMail MCP Server", false),
+        item("pm-bridge-mcp", "Proton Mail via Proton Bridge", false),
         sep,
         item(`\u25CF Connected`,    "", false),
         item(email || "Not configured", "", false),
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
   });
 
   process.stdout.write(
-    `\nProtonMail MCP tray icon active.\nSettings: ${settingsUrl}\nRight-click the tray icon to manage.\n\n`
+    `\npm-bridge-mcp tray icon active.\nSettings: ${settingsUrl}\nRight-click the tray icon to manage.\n\n`
   );
 }
 


### PR DESCRIPTION
## Summary

Stacks on #33. Rebrands the product to **pm-bridge-mcp** so the name no longer collides with Proton AG's registered trademarks, while keeping \"Proton Mail\" as a descriptive / nominative reference in docs and UX copy.

- \`package.json\` → name \`pm-bridge-mcp\`, version 2.1.0, bin \`pm-bridge-mcp\` / \`pm-bridge-mcp-settings\`
- README: new title, install/bin commands, keywords
- Settings UI, wizard, tray tooltip, TUI header: all rebranded
- Config path: prefer \`~/.pm-bridge-mcp.json\`, fall back to legacy \`~/.protonmail-mcp.json\` if present — zero-breakage for existing users
- Env var: \`PM_BRIDGE_MCP_CONFIG\` (preferred) with \`PROTONMAIL_MCP_CONFIG\` as fallback
- Internal \`ProtonMailConfig\` type kept unchanged (not user-visible)

## What's NOT in this PR

- GitHub repo rename (\`gh repo rename pm-bridge-mcp\`) — do this manually after merge so URL redirects are in place
- npm registry publish under the new name (package wasn't on npm before, per compliance report)

## Test plan

- [x] \`npm run build\` clean under new name
- [x] \`npm test\` — 1328 passed
- [x] Config path tests cover both the preferred and legacy lookups
- [x] Coverage: 96.07 / 94.46 / 95.46 / 96.57

## Review order

Stacked on #31 → #32 → #33. Merge those first.