### PR TITLE
feat: remind_if_no_reply scheduler + reminder tools

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 57 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(57);
+  it("has exactly 61 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(61);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -10,6 +10,7 @@ export const ALL_TOOLS = [
   "send_email", "reply_to_email", "forward_email", "send_test_email",
   // Drafts & scheduling
   "save_draft", "schedule_email", "list_scheduled_emails", "cancel_scheduled_email", "list_proton_scheduled",
+  "remind_if_no_reply", "list_pending_reminders", "cancel_reminder", "check_reminders",
   // Reading
   "get_emails", "get_email_by_id", "search_emails", "get_unread_count",
   "list_labels", "get_emails_by_label", "download_attachment",
@@ -57,7 +58,10 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   drafts: {
     label: "Drafts & Scheduling",
     description: "Save drafts and schedule emails for future delivery",
-    tools: ["save_draft", "schedule_email", "list_scheduled_emails", "cancel_scheduled_email", "list_proton_scheduled"],
+    tools: [
+      "save_draft", "schedule_email", "list_scheduled_emails", "cancel_scheduled_email", "list_proton_scheduled",
+      "remind_if_no_reply", "list_pending_reminders", "cancel_reminder", "check_reminders",
+    ],
     risk: "moderate",
   },
   reading: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { SimpleIMAPService } from "./services/simple-imap-service.js";
 import { SimpleLoginService } from "./services/simplelogin-service.js";
 import { AnalyticsService } from "./services/analytics-service.js";
 import { SchedulerService } from "./services/scheduler.js";
+import { ReminderService } from "./services/reminder-service.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
 import { isValidEmail, validateLabelName, validateFolderName, validateTargetFolder, requireNumericEmailId, validateAttachments } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
@@ -146,6 +147,10 @@ const analyticsService = new AnalyticsService();
 const SCHEDULER_STORE = process.env.PROTONMAIL_SCHEDULER_STORE
   || `${process.env.HOME || process.env.USERPROFILE || "."}/.protonmail-mcp-scheduled.json`;
 const schedulerService = new SchedulerService(smtpService, SCHEDULER_STORE);
+
+const REMINDERS_STORE = process.env.PM_BRIDGE_MCP_REMINDERS
+  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-reminders.json`;
+const reminderService = new ReminderService(REMINDERS_STORE);
 
 // ─── Bridge Auto-Start State ──────────────────────────────────────────────────
 /** Set to true when this process launched Proton Bridge; triggers kill on shutdown. */
@@ -1623,6 +1628,102 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         },
       },
       {
+        name: "remind_if_no_reply",
+        title: "Remind If No Reply",
+        description:
+          "Schedule a follow-up reminder for a message you've sent. Given the IMAP UID of a message in Sent, captures its Message-ID + recipient and fires a reminder after N days. Use check_reminders to retrieve due reminders; list_pending_reminders to audit; cancel_reminder to drop one.",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+        inputSchema: {
+          type: "object",
+          properties: {
+            email_id: { type: "string", description: "IMAP UID of the sent message (from Sent folder)" },
+            after_days: { type: "number", description: "Days from the message's send date until the reminder fires (1–365)" },
+            note: { type: "string", description: "Optional note explaining the reminder" },
+          },
+          required: ["email_id", "after_days"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            recipient: { type: "string" },
+            subject: { type: "string" },
+            fireAt: { type: "string", format: "date-time" },
+          },
+          required: ["id", "recipient", "subject", "fireAt"],
+        },
+      },
+      {
+        name: "list_pending_reminders",
+        title: "List Pending Reminders",
+        description: "List every pending no-reply reminder, sorted by earliest fireAt.",
+        annotations: { readOnlyHint: true },
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: {
+          type: "object",
+          properties: {
+            reminders: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  recipient: { type: "string" },
+                  subject: { type: "string" },
+                  sentAt: { type: "string", format: "date-time" },
+                  fireAt: { type: "string", format: "date-time" },
+                  note: { type: "string" },
+                },
+              },
+            },
+          },
+          required: ["reminders"],
+        },
+      },
+      {
+        name: "cancel_reminder",
+        title: "Cancel Reminder",
+        description: "Cancel a pending no-reply reminder by ID. Silently returns false if the ID is unknown or the reminder already fired.",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            reminder_id: { type: "string" },
+          },
+          required: ["reminder_id"],
+        },
+        outputSchema: ACTION_RESULT_SCHEMA,
+      },
+      {
+        name: "check_reminders",
+        title: "Check Reminders",
+        description:
+          "Return every pending reminder whose deadline has passed. Each returned reminder is transitioned to 'fired' status so it won't appear in subsequent calls. The agent can then search INBOX for replies to messageId and decide whether to surface the reminder to the user.",
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: {
+          type: "object",
+          properties: {
+            fired: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  messageId: { type: "string" },
+                  recipient: { type: "string" },
+                  subject: { type: "string" },
+                  sentAt: { type: "string", format: "date-time" },
+                  fireAt: { type: "string", format: "date-time" },
+                  note: { type: "string" },
+                },
+              },
+            },
+          },
+          required: ["fired"],
+        },
+      },
+      {
         name: "cancel_scheduled_email",
         title: "Cancel Scheduled Email",
         description: "Cancel a pending scheduled email before it is sent. Returns false if the ID is not found or the email has already been sent.",
@@ -2720,6 +2821,79 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return { content: [{ type: "text" as const, text: "Not found or not pending" }], isError: true, structuredContent: { success: false, reason: "Not found or not pending" } };
         }
         return actionOk();
+      }
+
+      // ── Reminders (no-reply follow-ups) ────────────────────────────────────
+      case "remind_if_no_reply": {
+        const remEmailId = requireNumericEmailId(args.email_id, "email_id");
+        const afterDays = typeof args.after_days === "number" ? args.after_days : NaN;
+        if (!Number.isFinite(afterDays) || afterDays < 1 || afterDays > 365) {
+          throw new McpError(ErrorCode.InvalidParams, "after_days must be a number between 1 and 365.");
+        }
+        const msg = await imapService.getEmailById(remEmailId);
+        if (!msg) {
+          return { content: [{ type: "text" as const, text: "Source message not found" }], isError: true, structuredContent: { success: false, reason: "Source message not found" } };
+        }
+        // Pull the RFC 2822 Message-ID so the agent can later search for replies
+        // with In-Reply-To / References headers matching it.
+        const headers = msg.headers ?? {};
+        const rawMsgId = Array.isArray(headers["message-id"]) ? headers["message-id"][0] : (headers["message-id"] as string | undefined);
+        if (!rawMsgId) {
+          throw new McpError(ErrorCode.InvalidRequest, "Source message has no Message-ID header; cannot track replies.");
+        }
+        const recipient = (msg.to ?? [])[0] ?? "";
+        const reminder = reminderService.add({
+          messageId: rawMsgId,
+          imapUid: remEmailId,
+          recipient,
+          subject: msg.subject ?? "",
+          sentAt: msg.date ?? new Date(),
+          afterDays,
+          note: typeof args.note === "string" ? args.note : undefined,
+        });
+        return ok({
+          id: reminder.id,
+          recipient: reminder.recipient,
+          subject: reminder.subject,
+          fireAt: reminder.fireAt,
+        });
+      }
+
+      case "list_pending_reminders": {
+        const reminders = reminderService.listPending().map(r => ({
+          id: r.id,
+          recipient: r.recipient,
+          subject: r.subject,
+          sentAt: r.sentAt,
+          fireAt: r.fireAt,
+          note: r.note ?? "",
+        }));
+        return ok({ reminders });
+      }
+
+      case "cancel_reminder": {
+        const rid = typeof args.reminder_id === "string" ? args.reminder_id : "";
+        if (!rid) throw new McpError(ErrorCode.InvalidParams, "reminder_id must be a non-empty string.");
+        const cancelled = reminderService.cancel(rid);
+        if (!cancelled) {
+          return { content: [{ type: "text" as const, text: "Reminder not found or already fired" }], isError: true, structuredContent: { success: false, reason: "Not found or already fired" } };
+        }
+        return actionOk();
+      }
+
+      case "check_reminders": {
+        const fired = reminderService.scanDue().map(r => ({
+          id: r.id,
+          messageId: r.messageId,
+          recipient: r.recipient,
+          subject: r.subject,
+          sentAt: r.sentAt,
+          fireAt: r.fireAt,
+          note: r.note ?? "",
+        }));
+        // Keep the store small over time
+        reminderService.prune();
+        return ok({ fired });
       }
 
       case "download_attachment": {

--- a/src/services/reminder-service.test.ts
+++ b/src/services/reminder-service.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the no-reply reminder service.
+ * Uses an in-memory tmpdir path so persistence is exercised without polluting
+ * the actual home directory.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ReminderService } from "./reminder-service.js";
+import { rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+
+function tmpPath(): string {
+  return join(tmpdir(), `pm-bridge-reminders-${randomBytes(6).toString("hex")}.json`);
+}
+
+describe("ReminderService", () => {
+  let path: string;
+
+  beforeEach(() => {
+    path = tmpPath();
+  });
+
+  afterEach(() => {
+    if (existsSync(path)) rmSync(path, { force: true });
+  });
+
+  it("starts empty when no file exists", () => {
+    const svc = new ReminderService(path);
+    expect(svc.listPending()).toEqual([]);
+  });
+
+  it("persists a new reminder and reloads it from disk", () => {
+    const sentAt = new Date("2026-01-01T00:00:00Z");
+    const svc1 = new ReminderService(path);
+    const rec = svc1.add({
+      messageId: "<m1@proton>",
+      recipient: "a@example.com",
+      subject: "Re: Proposal",
+      sentAt,
+      afterDays: 3,
+    });
+    expect(rec.id).toMatch(/^r-[0-9a-f]{10}$/);
+    expect(rec.status).toBe("pending");
+
+    const svc2 = new ReminderService(path);
+    const pending = svc2.listPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].messageId).toBe("<m1@proton>");
+    expect(pending[0].fireAt).toBe(new Date(sentAt.getTime() + 3 * 86_400_000).toISOString());
+  });
+
+  it("clamps afterDays to [1, 365]", () => {
+    const svc = new ReminderService(path);
+    const rec0 = svc.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date("2026-01-01Z"), afterDays: 0 });
+    const recHuge = svc.add({ messageId: "<b>", recipient: "a@x", subject: "s", sentAt: new Date("2026-01-01Z"), afterDays: 9999 });
+    const base = new Date("2026-01-01Z").getTime();
+    expect(Date.parse(rec0.fireAt) - base).toBe(1 * 86_400_000);
+    expect(Date.parse(recHuge.fireAt) - base).toBe(365 * 86_400_000);
+  });
+
+  it("rejects add without a messageId or recipient", () => {
+    const svc = new ReminderService(path);
+    expect(() => svc.add({ messageId: "", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 })).toThrow();
+    expect(() => svc.add({ messageId: "<a>", recipient: "", subject: "s", sentAt: new Date(), afterDays: 1 })).toThrow();
+  });
+
+  it("cancel() flips a pending reminder to 'cancelled' and drops it from listPending", () => {
+    const svc = new ReminderService(path);
+    const rec = svc.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 });
+    expect(svc.cancel(rec.id)).toBe(true);
+    expect(svc.listPending()).toEqual([]);
+    expect(svc.listAll().find(r => r.id === rec.id)?.status).toBe("cancelled");
+  });
+
+  it("cancel() returns false for unknown or non-pending IDs", () => {
+    const svc = new ReminderService(path);
+    expect(svc.cancel("r-missing")).toBe(false);
+    const rec = svc.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 });
+    svc.cancel(rec.id);
+    // second cancel on the same id is a no-op
+    expect(svc.cancel(rec.id)).toBe(false);
+  });
+
+  it("scanDue() fires only reminders whose deadline has passed", () => {
+    const svc = new ReminderService(path);
+    const sentAt = new Date("2026-04-01T00:00:00Z");
+    const soon  = svc.add({ messageId: "<a>", recipient: "a@x", subject: "soon",  sentAt, afterDays: 1 });
+    const later = svc.add({ messageId: "<b>", recipient: "a@x", subject: "later", sentAt, afterDays: 30 });
+    // now = sentAt + 5 days → soon is due, later is not
+    const fired = svc.scanDue(new Date(sentAt.getTime() + 5 * 86_400_000));
+    expect(fired.map(r => r.id)).toEqual([soon.id]);
+    // Firing is persisted — a re-scan at the same instant returns nothing.
+    expect(svc.scanDue(new Date(sentAt.getTime() + 5 * 86_400_000))).toEqual([]);
+    expect(svc.listPending().map(r => r.id)).toEqual([later.id]);
+  });
+
+  it("listPending is sorted by fireAt (earliest first)", () => {
+    const svc = new ReminderService(path);
+    const sentAt = new Date("2026-04-01T00:00:00Z");
+    svc.add({ messageId: "<z>", recipient: "a@x", subject: "long",  sentAt, afterDays: 30 });
+    svc.add({ messageId: "<a>", recipient: "a@x", subject: "short", sentAt, afterDays: 1 });
+    svc.add({ messageId: "<m>", recipient: "a@x", subject: "mid",   sentAt, afterDays: 7 });
+    expect(svc.listPending().map(r => r.subject)).toEqual(["short", "mid", "long"]);
+  });
+
+  it("prune() removes fired/cancelled records older than the retention window", () => {
+    const svc = new ReminderService(path);
+    const old = svc.add({ messageId: "<a>", recipient: "a@x", subject: "old", sentAt: new Date("2026-01-01Z"), afterDays: 1 });
+    svc.scanDue(new Date("2026-02-01Z"));
+    // After 2026-03-15 the old fired record is outside a 30-day window.
+    const removed = svc.prune(30); // retain last 30 days (prune uses Date.now)
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(svc.listAll().find(r => r.id === old.id)).toBeUndefined();
+  });
+
+  it("recovers from a malformed file by starting empty", async () => {
+    const svc1 = new ReminderService(path);
+    svc1.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 });
+    // Corrupt the file on disk
+    const { writeFileSync } = await import("fs");
+    writeFileSync(path, "{not valid json", "utf-8");
+    const svc2 = new ReminderService(path);
+    expect(svc2.listAll()).toEqual([]);
+  });
+});

--- a/src/services/reminder-service.ts
+++ b/src/services/reminder-service.ts
@@ -1,0 +1,162 @@
+/**
+ * No-reply reminder service.
+ *
+ * Persists reminders keyed to an already-sent email and fires them when a
+ * user-chosen deadline elapses. A follow-up PR will add automatic
+ * reply-detection via IMAP header search; for v1 the agent composes that
+ * check itself by calling search_emails with the stored Message-ID.
+ *
+ * Storage is a single JSON file written atomically via tmp → rename, with
+ * mode 0600 to match the rest of the project's credential-hygiene story.
+ */
+
+import { readFileSync, writeFileSync, existsSync, renameSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+import { logger } from "../utils/logger.js";
+
+export type ReminderStatus = "pending" | "fired" | "cancelled";
+
+export interface Reminder {
+  /** Short random ID, not persistent across manual edits. */
+  id: string;
+  /** RFC 2822 Message-ID of the message the user sent and wants a reply to. */
+  messageId: string;
+  /** IMAP UID of the original message (for quick re-lookup). */
+  imapUid?: string;
+  /** Recipient that ought to reply. */
+  recipient: string;
+  /** Original subject (stored so the reminder payload is human-readable). */
+  subject: string;
+  /** ISO-8601 timestamp the original message was sent. */
+  sentAt: string;
+  /** ISO-8601 timestamp when this reminder should fire. */
+  fireAt: string;
+  status: ReminderStatus;
+  /** Optional free-text reminder-why, shown with the notification. */
+  note?: string;
+}
+
+interface ReminderFile {
+  version: 1;
+  reminders: Reminder[];
+}
+
+export class ReminderService {
+  private readonly path: string;
+  private reminders: Reminder[] = [];
+
+  constructor(path: string) {
+    this.path = path;
+    this.load();
+  }
+
+  private load(): void {
+    if (!existsSync(this.path)) {
+      this.reminders = [];
+      return;
+    }
+    try {
+      const raw = readFileSync(this.path, "utf-8");
+      const parsed = JSON.parse(raw) as Partial<ReminderFile>;
+      this.reminders = Array.isArray(parsed.reminders) ? parsed.reminders : [];
+    } catch (err) {
+      logger.warn(`ReminderService: failed to parse ${this.path}, starting empty`, "ReminderService", err);
+      this.reminders = [];
+    }
+  }
+
+  private persist(): void {
+    const payload: ReminderFile = { version: 1, reminders: this.reminders };
+    const tmp = join(tmpdir(), `pm-bridge-reminders-${randomBytes(8).toString("hex")}.json.tmp`);
+    writeFileSync(tmp, JSON.stringify(payload, null, 2), { encoding: "utf-8", mode: 0o600 });
+    renameSync(tmp, this.path);
+  }
+
+  /**
+   * Create a reminder. Returns the persisted record.
+   * @param args.afterDays  Days from sentAt to the deadline. Minimum 1, maximum 365.
+   */
+  add(args: {
+    messageId: string;
+    imapUid?: string;
+    recipient: string;
+    subject: string;
+    sentAt: Date;
+    afterDays: number;
+    note?: string;
+  }): Reminder {
+    if (!args.messageId) throw new Error("messageId is required");
+    if (!args.recipient) throw new Error("recipient is required");
+    const clampedDays = Math.min(Math.max(Math.trunc(args.afterDays), 1), 365);
+    const fireAtMs = args.sentAt.getTime() + clampedDays * 24 * 60 * 60 * 1000;
+    const record: Reminder = {
+      id: `r-${randomBytes(5).toString("hex")}`,
+      messageId: args.messageId,
+      imapUid: args.imapUid,
+      recipient: args.recipient,
+      subject: args.subject,
+      sentAt: args.sentAt.toISOString(),
+      fireAt: new Date(fireAtMs).toISOString(),
+      status: "pending",
+      note: args.note,
+    };
+    this.reminders.push(record);
+    this.persist();
+    return record;
+  }
+
+  /** Return pending reminders sorted by earliest fireAt. */
+  listPending(): Reminder[] {
+    return this.reminders
+      .filter(r => r.status === "pending")
+      .sort((a, b) => Date.parse(a.fireAt) - Date.parse(b.fireAt));
+  }
+
+  /** Return every reminder, regardless of status. */
+  listAll(): Reminder[] {
+    return [...this.reminders];
+  }
+
+  cancel(id: string): boolean {
+    const r = this.reminders.find(x => x.id === id);
+    if (!r || r.status !== "pending") return false;
+    r.status = "cancelled";
+    this.persist();
+    return true;
+  }
+
+  /**
+   * Advance each due pending reminder to "fired" and return them. Caller is
+   * responsible for surfacing the list to the user (MCP log, tool response,
+   * etc.) — this method does not push anywhere.
+   */
+  scanDue(now: Date = new Date()): Reminder[] {
+    const cutoffMs = now.getTime();
+    const fired: Reminder[] = [];
+    let mutated = false;
+    for (const r of this.reminders) {
+      if (r.status === "pending" && Date.parse(r.fireAt) <= cutoffMs) {
+        r.status = "fired";
+        fired.push({ ...r });
+        mutated = true;
+      }
+    }
+    if (mutated) this.persist();
+    return fired;
+  }
+
+  /** Remove fired/cancelled reminders older than the retention window. */
+  prune(retainDays = 30): number {
+    const cutoff = Date.now() - retainDays * 24 * 60 * 60 * 1000;
+    const before = this.reminders.length;
+    this.reminders = this.reminders.filter(r => {
+      if (r.status === "pending") return true;
+      return Date.parse(r.fireAt) >= cutoff;
+    });
+    const removed = before - this.reminders.length;
+    if (removed > 0) this.persist();
+    return removed;
+  }
+}


### PR DESCRIPTION
Closes #39. [Top Proton UserVoice request](https://protonmail.uservoice.com/forums/284483-proton-mail/suggestions/48576497-remind-me-if-no-reply) — "Remind me if no reply" — translated into four MCP tools.

**New tools** (drafts category / extended tier)
- `remind_if_no_reply(email_id, after_days, note?)` — capture a sent message's Message-ID + recipient + subject and schedule a reminder for `sent_at + after_days`.
- `list_pending_reminders()` — sorted by earliest fireAt.
- `cancel_reminder(reminder_id)`
- `check_reminders()` — return every reminder whose deadline has passed, transition each to `fired`. The agent can then search INBOX for replies to the stored Message-ID and surface / dismiss.

**Storage** `~/.pm-bridge-mcp-reminders.json` (mode 0600, atomic tmp→rename, consistent with existing credential handling).

**V1 scope note** — auto reply-detection is deliberately out of this PR. The fired-reminder payload carries the RFC 2822 Message-ID, so a single `search_emails` call by the agent is enough. A v2 PR will add a server-side header-scan.

**Tests**
- 10 new tests for `ReminderService` (persistence, clamp, cancel, scanDue, prune, recovery from malformed file)
- Full suite: 1338 passing
- Coverage: 96.13 / 94.34 / 95.63 / 96.65