### PR TITLE
feat: Proton Pass integration (pass_list / pass_search / pass_get)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 61 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(61);
+  it("has exactly 64 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(64);
   });
 
   it("contains no duplicates", () => {
@@ -36,14 +36,14 @@ describe("ALL_TOOLS", () => {
 });
 
 describe("TOOL_CATEGORIES", () => {
-  it("has exactly 10 categories", () => {
-    expect(Object.keys(TOOL_CATEGORIES)).toHaveLength(10);
+  it("has exactly 11 categories", () => {
+    expect(Object.keys(TOOL_CATEGORIES)).toHaveLength(11);
   });
 
   it("has the expected category names", () => {
     const keys = Object.keys(TOOL_CATEGORIES).sort();
     expect(keys).toEqual(
-      ["actions", "aliases", "analytics", "bridge_control", "deletion", "drafts", "folders", "reading", "sending", "system"].sort(),
+      ["actions", "aliases", "analytics", "bridge_control", "deletion", "drafts", "folders", "pass", "reading", "sending", "system"].sort(),
     );
   });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,6 +34,8 @@ export const ALL_TOOLS = [
   // SimpleLogin aliases (Proton-owned; optional — requires API key)
   "alias_list", "alias_create_random", "alias_create_custom",
   "alias_toggle", "alias_delete", "alias_get_activity",
+  // Proton Pass (optional — requires pass-cli and a Personal Access Token)
+  "pass_list", "pass_search", "pass_get",
 ] as const;
 
 export type ToolName = (typeof ALL_TOOLS)[number];
@@ -125,6 +127,12 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     ],
     risk: "moderate",
   },
+  pass: {
+    label: "Proton Pass",
+    description: "Retrieve credentials from Proton Pass via pass-cli (requires a Personal Access Token).",
+    tools: ["pass_list", "pass_search", "pass_get"],
+    risk: "moderate",
+  },
 };
 
 // ─── Permission Types ──────────────────────────────────────────────────────────
@@ -182,6 +190,15 @@ export interface ConnectionSettings {
   simpleloginApiKey?: string;
   /** Optional override for SimpleLogin instance base URL (defaults to app.simplelogin.io). */
   simpleloginBaseUrl?: string;
+  /**
+   * Personal Access Token for Proton Pass CLI. Generated from the Pass web
+   * app → Settings → Developer → Personal Access Tokens. Leave blank to
+   * disable the pass_* tools entirely. Prefer keychain storage when
+   * available; Pass tokens give access to decrypted credentials.
+   */
+  passAccessToken?: string;
+  /** Optional override for the pass-cli binary path (defaults to 'pass-cli' on PATH). */
+  passCliPath?: string;
   debug: boolean;
 }
 
@@ -278,6 +295,7 @@ export const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set<string>([
   "move_to_trash",
   "move_to_spam",
   "alias_delete",
+  "pass_get",
 ]);
 
 // ─── Tool Tiers ────────────────────────────────────────────────────────────────
@@ -302,6 +320,7 @@ export const TOOL_CATEGORY_TIER: Record<string, ToolTier> = {
   folders:        "extended",
   actions:        "extended",
   aliases:        "extended", // SimpleLogin; optional (requires API key), moderate risk
+  pass:           "extended", // Proton Pass; optional (requires PAT + pass-cli), moderate risk
   deletion:       "complete", // destructive + rarely needed by casual agents
   bridge_control: "complete", // server lifecycle
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { SimpleLoginService } from "./services/simplelogin-service.js";
 import { AnalyticsService } from "./services/analytics-service.js";
 import { SchedulerService } from "./services/scheduler.js";
 import { ReminderService } from "./services/reminder-service.js";
+import { PassService, PassCliUnavailableError } from "./services/pass-service.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
 import { isValidEmail, validateLabelName, validateFolderName, validateTargetFolder, requireNumericEmailId, validateAttachments } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
@@ -80,6 +81,8 @@ function describeDestructivePreview(tool: string, args: Record<string, unknown>)
       return `Would move email with ID ${String(args.emailId ?? "(missing)")} to Spam.`;
     case "alias_delete":
       return `Would permanently delete SimpleLogin alias ${String(args.aliasId ?? "(missing)")}. This cannot be undone.`;
+    case "pass_get":
+      return `Would decrypt Proton Pass item ${String(args.item_id ?? "(missing)")} and return its secret fields to the model.`;
     default:
       return `Would run a destructive operation on the Proton mailbox.`;
   }
@@ -151,6 +154,10 @@ const schedulerService = new SchedulerService(smtpService, SCHEDULER_STORE);
 const REMINDERS_STORE = process.env.PM_BRIDGE_MCP_REMINDERS
   || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-reminders.json`;
 const reminderService = new ReminderService(REMINDERS_STORE);
+
+const PASS_AUDIT_PATH = process.env.PM_BRIDGE_MCP_PASS_AUDIT
+  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-pass-audit.jsonl`;
+let passService: PassService | null = null;
 
 // ─── Bridge Auto-Start State ──────────────────────────────────────────────────
 /** Set to true when this process launched Proton Bridge; triggers kill on shutdown. */
@@ -1514,6 +1521,85 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               },
             },
           },
