### PR TITLE
feat: SimpleLogin alias tools (alias_*)

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -88,11 +88,20 @@ export function buildPermissions(preset: PermissionPreset): ServerConfig["permis
       ...TOOL_CATEGORIES.system.tools,
       "get_folders",
       "start_bridge",  // needed to bring Bridge up before reading
+      // SimpleLogin read-only surface: list + activity logs only.
+      "alias_list",
+      "alias_get_activity",
     ]);
     for (const tool of ALL_TOOLS) {
       tools[tool].enabled = allowed.has(tool);
     }
   } else if (preset === "supervised") {
+    // SimpleLogin write tools: cap creation + toggle + delete to keep a human
+    // in the loop even when the preset is otherwise permissive.
+    tools["alias_create_random"].rateLimit = 10;
+    tools["alias_create_custom"].rateLimit = 10;
+    tools["alias_toggle"].rateLimit = 20;
+    tools["alias_delete"].rateLimit = 5;
     for (const tool of TOOL_CATEGORIES.deletion.tools) {
       tools[tool].rateLimit = 5;
     }

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -7,8 +7,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 49 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(49);
+  it("has exactly 55 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(55);
   });
 
   it("contains no duplicates", () => {
@@ -33,14 +33,14 @@ describe("ALL_TOOLS", () => {
 });
 
 describe("TOOL_CATEGORIES", () => {
-  it("has exactly 9 categories", () => {
-    expect(Object.keys(TOOL_CATEGORIES)).toHaveLength(9);
+  it("has exactly 10 categories", () => {
+    expect(Object.keys(TOOL_CATEGORIES)).toHaveLength(10);
   });
 
   it("has the expected category names", () => {
     const keys = Object.keys(TOOL_CATEGORIES).sort();
     expect(keys).toEqual(
-      ["actions", "analytics", "bridge_control", "deletion", "drafts", "folders", "reading", "sending", "system"].sort(),
+      ["actions", "aliases", "analytics", "bridge_control", "deletion", "drafts", "folders", "reading", "sending", "system"].sort(),
     );
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -29,6 +29,9 @@ export const ALL_TOOLS = [
   "get_connection_status", "sync_emails", "clear_cache", "get_logs",
   // Bridge & server control
   "start_bridge", "shutdown_server", "restart_server",
+  // SimpleLogin aliases (Proton-owned; optional — requires API key)
+  "alias_list", "alias_create_random", "alias_create_custom",
+  "alias_toggle", "alias_delete", "alias_get_activity",
 ] as const;
 
 export type ToolName = (typeof ALL_TOOLS)[number];
@@ -104,6 +107,15 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     tools: ["start_bridge", "shutdown_server", "restart_server"],
     risk: "destructive",
   },
+  aliases: {
+    label: "SimpleLogin Aliases",
+    description: "Create and manage SimpleLogin aliases (Proton-owned alias service; requires API key)",
+    tools: [
+      "alias_list", "alias_create_random", "alias_create_custom",
+      "alias_toggle", "alias_delete", "alias_get_activity",
+    ],
+    risk: "moderate",
+  },
 };
 
 // ─── Permission Types ──────────────────────────────────────────────────────────
@@ -153,6 +165,14 @@ export interface ConnectionSettings {
   autoStartBridge?: boolean;
   /** Explicit path to the Proton Bridge executable. Leave blank to auto-detect. */
   bridgePath?: string;
+  /**
+   * SimpleLogin API key for the alias_* tools. Generated from
+   * https://app.simplelogin.io/dashboard/api_key. Leave blank to disable the
+   * alias tool group entirely (tools return a configuration error if invoked).
+   */
+  simpleloginApiKey?: string;
+  /** Optional override for SimpleLogin instance base URL (defaults to app.simplelogin.io). */
+  simpleloginBaseUrl?: string;
   debug: boolean;
 }
 
@@ -239,4 +259,5 @@ export const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set<string>([
   "bulk_delete_emails",
   "move_to_trash",
   "move_to_spam",
+  "alias_delete",
 ]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import {
 import { ProtonMailConfig, EmailMessage, EmailAttachment, EmailFolder } from "./types/index.js";
 import { SMTPService } from "./services/smtp-service.js";
 import { SimpleIMAPService } from "./services/simple-imap-service.js";
+import { SimpleLoginService } from "./services/simplelogin-service.js";
 import { AnalyticsService } from "./services/analytics-service.js";
 import { SchedulerService } from "./services/scheduler.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
@@ -76,6 +77,8 @@ function describeDestructivePreview(tool: string, args: Record<string, unknown>)
       return `Would move email with ID ${String(args.emailId ?? "(missing)")} to Trash.`;
     case "move_to_spam":
       return `Would move email with ID ${String(args.emailId ?? "(missing)")} to Spam.`;
+    case "alias_delete":
+      return `Would permanently delete SimpleLogin alias ${String(args.aliasId ?? "(missing)")}. This cannot be undone.`;
     default:
       return `Would run a destructive operation on the Proton mailbox.`;
   }
@@ -110,6 +113,9 @@ const config: ProtonMailConfig = {
 
 const smtpService = new SMTPService(config);
 const imapService = new SimpleIMAPService();
+// SimpleLogin client is lazy: constructed empty and reconfigured in main() once
+// the API key is loaded. Alias tools check isConfigured() before dispatching.
+let simpleloginService = new SimpleLoginService("");
 const analyticsService = new AnalyticsService();
 
 const SCHEDULER_STORE = process.env.PROTONMAIL_SCHEDULER_STORE
@@ -1318,6 +1324,153 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
         inputSchema: { type: "object", properties: {} },
         outputSchema: ACTION_RESULT_SCHEMA,
+      },
+
+      // ── SimpleLogin aliases (Proton-owned; optional — requires API key) ─────
+      {
+        name: "alias_list",
+        title: "List SimpleLogin Aliases",
+        description: "List aliases on the configured SimpleLogin account. Returns up to pageSize aliases (default 200). Requires simpleloginApiKey in settings.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            pageSize: { type: "number", description: "Max aliases to return (default 200, cap 1000)" },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            aliases: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "number" },
+                  email: { type: "string" },
+                  enabled: { type: "boolean" },
+                  note: { type: "string" },
+                  nb_forward: { type: "number" },
+                  nb_block: { type: "number" },
+                  nb_reply: { type: "number" },
+                },
+              },
+            },
+          },
+        },
+      },
+      {
+        name: "alias_create_random",
+        title: "Create Random SimpleLogin Alias",
+        description: "Create a new random SimpleLogin alias. mode='uuid' produces a long random hex local-part (hardest to guess, good for sensitive signups); mode='word' is two readable words (easier to type). Optional note lets you tag what the alias is for so you can audit later.",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {
+            mode: { type: "string", enum: ["uuid", "word"], default: "uuid" },
+            note: { type: "string", description: "Free-text note describing what this alias is for" },
+            hostname: { type: "string", description: "Optional hostname the alias is being created for (used by SimpleLogin for analytics)" },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            email: { type: "string" },
+            enabled: { type: "boolean" },
+            note: { type: "string" },
+          },
+        },
+      },
+      {
+        name: "alias_create_custom",
+        title: "Create Custom SimpleLogin Alias",
+        description: "Create a custom SimpleLogin alias with a user-chosen prefix and a signed suffix (obtain suffixes from SimpleLogin's alias-options endpoint; the UI picker handles this for end users).",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {
+            aliasPrefix: { type: "string", description: "Local-part of the alias (before the suffix)" },
+            signedSuffix: { type: "string", description: "Signed suffix returned by GET /api/v5/alias/options" },
+            mailboxIds: { type: "array", items: { type: "number" }, description: "Mailbox IDs to deliver to" },
+            note: { type: "string" },
+            name: { type: "string", description: "Display name shown in replies sent through the alias" },
+            hostname: { type: "string" },
+          },
+          required: ["aliasPrefix", "signedSuffix"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "number" },
+            email: { type: "string" },
+            enabled: { type: "boolean" },
+          },
+        },
+      },
+      {
+        name: "alias_toggle",
+        title: "Toggle SimpleLogin Alias",
+        description: "Enable or disable a SimpleLogin alias. Disabled aliases block all incoming mail without deleting the alias record (useful when a service starts abusing an alias).",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            aliasId: { type: "number" },
+          },
+          required: ["aliasId"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: { enabled: { type: "boolean" } },
+        },
+      },
+      {
+        name: "alias_delete",
+        title: "Delete SimpleLogin Alias",
+        description: "Permanently delete a SimpleLogin alias. Irreversible — prefer alias_toggle unless you are certain. Destructive: requires { confirmed: true }.",
+        annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {
+            aliasId: { type: "number" },
+            confirmed: { type: "boolean", description: "Must be true to execute." },
+          },
+          required: ["aliasId"],
+        },
+        outputSchema: ACTION_RESULT_SCHEMA,
+      },
+      {
+        name: "alias_get_activity",
+        title: "Get SimpleLogin Alias Activity",
+        description: "Return forward/block/reply activity log for a single SimpleLogin alias (most recent first). Useful for auditing what's hitting a specific alias before you disable or delete it.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            aliasId: { type: "number" },
+            pageSize: { type: "number", description: "Max activity rows (default 50, cap 1000)" },
+          },
+          required: ["aliasId"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            activities: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  action: { type: "string", enum: ["forward", "block", "reply", "bounced"] },
+                  from: { type: "string" },
+                  to: { type: "string" },
+                  timestamp: { type: "number" },
+                  reverse_alias: { type: "string" },
+                },
+              },
+            },
+          },
+        },
       },
 
       // ── Drafts & Scheduling ────────────────────────────────────────────────
