### PR TITLE
feat: progressive tool tiering (core / extended / complete)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -4,6 +4,9 @@ import {
   TOOL_CATEGORIES,
   CONFIG_VERSION,
   DEFAULT_RESPONSE_LIMITS,
+  toolsForTier,
+  parseToolTier,
+  ALWAYS_AVAILABLE_TOOLS,
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
@@ -111,5 +114,69 @@ describe("DEFAULT_RESPONSE_LIMITS", () => {
 
   it("warnOnLargeResponse defaults to true", () => {
     expect(DEFAULT_RESPONSE_LIMITS.warnOnLargeResponse).toBe(true);
+  });
+});
+
+describe("Tool tiering", () => {
+  describe("toolsForTier", () => {
+    it("'core' returns only reading/sending/analytics/system tools + always-available ones", () => {
+      const core = toolsForTier("core");
+      expect(core.has("get_emails")).toBe(true);          // reading
+      expect(core.has("send_email")).toBe(true);          // sending
+      expect(core.has("get_email_stats")).toBe(true);     // analytics
+      expect(core.has("get_connection_status")).toBe(true); // system
+      expect(core.has("request_permission_escalation")).toBe(true); // always available
+      // Not in core:
+      expect(core.has("delete_email")).toBe(false);       // deletion → complete
+      expect(core.has("save_draft")).toBe(false);         // drafts → extended
+      expect(core.has("create_folder")).toBe(false);      // folders → extended
+      expect(core.has("start_bridge")).toBe(false);       // bridge_control → complete
+    });
+
+    it("'extended' adds drafts, folders, and actions to core", () => {
+      const ext = toolsForTier("extended");
+      expect(ext.has("save_draft")).toBe(true);
+      expect(ext.has("create_folder")).toBe(true);
+      expect(ext.has("mark_email_read")).toBe(true);
+      expect(ext.has("move_to_trash")).toBe(true);
+      // Still not extended: deletion / bridge control
+      expect(ext.has("delete_email")).toBe(false);
+      expect(ext.has("shutdown_server")).toBe(false);
+    });
+
+    it("'complete' exposes every tool in every registered category", () => {
+      const full = toolsForTier("complete");
+      for (const def of Object.values(TOOL_CATEGORIES)) {
+        for (const tool of def.tools) {
+          expect(full.has(tool)).toBe(true);
+        }
+      }
+      for (const always of ALWAYS_AVAILABLE_TOOLS) {
+        expect(full.has(always)).toBe(true);
+      }
+    });
+
+    it("core tier is strictly smaller than extended; extended is strictly smaller than complete", () => {
+      const core = toolsForTier("core");
+      const ext = toolsForTier("extended");
+      const full = toolsForTier("complete");
+      expect(core.size).toBeLessThan(ext.size);
+      expect(ext.size).toBeLessThan(full.size);
+    });
+  });
+
+  describe("parseToolTier", () => {
+    it("accepts the three known tier strings", () => {
+      expect(parseToolTier("core")).toBe("core");
+      expect(parseToolTier("extended")).toBe("extended");
+      expect(parseToolTier("complete")).toBe("complete");
+    });
+
+    it("defaults to 'complete' for unknown, null, or undefined input", () => {
+      expect(parseToolTier("bogus")).toBe("complete");
+      expect(parseToolTier(undefined)).toBe("complete");
+      expect(parseToolTier(null)).toBe("complete");
+      expect(parseToolTier(42)).toBe("complete");
+    });
   });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -218,6 +218,15 @@ export interface ServerConfig {
   /** Port the settings UI server listens on (default 8765). */
   settingsPort?: number;
   /**
+   * Progressive tool-disclosure tier. Controls how many tools appear in the
+   * ListTools response — reduces context bloat when only a subset is needed.
+   *   "core"     — reading / sending / analytics / system (~20 tools)
+   *   "extended" — core + drafts / folders / actions
+   *   "complete" — all tools (default, preserves current behavior)
+   * Override per-launch with PM_BRIDGE_MCP_TIER.
+   */
+  toolTier?: ToolTier;
+  /**
    * Require an explicit { confirmed: true } argument on destructive tool calls.
    * Default true. Intended to keep the workflow user-initiated (per Proton
    * ToS §2.10 on automated access) — the agent must surface each destructive
@@ -240,3 +249,62 @@ export const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set<string>([
   "move_to_trash",
   "move_to_spam",
 ]);
+
+// ─── Tool Tiers ────────────────────────────────────────────────────────────────
+//
+// Every connected MCP server contributes its ListTools response to the client's
+// system-prompt context. At 50+ tools this is measurable — multiple servers can
+// burn tens of thousands of tokens before the user types anything.
+//
+// Tiering lets operators expose only the tools they actually use. Activate via
+// the PM_BRIDGE_MCP_TIER env var (core|extended|complete; default complete) or
+// the `toolTier` field in the config file.
+
+export type ToolTier = "core" | "extended" | "complete";
+
+/** Where each category surfaces first. */
+export const TOOL_CATEGORY_TIER: Record<string, ToolTier> = {
+  reading:        "core",     // reading is the 80 % use case
+  sending:        "core",     // sending needs to be available in core too — common ask
+  analytics:      "core",     // analytics is read-only and small
+  system:         "core",     // connection status, cache, logs
+  drafts:         "extended",
+  folders:        "extended",
+  actions:        "extended",
+  deletion:       "complete", // destructive + rarely needed by casual agents
+  bridge_control: "complete", // server lifecycle
+};
+
+/**
+ * Escalation tools (request_permission_escalation, check_escalation_status)
+ * are always available — they bypass the permission gate and sit outside the
+ * category registry. They are also outside the tiering system.
+ */
+export const ALWAYS_AVAILABLE_TOOLS: ReadonlySet<string> = new Set<string>([
+  "request_permission_escalation",
+  "check_escalation_status",
+]);
+
+/** Resolve the set of tools that should be exposed by ListTools for a given tier. */
+export function toolsForTier(tier: ToolTier): Set<string> {
+  const tiersIncluded: ToolTier[] =
+    tier === "core"     ? ["core"] :
+    tier === "extended" ? ["core", "extended"] :
+                          ["core", "extended", "complete"];
+  const result = new Set<string>();
+  for (const [cat, catTier] of Object.entries(TOOL_CATEGORY_TIER)) {
+    if (tiersIncluded.includes(catTier)) {
+      const def = TOOL_CATEGORIES[cat];
+      if (def) for (const tool of def.tools) result.add(tool);
+    }
+  }
+  // Always-available tools are added regardless of tier.
+  for (const tool of ALWAYS_AVAILABLE_TOOLS) result.add(tool);
+  return result;
+}
+
+/** Parse a value into a ToolTier, defaulting to "complete" on anything else. */
+export function parseToolTier(value: unknown): ToolTier {
+  if (value === "core" || value === "extended" || value === "complete") return value;
+  return "complete";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ import {
 } from "./permissions/escalation.js";
 import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain } from "./config/loader.js";
 import type { ToolName, PermissionPreset } from "./config/schema.js";
-import { DESTRUCTIVE_TOOLS } from "./config/schema.js";
+import { DESTRUCTIVE_TOOLS, toolsForTier, parseToolTier } from "./config/schema.js";
 
 /**
  * Build a short, user-readable preview of what a destructive tool call would
@@ -326,10 +326,24 @@ const server = new Server(
 // TOOLS
 // ═════════════════════════════════════════════════════════════════════════════
 
+/**
+ * Resolve the active tool tier at the moment of the ListTools call. Order:
+ *   1. PM_BRIDGE_MCP_TIER env var (per-launch override)
+ *   2. config.toolTier (persisted)
+ *   3. "complete" (default — preserves pre-tiering behavior)
+ */
+function activeToolTier(): ReturnType<typeof parseToolTier> {
+  const envTier = process.env.PM_BRIDGE_MCP_TIER;
+  if (envTier) return parseToolTier(envTier);
+  const cfg = loadConfig();
+  return parseToolTier(cfg?.toolTier);
+}
+
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  logger.debug("Listing tools", "MCPServer");
-  return {
-    tools: [
+  const tier = activeToolTier();
+  const visible = toolsForTier(tier);
+  logger.debug(`Listing tools (tier=${tier}, visible=${visible.size})`, "MCPServer");
+  const allTools = [
       // ── Sending ────────────────────────────────────────────────────────────
       {
         name: "send_email",
@@ -1530,8 +1544,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
-    ],
-  };
+    ];
+  return { tools: allTools.filter(t => visible.has(t.name)) };
 });
 
 // ─── Tool Handlers ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #42.

**Problem.** Every connected MCP server contributes its tool list to the client's context budget. ~50 tools is measurable; users with multi-server setups report tens of thousands of tokens burned before the first prompt ([Morph LLM data](https://www.morphllm.com/claude-code-reddit)).

**Solution.** Three tiers let callers expose only what they need:
- `core` — reading + sending + analytics + system (+ always-available escalation)
- `extended` — core + drafts + folders + actions
- `complete` — everything (default; preserves pre-change behavior)

**Activation**
- `PM_BRIDGE_MCP_TIER=core` env var (per-launch override)
- `toolTier` in `~/.pm-bridge-mcp.json` (persistent)
- Honored live on every `ListTools` call — no restart needed

**Tests**
- 6 new tests covering `toolsForTier` and `parseToolTier`
- Full suite: 1334 passing
- Coverage: 96.14 / 94.51 / 95.49 / 96.59