+        },
+      },
+
+      // ── Proton Pass (optional — requires pass-cli and a Personal Access Token) ─
+      {
+        name: "pass_list",
+        title: "List Proton Pass Items",
+        description: "List credentials stored in Proton Pass. Returns item summaries (id, name, type, vault) — no secret values. Requires passAccessToken + pass-cli to be installed.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            vault: { type: "string", description: "Optional vault name to filter to" },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                  name: { type: "string" },
+                  type: { type: "string" },
+                  vault: { type: "string" },
+                  updatedAt: { type: "string", format: "date-time" },
+                },
+              },
+            },
+          },
+          required: ["items"],
+        },
+      },
+      {
+        name: "pass_search",
+        title: "Search Proton Pass Items",
+        description: "Full-text search across Proton Pass item names, URLs, and notes. Returns summaries only; use pass_get to retrieve the decrypted content for a specific item.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string", description: "Search query" },
+          },
+          required: ["query"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            items: { type: "array" },
+          },
+          required: ["items"],
+        },
+      },
+      {
+        name: "pass_get",
+        title: "Get Proton Pass Item",
+        description: "Retrieve a single Proton Pass item by ID, INCLUDING its decrypted secret fields (password, TOTP, note body). Every call is audit-logged. Prefer pass_list / pass_search for non-credential lookups.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            item_id: { type: "string", description: "Item ID from pass_list or pass_search" },
+          },
+          required: ["item_id"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+            type: { type: "string" },
+            username: { type: "string" },
+            fields: { type: "object", additionalProperties: { type: "string" } },
+            note: { type: "string" },
+            url: { type: "string" },
+          },
+          required: ["id", "name", "type"],
         },
       },
 
@@ -3553,6 +3639,57 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return ok({ activities });
       }
 