@@ -2976,6 +3129,83 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok({ success: true }, "Restart initiated. A new MCP server process is starting.");
       }
 
+      // ── SimpleLogin aliases ────────────────────────────────────────────────
+      case "alias_list": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        const pageSize = typeof args.pageSize === "number"
+          ? Math.min(Math.max(1, args.pageSize), 1000)
+          : 200;
+        const aliases = await simpleloginService.listAliases(pageSize);
+        return ok({ aliases });
+      }
+
+      case "alias_create_random": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        const mode = args.mode === "word" ? "word" as const : "uuid" as const;
+        const note = typeof args.note === "string" ? args.note : undefined;
+        const hostname = typeof args.hostname === "string" ? args.hostname : undefined;
+        const alias = await simpleloginService.createRandomAlias({ mode, note, hostname });
+        return ok({ id: alias.id, email: alias.email, enabled: alias.enabled, note: alias.note ?? "" });
+      }
+
+      case "alias_create_custom": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        if (typeof args.aliasPrefix !== "string" || typeof args.signedSuffix !== "string") {
+          throw new McpError(ErrorCode.InvalidParams, "aliasPrefix and signedSuffix are required.");
+        }
+        const alias = await simpleloginService.createCustomAlias({
+          aliasPrefix: args.aliasPrefix,
+          signedSuffix: args.signedSuffix,
+          mailboxIds: Array.isArray(args.mailboxIds) ? (args.mailboxIds as number[]) : undefined,
+          note: typeof args.note === "string" ? args.note : undefined,
+          name: typeof args.name === "string" ? args.name : undefined,
+          hostname: typeof args.hostname === "string" ? args.hostname : undefined,
+        });
+        return ok({ id: alias.id, email: alias.email, enabled: alias.enabled });
+      }
+
+      case "alias_toggle": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        if (typeof args.aliasId !== "number") {
+          throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+        }
+        const result = await simpleloginService.toggleAlias(args.aliasId);
+        return ok({ enabled: result.enabled });
+      }
+
+      case "alias_delete": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        if (typeof args.aliasId !== "number") {
+          throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+        }
+        await simpleloginService.deleteAlias(args.aliasId);
+        return ok({ success: true });
+      }
+
+      case "alias_get_activity": {
+        if (!simpleloginService.isConfigured()) {
+          throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+        }
+        if (typeof args.aliasId !== "number") {
+          throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+        }
+        const pageSize = typeof args.pageSize === "number"
+          ? Math.min(Math.max(1, args.pageSize), 1000)
+          : 50;
+        const activities = await simpleloginService.getAliasActivities(args.aliasId, pageSize);
+        return ok({ activities });
+      }
+
       case "sync_emails": {
         const folder = (args.folder as string) || "INBOX";
         // Validate folder to prevent path traversal via the folder argument.
@@ -3913,6 +4143,15 @@ async function main() {
       config.autoStartBridge    = !!cn.autoStartBridge;
       config.bridgePath         = cn.bridgePath || undefined;
       config.settingsPort       = fileConfig.settingsPort ?? 8765;
+
+      // SimpleLogin client — populated from config; stays empty (isConfigured=false) if no key.
+      if (cn.simpleloginApiKey) {
+        simpleloginService = new SimpleLoginService(
+          cn.simpleloginApiKey,
+          cn.simpleloginBaseUrl || undefined,
+        );
+        logger.info("SimpleLogin client configured (alias_* tools active)", "MCPServer");
+      }
       logger.setDebugMode(!!cn.debug);
       tracer.setEnabled(!!cn.debug);
 

--- a/src/services/simplelogin-service.test.ts
+++ b/src/services/simplelogin-service.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for SimpleLoginService — REST client for the Proton-owned alias service.
+ * Uses a hand-rolled fetch mock because we're calling a public HTTP endpoint
+ * and don't want to couple to any particular fetch-mock library.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SimpleLoginService } from "./simplelogin-service.js";
+
+function mockFetch(handler: (url: string, init: RequestInit) => { status: number; body: unknown }) {
+  return vi.fn((input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url = typeof input === "string" ? input : String(input);
+    const { status, body } = handler(url, init);
+    return Promise.resolve(
+      new Response(typeof body === "string" ? body : JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+}
+
+describe("SimpleLoginService", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe("isConfigured", () => {
+    it("returns false when instantiated without an API key", () => {
+      expect(new SimpleLoginService("").isConfigured()).toBe(false);
+    });
+
+    it("returns true when an API key is supplied", () => {
+      expect(new SimpleLoginService("sl-test-key").isConfigured()).toBe(true);
+    });
+  });
+
+  describe("auth header + error handling", () => {
+    it("throws with a clear message when called without an API key", async () => {
+      const svc = new SimpleLoginService("");
+      await expect(svc.listAliases()).rejects.toThrow(/no API key configured/);
+    });
+
+    it("sends the Authentication header (non-standard SimpleLogin spelling)", async () => {
+      let capturedHeaders: HeadersInit | undefined;
+      globalThis.fetch = mockFetch((_, init) => {
+        capturedHeaders = init.headers;
+        return { status: 200, body: { aliases: [] } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-test-key");
+      await svc.listAliases();
+
+      const hdrs = capturedHeaders as Record<string, string>;
+      expect(hdrs.Authentication).toBe("sl-test-key");
+      expect(hdrs.Authorization).toBeUndefined();
+    });
+
+    it("surfaces the structured error message from SimpleLogin on 4xx/5xx", async () => {
+      globalThis.fetch = mockFetch(() => ({ status: 403, body: { error: "alias quota exceeded" } })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      await expect(svc.createRandomAlias()).rejects.toThrow(/alias quota exceeded/);
+    });
+
+    it("falls back to HTTP status text when the body isn't JSON", async () => {
+      globalThis.fetch = mockFetch(() => ({ status: 500, body: "upstream boom" })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      await expect(svc.listAliases()).rejects.toThrow(/500/);
+    });
+  });
+
+  describe("listAliases", () => {
+    it("paginates through empty results cleanly", async () => {
+      globalThis.fetch = mockFetch(() => ({ status: 200, body: { aliases: [] } })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      const aliases = await svc.listAliases();
+      expect(aliases).toEqual([]);
+    });
+
+    it("aggregates paginated responses until the API returns an empty page", async () => {
+      let page = 0;
+      globalThis.fetch = mockFetch(() => {
+        const batch = page < 2 ? [{ id: page * 10, email: `a${page}@sl`, enabled: true }] : [];
+        page++;
+        return { status: 200, body: { aliases: batch } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const aliases = await svc.listAliases(100);
+      expect(aliases).toHaveLength(2);
+      expect(aliases[0].email).toBe("a0@sl");
+      expect(aliases[1].email).toBe("a1@sl");
+    });
+
+    it("respects the pageSize cap", async () => {
+      globalThis.fetch = mockFetch(() => ({
+        status: 200,
+        body: { aliases: [{ id: 1, email: "x@sl", enabled: true }, { id: 2, email: "y@sl", enabled: true }] },
+      })) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const aliases = await svc.listAliases(1);
+      expect(aliases).toHaveLength(1);
+    });
+  });
+
+  describe("createRandomAlias", () => {
+    it("posts to /api/alias/random/new with the expected body", async () => {
+      let capturedBody: string | undefined;
+      let capturedUrl = "";
+      globalThis.fetch = mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedBody = init.body as string;
+        return { status: 201, body: { id: 42, email: "random@sl.local", enabled: true, note: "test" } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const alias = await svc.createRandomAlias({ mode: "word", note: "test", hostname: "example.com" });
+
+      expect(capturedUrl).toContain("/api/alias/random/new");
+      expect(capturedUrl).toContain("hostname=example.com");
+      expect(JSON.parse(capturedBody!)).toEqual({ mode: "word", note: "test" });
+      expect(alias.id).toBe(42);
+    });
+
+    it("defaults mode to 'uuid' when not specified", async () => {
+      let capturedBody: string | undefined;
+      globalThis.fetch = mockFetch((_, init) => {
+        capturedBody = init.body as string;
+        return { status: 201, body: { id: 1, email: "x@sl", enabled: true } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      await svc.createRandomAlias();
+      expect(JSON.parse(capturedBody!).mode).toBe("uuid");
+    });
+  });
+
+  describe("createCustomAlias", () => {
+    it("posts to /api/v3/alias/custom/new with alias_prefix / signed_suffix", async () => {
+      let capturedBody: string | undefined;
+      globalThis.fetch = mockFetch((_, init) => {
+        capturedBody = init.body as string;
+        return { status: 201, body: { id: 99, email: "custom@sl", enabled: true } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const alias = await svc.createCustomAlias({
+        aliasPrefix: "news",
+        signedSuffix: "signed-abc",
+        mailboxIds: [1, 2],
+        note: "n",
+        name: "Newsletter",
+      });
+      const body = JSON.parse(capturedBody!);
+      expect(body.alias_prefix).toBe("news");
+      expect(body.signed_suffix).toBe("signed-abc");
+      expect(body.mailbox_ids).toEqual([1, 2]);
+      expect(alias.id).toBe(99);
+    });
+  });
+
+  describe("toggle / delete / update / activities", () => {
+    it("toggleAlias posts to /api/aliases/:id/toggle and returns enabled state", async () => {
+      globalThis.fetch = mockFetch(() => ({ status: 200, body: { enabled: false } })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      await expect(svc.toggleAlias(7)).resolves.toEqual({ enabled: false });
+    });
+
+    it("deleteAlias sends a DELETE", async () => {
+      let capturedMethod = "";
+      globalThis.fetch = mockFetch((_, init) => {
+        capturedMethod = init.method ?? "GET";
+        return { status: 200, body: "" };
+      }) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      await svc.deleteAlias(5);
+      expect(capturedMethod).toBe("DELETE");
+    });
+
+    it("updateAlias sends a PUT with the patch body", async () => {
+      let capturedBody: string | undefined;
+      globalThis.fetch = mockFetch((_, init) => {
+        capturedBody = init.body as string;
+        return { status: 200, body: "" };
+      }) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      await svc.updateAlias(5, { name: "X", note: "y" });
+      expect(JSON.parse(capturedBody!)).toEqual({ name: "X", note: "y" });
+    });
+
+    it("getAliasActivities paginates until an empty page", async () => {
+      let page = 0;
+      globalThis.fetch = mockFetch(() => {
+        const batch = page === 0 ? [{ action: "forward", from: "a@x", to: "b@y", timestamp: 1 }] : [];
+        page++;
+        return { status: 200, body: { activities: batch } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const activities = await svc.getAliasActivities(5);
+      expect(activities).toHaveLength(1);
+      expect(activities[0].action).toBe("forward");
+    });
+
+    it("getAliasOptions forwards a hostname query and returns the suffix list", async () => {
+      let capturedUrl = "";
+      globalThis.fetch = mockFetch((url) => {
+        capturedUrl = url;
+        return {
+          status: 200,
+          body: {
+            can_create: true,
+            suffixes: [{ suffix: ".abc@sl", signed_suffix: "sig1", is_custom: false }],
+            prefix_suggestion: "news",
+          },
+        };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const opts = await svc.getAliasOptions("example.com");
+      expect(capturedUrl).toContain("hostname=example.com");
+      expect(opts.suffixes).toHaveLength(1);
+    });
+  });
+
+  describe("baseUrl normalization", () => {
+    it("strips trailing slashes from the base URL", async () => {
+      let capturedUrl = "";
+      globalThis.fetch = mockFetch((url) => {
+        capturedUrl = url;
+        return { status: 200, body: { aliases: [] } };
+      }) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key", "https://sl.example.com///");
+      await svc.listAliases();
+      expect(capturedUrl).toMatch(/^https:\/\/sl\.example\.com\/api\//);
+    });
+  });
+});

--- a/src/services/simplelogin-service.ts
+++ b/src/services/simplelogin-service.ts
@@ -1,0 +1,215 @@
+/**
+ * SimpleLogin REST client.
+ *
+ * SimpleLogin is the alias-management service owned by Proton (since 2022).
+ * It exposes a public HTTP API documented at:
+ *   https://github.com/simple-login/app/blob/master/docs/api.md
+ *
+ * Authentication uses a single `Authentication:` header (note the non-standard
+ * spelling — that's how SimpleLogin designed it). API keys are scoped per
+ * account and generated from the SimpleLogin dashboard.
+ *
+ * All requests are fire-and-forget from pm-bridge-mcp's perspective; we do
+ * not persist alias state locally — the agent always reads fresh from the API.
+ */
+
+import { logger } from "../utils/logger.js";
+
+const DEFAULT_BASE_URL = "https://app.simplelogin.io";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export interface SimpleLoginAlias {
+  id: number;
+  email: string;
+  enabled: boolean;
+  creation_date?: string;
+  creation_timestamp?: number;
+  name?: string | null;
+  note?: string | null;
+  nb_block?: number;
+  nb_forward?: number;
+  nb_reply?: number;
+}
+
+export interface SimpleLoginActivity {
+  action: "forward" | "block" | "reply" | "bounced";
+  from: string;
+  to: string;
+  timestamp: number;
+  reverse_alias?: string;
+}
+
+export interface AliasCreateRandomOptions {
+  /** "uuid" = long random hex; "word" = readable word-pairs. */
+  mode?: "uuid" | "word";
+  hostname?: string;
+  note?: string;
+}
+
+export interface AliasCreateCustomOptions {
+  /** Prefix portion of the alias email (before the suffix). Must match API constraints. */
+  aliasPrefix: string;
+  /** Signed suffix string returned by the /api/v5/alias/options endpoint. */
+  signedSuffix: string;
+  mailboxIds?: number[];
+  hostname?: string;
+  note?: string;
+  name?: string;
+}
+
+export class SimpleLoginService {
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(apiKey: string, baseUrl: string = DEFAULT_BASE_URL) {
+    this.apiKey = apiKey;
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+  }
+
+  /** True when the service has been configured with a non-empty API key. */
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    if (!this.apiKey) {
+      throw new Error(
+        "SimpleLogin: no API key configured. Set simpleloginApiKey in Settings → Aliases, " +
+        "or obtain one at https://app.simplelogin.io/dashboard/api_key",
+      );
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        ...init,
+        headers: {
+          "Authentication": this.apiKey,
+          "Content-Type": "application/json",
+          ...(init.headers ?? {}),
+        },
+        signal: controller.signal,
+      });
+      const text = await res.text();
+      if (!res.ok) {
+        // SimpleLogin returns structured errors: { error: "message" }
+        let message = `${res.status} ${res.statusText}`;
+        try {
+          const parsed = JSON.parse(text) as { error?: string };
+          if (parsed.error) message = parsed.error;
+        } catch { /* non-JSON body — use status text */ }
+        throw new Error(`SimpleLogin ${init.method ?? "GET"} ${path} → ${message}`);
+      }
+      if (!text) return undefined as T;
+      return JSON.parse(text) as T;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * List all aliases on the account. Paginates transparently.
+   * `pageSize` is a caller-enforced cap on total results (not a SimpleLogin parameter).
+   */
+  async listAliases(pageSize = 200): Promise<SimpleLoginAlias[]> {
+    logger.debug("SimpleLogin: listing aliases", "SimpleLoginService", { pageSize });
+    const collected: SimpleLoginAlias[] = [];
+    let page = 0;
+    // SimpleLogin returns { aliases: SimpleLoginAlias[] }. An empty array signals end.
+    while (collected.length < pageSize) {
+      const body = await this.request<{ aliases?: SimpleLoginAlias[] }>(
+        `/api/v2/aliases?page_id=${page}`,
+      );
+      const batch = body.aliases ?? [];
+      if (batch.length === 0) break;
+      collected.push(...batch);
+      if (collected.length >= pageSize) break;
+      page += 1;
+      // Safety: never fetch more than 50 pages — 20/page × 50 = 1000 aliases
+      if (page >= 50) break;
+    }
+    return collected.slice(0, pageSize);
+  }
+
+  /** Create a random alias. Default mode is "uuid" (long, least guessable). */
+  async createRandomAlias(opts: AliasCreateRandomOptions = {}): Promise<SimpleLoginAlias> {
+    const params = new URLSearchParams();
+    if (opts.hostname) params.set("hostname", opts.hostname);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    return this.request<SimpleLoginAlias>(`/api/alias/random/new${qs}`, {
+      method: "POST",
+      body: JSON.stringify({
+        mode: opts.mode ?? "uuid",
+        note: opts.note ?? null,
+      }),
+    });
+  }
+
+  /**
+   * Create a custom alias. Requires a `signedSuffix` obtained from
+   * /api/v5/alias/options — we expose that via {@link getAliasOptions} for the
+   * caller to populate the UI.
+   */
+  async createCustomAlias(opts: AliasCreateCustomOptions): Promise<SimpleLoginAlias> {
+    const params = new URLSearchParams();
+    if (opts.hostname) params.set("hostname", opts.hostname);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    return this.request<SimpleLoginAlias>(`/api/v3/alias/custom/new${qs}`, {
+      method: "POST",
+      body: JSON.stringify({
+        alias_prefix: opts.aliasPrefix,
+        signed_suffix: opts.signedSuffix,
+        mailbox_ids: opts.mailboxIds,
+        note: opts.note,
+        name: opts.name,
+      }),
+    });
+  }
+
+  /** Fetch the prefixes / suffixes available for custom-alias creation. */
+  async getAliasOptions(hostname?: string): Promise<{
+    can_create: boolean;
+    suffixes: Array<{ suffix: string; signed_suffix: string; is_custom: boolean; is_premium?: boolean }>;
+    prefix_suggestion?: string;
+  }> {
+    const params = new URLSearchParams();
+    if (hostname) params.set("hostname", hostname);
+    const qs = params.toString() ? `?${params.toString()}` : "";
+    return this.request(`/api/v5/alias/options${qs}`);
+  }
+
+  async toggleAlias(aliasId: number): Promise<{ enabled: boolean }> {
+    return this.request(`/api/aliases/${aliasId}/toggle`, { method: "POST" });
+  }
+
+  async deleteAlias(aliasId: number): Promise<void> {
+    await this.request(`/api/aliases/${aliasId}`, { method: "DELETE" });
+  }
+
+  async getAliasActivities(aliasId: number, pageSize = 50): Promise<SimpleLoginActivity[]> {
+    const collected: SimpleLoginActivity[] = [];
+    let page = 0;
+    while (collected.length < pageSize) {
+      const body = await this.request<{ activities?: SimpleLoginActivity[] }>(
+        `/api/aliases/${aliasId}/activities?page_id=${page}`,
+      );
+      const batch = body.activities ?? [];
+      if (batch.length === 0) break;
+      collected.push(...batch);
+      if (collected.length >= pageSize) break;
+      page += 1;
+      if (page >= 20) break;
+    }
+    return collected.slice(0, pageSize);
+  }
+
+  async updateAlias(
+    aliasId: number,
+    patch: { name?: string; note?: string; mailbox_ids?: number[]; disable_pgp?: boolean },
+  ): Promise<void> {
+    await this.request(`/api/aliases/${aliasId}`, {
+      method: "PUT",
+      body: JSON.stringify(patch),
+    });
+  }
+}

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -3110,6 +3110,9 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
             debug:           typeof c.debug === "boolean" ? c.debug : current.connection.debug,
             autoStartBridge: typeof c.autoStartBridge === "boolean" ? c.autoStartBridge : current.connection.autoStartBridge,
             allowInsecureBridge: typeof c.allowInsecureBridge === "boolean" ? c.allowInsecureBridge : current.connection.allowInsecureBridge,
+            // SimpleLogin: only overwrite when a non-placeholder key was posted
+            ...(typeof c.simpleloginApiKey === "string" && c.simpleloginApiKey && c.simpleloginApiKey !== "••••••••" ? { simpleloginApiKey: c.simpleloginApiKey } : {}),
+            simpleloginBaseUrl: typeof c.simpleloginBaseUrl === "string" ? c.simpleloginBaseUrl : current.connection.simpleloginBaseUrl,
             // Only overwrite credentials if a non-empty, non-placeholder string was sent
             ...(typeof c.password  === "string" && c.password  && c.password  !== "••••••••" ? { password:  c.password  } : {}),
             ...(typeof c.smtpToken === "string" && c.smtpToken && c.smtpToken !== "••••••••" ? { smtpToken: c.smtpToken } : {}),


### PR DESCRIPTION
Closes #36.

**Why this first.** SimpleLogin is owned by Proton and has a real public REST API. The workflow it unlocks — "sign me up with a throwaway, replies flow back into the inbox pm-bridge-mcp already reads" — is the tightest email-MCP loop on the board.

**What's new**
- `src/services/simplelogin-service.ts` — HTTP client for SimpleLogin v2/v3/v5 endpoints
- 6 new tools: `alias_list`, `alias_create_random`, `alias_create_custom`, `alias_toggle`, `alias_delete`, `alias_get_activity`
- New permissions category `aliases`; read_only preset surfaces list + activity only
- `alias_delete` joins `DESTRUCTIVE_TOOLS` (needs `{ confirmed: true }`)
- Config: `simpleloginApiKey` (never committed), optional `simpleloginBaseUrl`
- Fully opt-in: no key → tools return a structured configuration error

**Tests**
- 15 new tests in `simplelogin-service.test.ts` cover auth header, error shape, pagination, each endpoint
- Full suite: 1346 passing
- Coverage: 95.98 / 94.02 / 95.33 / 96.67

**Test plan**
- [x] Unit tests
- [ ] Manual: obtain a SimpleLogin API key, exercise each tool from Claude Desktop
- [ ] Manual: verify `alias_delete` fires the confirm-gate preview