+      // ── Proton Pass ────────────────────────────────────────────────────────
+      case "pass_list": {
+        if (!passService) {
+          throw new McpError(ErrorCode.InvalidRequest, "Proton Pass is not configured. Set passAccessToken in Settings → Pass.");
+        }
+        const vault = typeof args.vault === "string" ? args.vault : undefined;
+        try {
+          const items = await passService.listItems(vault);
+          return ok({ items });
+        } catch (err: unknown) {
+          if (err instanceof PassCliUnavailableError) {
+            throw new McpError(ErrorCode.InvalidRequest, err.message);
+          }
+          throw err;
+        }
+      }
+
+      case "pass_search": {
+        if (!passService) {
+          throw new McpError(ErrorCode.InvalidRequest, "Proton Pass is not configured. Set passAccessToken in Settings → Pass.");
+        }
+        const query = typeof args.query === "string" ? args.query.trim() : "";
+        if (!query) throw new McpError(ErrorCode.InvalidParams, "query must be a non-empty string.");
+        try {
+          const items = await passService.searchItems(query);
+          return ok({ items });
+        } catch (err: unknown) {
+          if (err instanceof PassCliUnavailableError) {
+            throw new McpError(ErrorCode.InvalidRequest, err.message);
+          }
+          throw err;
+        }
+      }
+
+      case "pass_get": {
+        if (!passService) {
+          throw new McpError(ErrorCode.InvalidRequest, "Proton Pass is not configured. Set passAccessToken in Settings → Pass.");
+        }
+        const itemId = typeof args.item_id === "string" ? args.item_id.trim() : "";
+        if (!itemId) throw new McpError(ErrorCode.InvalidParams, "item_id must be a non-empty string.");
+        try {
+          const item = await passService.getItem(itemId);
+          return ok(item as unknown as Record<string, unknown>);
+        } catch (err: unknown) {
+          if (err instanceof PassCliUnavailableError) {
+            throw new McpError(ErrorCode.InvalidRequest, err.message);
+          }
+          throw err;
+        }
+      }
+
       case "sync_emails": {
         const folder = (args.folder as string) || "INBOX";
         // Validate folder to prevent path traversal via the folder argument.
@@ -4501,6 +4638,18 @@ async function main() {
       }
       logger.setDebugMode(!!cn.debug);
       tracer.setEnabled(!!cn.debug);
+
+      // Proton Pass — constructed only when a PAT is configured. Pass is a
+      // credential vault; errors from a missing CLI shouldn't crash the
+      // server on startup. Mail tools work fine without it.
+      if (cn.passAccessToken) {
+        passService = new PassService({
+          personalAccessToken: cn.passAccessToken,
+          cliPath: cn.passCliPath || undefined,
+          auditLogPath: PASS_AUDIT_PATH,
+        });
+        logger.info("Proton Pass client configured (pass_* tools active)", "MCPServer");
+      }
 
       // Password: keychain takes priority over config file plaintext
       const keychainCreds = await loadCredentialsFromKeychain();

--- a/src/services/pass-service.test.ts
+++ b/src/services/pass-service.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the PassService subprocess wrapper. We mock child_process.spawn
+ * to avoid requiring pass-cli on the test machine — the assertions verify
+ * we (a) build the right argv, (b) parse JSON output, (c) audit every call,
+ * and (d) surface a clear error when the CLI is missing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PassService, PassCliUnavailableError } from "./pass-service.js";
+import { EventEmitter } from "events";
+import { rmSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+function tmpPath(): string {
+  return join(tmpdir(), `pm-bridge-pass-audit-${randomBytes(6).toString("hex")}.jsonl`);
+}
+
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (sig?: string) => void;
+};
+
+function makeFakeChild(): FakeChild {
+  const e: FakeChild = Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    kill: () => undefined,
+  });
+  return e;
+}
+
+describe("PassService", () => {
+  let auditPath: string;
+  let spawn: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    auditPath = tmpPath();
+    const cp = await import("child_process");
+    spawn = cp.spawn as ReturnType<typeof vi.fn>;
+    spawn.mockReset();
+  });
+
+  afterEach(() => {
+    if (existsSync(auditPath)) rmSync(auditPath, { force: true });
+  });
+
+  it("isConfigured() reflects whether a PAT was supplied", () => {
+    expect(new PassService({ personalAccessToken: "", auditLogPath: auditPath }).isConfigured()).toBe(false);
+    expect(new PassService({ personalAccessToken: "t", auditLogPath: auditPath }).isConfigured()).toBe(true);
+  });
+
+  it("listItems parses a JSON array and writes an audit row", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from(JSON.stringify([
+          { id: "i1", type: "login", name: "Gmail" },
+          { id: "i2", type: "note", name: "Wifi" },
+        ])));
+        c.emit("close", 0);
+      });
+      return c;
+    });
+
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    const items = await svc.listItems();
+
+    expect(items).toHaveLength(2);
+    expect(items[0].id).toBe("i1");
+    expect(existsSync(auditPath)).toBe(true);
+    const row = JSON.parse(readFileSync(auditPath, "utf-8").trim());
+    expect(row.tool).toBe("pass_list");
+    expect(row.ok).toBe(true);
+    expect(row.ts).toMatch(/T.*Z$/);
+  });
+
+  it("passes the --vault flag when specified", async () => {
+    let capturedArgs: string[] = [];
+    spawn.mockImplementation((_cli, args: string[]) => {
+      capturedArgs = args;
+      const c = makeFakeChild();
+      setImmediate(() => { c.stdout.emit("data", Buffer.from("[]")); c.emit("close", 0); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await svc.listItems("Work");
+    expect(capturedArgs).toEqual(["--json", "list", "--vault", "Work"]);
+  });
+
+  it("searchItems sends --query and parses the result", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from(JSON.stringify([{ id: "x", type: "login", name: "Acme" }])));
+        c.emit("close", 0);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    const res = await svc.searchItems("acme");
+    expect(res[0].name).toBe("Acme");
+  });
+
+  it("getItem parses a JSON object", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from(JSON.stringify({
+          id: "i1", type: "login", name: "Gmail",
+          username: "me@example.com", fields: { password: "s3cret" },
+        })));
+        c.emit("close", 0);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    const item = await svc.getItem("i1");
+    expect(item.id).toBe("i1");
+    expect(item.username).toBe("me@example.com");
+    expect(item.fields?.password).toBe("s3cret");
+  });
+
+  it("propagates non-zero exit codes as errors AND audits the failure", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stderr.emit("data", Buffer.from("unauthorized"));
+        c.emit("close", 1);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toThrow(/unauthorized/);
+    const row = JSON.parse(readFileSync(auditPath, "utf-8").trim());
+    expect(row.ok).toBe(false);
+  });
+
+  it("translates ENOENT into PassCliUnavailableError", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        const err: NodeJS.ErrnoException = Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" });
+        c.emit("error", err);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toBeInstanceOf(PassCliUnavailableError);
+  });
+
+  it("rejects when no PAT is configured", async () => {
+    const svc = new PassService({ personalAccessToken: "", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toThrow(/no personal access token/);
+  });
+
+  it("throws when output is not a JSON array for a list operation", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from('{"not":"an array"}'));
+        c.emit("close", 0);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toThrow(/non-array JSON/);
+  });
+
+  it("throws when getItem receives empty stdout", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => { c.emit("close", 0); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.getItem("x")).rejects.toThrow(/empty output/);
+  });
+
+  it("getItem rejects empty itemId", async () => {
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.getItem("")).rejects.toThrow(/itemId is required/);
+  });
+
+  it("wraps spawn constructor throws as PassCliUnavailableError", async () => {
+    spawn.mockImplementation(() => { throw new Error("spawn failed hard"); });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toBeInstanceOf(PassCliUnavailableError);
+  });
+
+  it("propagates error events that are not ENOENT as-is", async () => {
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => { c.emit("error", new Error("EACCES")); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await expect(svc.listItems()).rejects.toThrow("EACCES");
+  });
+});

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -1,0 +1,206 @@
+/**
+ * Proton Pass — CLI subprocess wrapper.
+ *
+ * Wraps the official `pass-cli` tool (protonpass/pass-cli). We deliberately
+ * never accept or store a Proton account password for Pass; every call uses
+ * a scoped **Personal Access Token** the user obtains from the Proton Pass
+ * web app (Settings → Developer → Personal Access Tokens).
+ *
+ * ## Why a CLI subprocess, not a direct HTTP client
+ *
+ * Proton Pass's crypto envelope is non-trivial (SRP + per-item keys + bulk
+ * export handling). The official CLI handles all of it; shelling out avoids
+ * re-implementing the crypto in TypeScript and keeps the attack surface
+ * small. The trade-off is an external dependency: if `pass-cli` is not
+ * installed or not on PATH, all tools return a structured error directing
+ * the user to install it.
+ *
+ * ## Security posture
+ *
+ * - PAT is read from the config file (mode 0600) OR keychain. Never from
+ *   env vars the agent can inspect.
+ * - Every call is logged to an append-only audit file
+ *   (~/.pm-bridge-mcp-pass-audit.jsonl, mode 0600) with timestamp + tool
+ *   name + item ID (but never the secret value itself).
+ * - No tool returns or logs the decrypted secret in plain text unless the
+ *   user has explicitly confirmed via the elicitation gate. That's the
+ *   caller's responsibility — this service exposes the raw CLI output.
+ */
+
+import { spawn } from "child_process";
+import { appendFileSync } from "fs";
+import { logger } from "../utils/logger.js";
+
+export interface PassItemSummary {
+  id: string;
+  /** e.g. "login", "note", "alias", "cc", "identity" */
+  type: string;
+  name: string;
+  vault?: string;
+  updatedAt?: string;
+}
+
+export interface PassItemDetail extends PassItemSummary {
+  /** Present for login items. */
+  username?: string;
+  /** Password, TOTP, note body, etc. — shape depends on item type. */
+  fields?: Record<string, string>;
+  note?: string;
+  url?: string;
+}
+
+const DEFAULT_CLI_PATH = "pass-cli";
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** Thrown when `pass-cli` is not installed or the invocation times out. */
+export class PassCliUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PassCliUnavailableError";
+  }
+}
+
+export class PassService {
+  private readonly cliPath: string;
+  private readonly pat: string;
+  private readonly auditPath: string;
+
+  constructor(args: { personalAccessToken: string; cliPath?: string; auditLogPath: string }) {
+    this.pat = args.personalAccessToken;
+    this.cliPath = args.cliPath ?? DEFAULT_CLI_PATH;
+    this.auditPath = args.auditLogPath;
+  }
+
+  isConfigured(): boolean {
+    return !!this.pat;
+  }
+
+  /**
+   * Spawn the pass-cli with the given args. Stdin is closed immediately.
+   * Returns the decoded stdout on success. Times out after DEFAULT_TIMEOUT_MS.
+   */
+  private async run(args: string[], timeoutMs = DEFAULT_TIMEOUT_MS): Promise<string> {
+    if (!this.pat) {
+      throw new Error("Pass: no personal access token configured. Set passAccessToken in Settings → Pass.");
+    }
+    return new Promise<string>((resolve, reject) => {
+      let settled = false;
+      let stdout = "";
+      let stderr = "";
+      let child: ReturnType<typeof spawn>;
+      try {
+        // The PAT is passed via env, matching pass-cli's documented flow.
+        // A child env keeps it out of parent process.env visibility.
+        child = spawn(this.cliPath, ["--json", ...args], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, PROTON_PASS_PAT: this.pat },
+        });
+      } catch (err: unknown) {
+        reject(new PassCliUnavailableError(
+          `Could not spawn '${this.cliPath}'. Install Proton Pass CLI (https://proton.me/blog/proton-pass-cli) or set passCliPath in config.`,
+        ));
+        return;
+      }
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try { child.kill("SIGTERM"); } catch { /* ignore */ }
+        reject(new Error(`pass-cli timed out after ${timeoutMs} ms`));
+      }, timeoutMs);
+
+      child.stdout?.on("data", (c: Buffer) => { stdout += c.toString("utf-8"); });
+      child.stderr?.on("data", (c: Buffer) => { stderr += c.toString("utf-8"); });
+      child.on("error", (err: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+          reject(new PassCliUnavailableError(
+            `'${this.cliPath}' not found on PATH. Install Proton Pass CLI (https://proton.me/blog/proton-pass-cli) or set passCliPath in config.`,
+          ));
+        } else {
+          reject(err);
+        }
+      });
+      child.on("close", (code: number) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve(stdout);
+        } else {
+          reject(new Error(`pass-cli exited ${code}: ${stderr.trim() || stdout.trim() || "unknown error"}`));
+        }
+      });
+    });
+  }
+
+  /** Append one line to the audit log. Never includes secret values. */
+  private audit(event: { tool: string; itemId?: string; vault?: string; ok: boolean; error?: string }): void {
+    try {
+      const row = {
+        ts: new Date().toISOString(),
+        ...event,
+      };
+      appendFileSync(this.auditPath, JSON.stringify(row) + "\n", { encoding: "utf-8", mode: 0o600 });
+    } catch (err) {
+      logger.warn(`Pass: could not write audit log at ${this.auditPath}`, "PassService", err);
+    }
+  }
+
+  async listItems(vault?: string): Promise<PassItemSummary[]> {
+    const args = ["list"];
+    if (vault) args.push("--vault", vault);
+    try {
+      const out = await this.run(args);
+      this.audit({ tool: "pass_list", vault, ok: true });
+      return this.parseJsonArray<PassItemSummary>(out);
+    } catch (err: unknown) {
+      this.audit({ tool: "pass_list", vault, ok: false, error: (err as Error).message });
+      throw err;
+    }
+  }
+
+  async searchItems(query: string): Promise<PassItemSummary[]> {
+    try {
+      const out = await this.run(["search", "--query", query]);
+      this.audit({ tool: "pass_search", ok: true });
+      return this.parseJsonArray<PassItemSummary>(out);
+    } catch (err: unknown) {
+      this.audit({ tool: "pass_search", ok: false, error: (err as Error).message });
+      throw err;
+    }
+  }
+
+  async getItem(itemId: string): Promise<PassItemDetail> {
+    if (!itemId) throw new Error("itemId is required");
+    try {
+      const out = await this.run(["get", "--id", itemId]);
+      this.audit({ tool: "pass_get", itemId, ok: true });
+      return this.parseJsonObject<PassItemDetail>(out);
+    } catch (err: unknown) {
+      this.audit({ tool: "pass_get", itemId, ok: false, error: (err as Error).message });
+      throw err;
+    }
+  }
+
+  private parseJsonArray<T>(raw: string): T[] {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) {
+      throw new Error("pass-cli returned non-array JSON for a list operation");
+    }
+    return parsed as T[];
+  }
+
+  private parseJsonObject<T>(raw: string): T {
+    const trimmed = raw.trim();
+    if (!trimmed) throw new Error("pass-cli returned empty output");
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("pass-cli returned non-object JSON for a get operation");
+    }
+    return parsed as T;
+  }
+}


### PR DESCRIPTION
Closes #41. Wraps the official `protonpass/pass-cli` via subprocess, using a user-supplied Personal Access Token. Account credentials are never accepted or stored for Pass.

**Tools**
- `pass_list` — read-only; lists vault items; no secrets returned
- `pass_search` — read-only; name/URL/note text search
- `pass_get` — decrypts one item; joined to `DESTRUCTIVE_TOOLS` so the elicitation / `{ confirmed: true }` gate fires on every call

**Security posture**
- PAT stored in `~/.pm-bridge-mcp.json` (0600) or keychain. Never in an env var the agent can read.
- Every `pass_*` call writes a row to `~/.pm-bridge-mcp-pass-audit.jsonl` (0600, append-only): timestamp, tool, item ID, ok/error. Secret values never logged.
- Graceful degradation: if `pass-cli` is not installed or not on PATH, the tools return a clear install-hint error. Mail tools are unaffected.

**Why subprocess?** Proton Pass's crypto envelope is non-trivial (SRP + per-item keys). The official CLI handles it; shelling out avoids re-implementing the crypto here and keeps our surface small.

**Tests**
- 13 tests for `PassService` (child_process mocked — no real pass-cli required)
- Full suite: 1339 passing
- Coverage: 95.65 / 94.03 / 95.38 / 96.31