### PR TITLE
feat: agents UI (A2) — tab, SSE notifications, tray updates

### DIFF
--- a/src/agents/grant-store.ts
+++ b/src/agents/grant-store.ts
@@ -17,6 +17,7 @@ import { randomBytes } from "crypto";
 import type { AgentGrant, AgentGrantStatus, GrantConditions } from "./types.js";
 import type { PermissionPreset, ToolName } from "../config/schema.js";
 import { logger } from "../utils/logger.js";
+import { notifications } from "./notifications.js";
 
 interface StoreFile {
   version: 1;
@@ -92,6 +93,7 @@ export class AgentGrantStore {
     };
     this.grants.set(args.clientId, grant);
     this.persist();
+    notifications.emitGrantChanged("grant-created", grant);
     return grant;
   }
 
@@ -106,16 +108,21 @@ export class AgentGrantStore {
     g.approvedAt = new Date().toISOString();
     g.revokedAt = undefined;
     this.persist();
+    notifications.emitGrantChanged("grant-approved", g);
     return g;
   }
 
   deny(clientId: string, note?: string): AgentGrant | null {
     const g = this.grants.get(clientId);
     if (!g) return null;
+    const wasPending = g.status === "pending";
     g.status = "revoked";
     g.revokedAt = new Date().toISOString();
     g.note = note ?? g.note;
     this.persist();
+    // Distinguish "deny" (never-approved pending grant rejected) from
+    // "revoke" (previously-approved grant taken back) for UI filtering.
+    notifications.emitGrantChanged(wasPending ? "grant-denied" : "grant-revoked", g);
     return g;
   }
 
@@ -133,6 +140,7 @@ export class AgentGrantStore {
     if (g.status === "expired") return g;
     g.status = "expired";
     this.persist();
+    notifications.emitGrantChanged("grant-expired", g);
     return g;
   }
 

--- a/src/agents/notifications.test.ts
+++ b/src/agents/notifications.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { notifications } from "./notifications.js";
+import type { AgentGrant } from "./types.js";
+import type { GrantChangedEvent } from "./notifications.js";
+
+function stubGrant(clientId = "pmc_x"): AgentGrant {
+  return {
+    clientId,
+    clientName: "Stub",
+    status: "pending",
+    preset: "read_only",
+    createdAt: new Date().toISOString(),
+    totalCalls: 0,
+  };
+}
+
+describe("NotificationBroker", () => {
+  it("emits a grant-changed event with a monotonic sequence", () => {
+    const received: GrantChangedEvent[] = [];
+    const unsub = notifications.subscribe(e => received.push(e));
+    try {
+      notifications.emitGrantChanged("grant-created", stubGrant("pmc_1"));
+      notifications.emitGrantChanged("grant-approved", stubGrant("pmc_1"));
+      expect(received).toHaveLength(2);
+      expect(received[0].kind).toBe("grant-created");
+      expect(received[1].kind).toBe("grant-approved");
+      expect(received[1].seq).toBeGreaterThan(received[0].seq);
+    } finally { unsub(); }
+  });
+
+  it("subscribe returns an unsubscribe function that stops delivery", () => {
+    let count = 0;
+    const unsub = notifications.subscribe(() => { count++; });
+    notifications.emitGrantChanged("grant-created", stubGrant("pmc_u"));
+    expect(count).toBe(1);
+    unsub();
+    notifications.emitGrantChanged("grant-created", stubGrant("pmc_u"));
+    expect(count).toBe(1);
+  });
+
+  it("supports multiple concurrent subscribers", () => {
+    const a: GrantChangedEvent[] = [];
+    const b: GrantChangedEvent[] = [];
+    const ua = notifications.subscribe(e => a.push(e));
+    const ub = notifications.subscribe(e => b.push(e));
+    try {
+      notifications.emitGrantChanged("grant-denied", stubGrant("pmc_m"));
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+      expect(a[0].seq).toBe(b[0].seq);
+    } finally { ua(); ub(); }
+  });
+});

--- a/src/agents/notifications.ts
+++ b/src/agents/notifications.ts
@@ -1,0 +1,51 @@
+/**
+ * Minimal in-process event bus for agent-related notifications.
+ *
+ * Subscribers include:
+ *   - the settings UI's SSE endpoint (live updates in the browser tab)
+ *   - the tray icon updater (dynamic "Pending: N" item)
+ *
+ * The bus is deliberately simple: one event type ("grant-changed") carrying
+ * a snapshot of the grant record. Consumers decide what to do with it.
+ * Decoupling via events means the store doesn't need to know about either
+ * the UI or the tray — they subscribe independently.
+ */
+
+import { EventEmitter } from "events";
+import type { AgentGrant } from "./types.js";
+
+export type NotificationKind =
+  | "grant-created"    // new DCR → pending grant just created
+  | "grant-approved"   // user approved in UI
+  | "grant-denied"
+  | "grant-revoked"
+  | "grant-expired";   // grant manager flipped an expiry during a tool call
+
+export interface GrantChangedEvent {
+  kind: NotificationKind;
+  grant: AgentGrant;
+  /** Monotonic sequence so SSE clients can detect gaps. */
+  seq: number;
+}
+
+class NotificationBroker extends EventEmitter {
+  private sequence = 0;
+
+  /** Emit a grant-changed event. All subscribers observe synchronously. */
+  emitGrantChanged(kind: NotificationKind, grant: AgentGrant): void {
+    this.sequence += 1;
+    this.emit("grant-changed", { kind, grant, seq: this.sequence } as GrantChangedEvent);
+  }
+
+  subscribe(listener: (ev: GrantChangedEvent) => void): () => void {
+    this.on("grant-changed", listener);
+    return () => { this.off("grant-changed", listener); };
+  }
+
+  /** Current sequence, for health checks and gap detection. */
+  get seq(): number { return this.sequence; }
+}
+
+// Module-scope singleton so both the settings server and the tray updater
+// can subscribe without threading the broker through every call site.
+export const notifications = new NotificationBroker();

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import { GrantManager } from "./agents/grant-manager.js";
 import { AgentAuditLog, hashArgs } from "./agents/audit.js";
 import { currentCaller } from "./agents/caller-context.js";
 import { registerAgentServices } from "./agents/registry.js";
+import { notifications as agentNotifications } from "./agents/notifications.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
 import { isValidEmail, validateLabelName, validateFolderName, validateTargetFolder, requireNumericEmailId, validateAttachments } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
@@ -3908,11 +3909,22 @@ function _buildTrayMenu(): SysTrayMenu {
   const sep: MenuItem = { title: "<SEPARATOR>", tooltip: "", enabled: true, checked: false };
   const statusLabel   = smtpStatus.connected ? "\u25CF Connected" : "\u25CB Disconnected";
   const emailLabel    = config.smtp.username || "Not configured";
+  const pendingCount  = agentGrants.list({ status: "pending" }).length;
+  const activeCount   = agentGrants.list({ status: "active" }).length;
+  const tooltip = pendingCount > 0
+    ? `pm-bridge-mcp · ${pendingCount} agent(s) awaiting approval`
+    : "pm-bridge-mcp";
   const items: MenuItem[] = [
     { title: "pm-bridge-mcp", tooltip: "pm-bridge-mcp daemon", enabled: false, checked: false },
     sep,
     { title: statusLabel, tooltip: "", enabled: false, checked: false },
     { title: emailLabel,  tooltip: "", enabled: false, checked: false },
+    ...(pendingCount > 0
+      ? [{ title: `\u26A0 ${pendingCount} agent(s) pending`, tooltip: "Open Settings → Agents to approve", enabled: false, checked: false }]
+      : []),
+    ...(activeCount > 0
+      ? [{ title: `\u25CF ${activeCount} agent(s) active`, tooltip: "", enabled: false, checked: false }]
+      : []),
     sep,
     ...(_settingsEnabled && _settingsUrl
       ? [{ title: "Open Settings", tooltip: `Open ${_settingsUrl}`, enabled: true, checked: false }]
@@ -3927,7 +3939,7 @@ function _buildTrayMenu(): SysTrayMenu {
     sep,
     { title: "Quit", tooltip: "Stop the MCP daemon", enabled: true, checked: false },
   ];
-  return { icon: TRAY_ICON_B64, title: "", tooltip: "pm-bridge-mcp", items };
+  return { icon: TRAY_ICON_B64, title: "", tooltip, items };
 }
 
 async function _rebuildTray(): Promise<void> {
@@ -3956,6 +3968,13 @@ async function _initTray(): Promise<void> {
     await tray.ready();
     _trayInstance = tray;
     logger.info("System tray icon active", "MCPServer");
+
+    // Keep the tray menu in sync with grant changes (new pending → badge,
+    // approved/revoked → count update). Handler is fire-and-forget; if
+    // rebuild fails we swallow to avoid crashing the daemon.
+    agentNotifications.subscribe(() => {
+      void _rebuildTray().catch(() => { /* swallow */ });
+    });
 
     await tray.onClick((action: { item: MenuItem }) => {
       switch (action.item.title) {

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -66,6 +66,7 @@ import {
 } from "../permissions/escalation.js";
 import { getLogFilePath } from "../utils/logger.js";
 import { getAgentGrantStore, getAgentAuditLog } from "../agents/registry.js";
+import { notifications as agentNotifications } from "../agents/notifications.js";
 
 // ─── TCP connectivity test ─────────────────────────────────────────────────────
 
@@ -853,6 +854,10 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 <nav id="main-nav" style="display:none">
   <button class="active" onclick="showTab('setup',this)">Setup</button>
   <button onclick="showTab('permissions',this)">Permissions</button>
+  <button onclick="showTab('agents',this)">
+    Agents
+    <span id="agents-pending-badge" style="display:none;background:#ef4444;color:#fff;border-radius:10px;padding:2px 7px;margin-left:6px;font-size:11px;font-weight:700">0</span>
+  </button>
   <button onclick="showTab('status',this)">Status</button>
   <button id="logs-tab-btn" style="display:none" onclick="showTab('logs',this)">Logs</button>
 </nav>
@@ -1516,6 +1521,40 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
   </div>
 </section>
 
+<!-- ══ AGENTS TAB ══ -->
+<section id="agents">
+  <div class="section-heading">Connected agents</div>
+  <div class="section-subheading">
+    Each MCP client that registers via OAuth gets its own grant. Approve,
+    deny, or revoke access independently. Stdio callers (the local Claude
+    Desktop default) bypass this system and use the global preset above.
+  </div>
+
+  <div class="card" style="margin-top:10px">
+    <div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px">
+      <button class="btn btn-ghost" id="ag-filter-pending"  onclick="switchAgentFilter('pending')"  style="font-weight:600">🔴 Pending <span id="ag-count-pending">0</span></button>
+      <button class="btn btn-ghost" id="ag-filter-active"   onclick="switchAgentFilter('active')">🟢 Active <span id="ag-count-active">0</span></button>
+      <button class="btn btn-ghost" id="ag-filter-revoked"  onclick="switchAgentFilter('revoked')">⚪ Revoked <span id="ag-count-revoked">0</span></button>
+      <button class="btn btn-ghost" id="ag-filter-audit"    onclick="switchAgentFilter('audit')">📋 Audit log</button>
+    </div>
+    <div id="agents-list" style="display:flex;flex-direction:column;gap:10px">
+      <div class="hint" style="text-align:center;padding:30px">Loading…</div>
+    </div>
+    <div id="agents-audit" style="display:none">
+      <table style="width:100%;border-collapse:collapse;font-size:13px">
+        <thead><tr>
+          <th style="text-align:left;padding:6px;border-bottom:1px solid #333">Time (ET)</th>
+          <th style="text-align:left;padding:6px;border-bottom:1px solid #333">Agent</th>
+          <th style="text-align:left;padding:6px;border-bottom:1px solid #333">Tool</th>
+          <th style="text-align:left;padding:6px;border-bottom:1px solid #333">Outcome</th>
+          <th style="text-align:right;padding:6px;border-bottom:1px solid #333">ms</th>
+        </tr></thead>
+        <tbody id="agents-audit-body"></tbody>
+      </table>
+    </div>
+  </div>
+</section>
+
 <!-- ══ STATUS TAB ══ -->
 <section id="status">
   <div class="section-heading">Status</div>
@@ -1749,9 +1788,163 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
     document.getElementById(id).classList.add('active');
     btn.classList.add('active');
     if (id === 'status') { populateStatus(cfg); loadAuditLog(); }
+    if (id === 'agents') { refreshAgents(); }
     if (id === 'logs')   { logInit(); }
     else                 { logStopFollow(); }
   };
+
+  // ══ AGENTS TAB LOGIC ══════════════════════════════════════════════════════
+  let agentFilter = 'pending';
+  let agentEventSource = null;
+
+  window.switchAgentFilter = function(which) {
+    agentFilter = which;
+    ['pending','active','revoked','audit'].forEach(f => {
+      const b = document.getElementById('ag-filter-' + f);
+      if (b) b.style.fontWeight = (f === which ? '700' : '500');
+    });
+    document.getElementById('agents-list').style.display = (which === 'audit') ? 'none' : '';
+    document.getElementById('agents-audit').style.display = (which === 'audit') ? '' : 'none';
+    refreshAgents();
+  };
+
+  async function refreshAgents() {
+    if (agentFilter === 'audit') { await loadAgentAudit(); return; }
+    const r = await fetch('/api/agents?status=' + encodeURIComponent(agentFilter));
+    const body = await r.json();
+    renderAgents(body.grants || []);
+    // Also update the counts on the filter buttons.
+    for (const s of ['pending','active','revoked']) {
+      const rr = await fetch('/api/agents?status=' + s);
+      const bb = await rr.json();
+      const el = document.getElementById('ag-count-' + s);
+      if (el) el.textContent = '(' + (bb.grants ? bb.grants.length : 0) + ')';
+    }
+    updatePendingBadge();
+  }
+
+  async function updatePendingBadge() {
+    const r = await fetch('/api/agents?status=pending');
+    const b = await r.json();
+    const n = (b.grants || []).length;
+    const badge = document.getElementById('agents-pending-badge');
+    if (!badge) return;
+    if (n > 0) {
+      badge.textContent = String(n);
+      badge.style.display = '';
+    } else {
+      badge.style.display = 'none';
+    }
+  }
+
+  function renderAgents(grants) {
+    const list = document.getElementById('agents-list');
+    if (!grants.length) {
+      list.innerHTML = '<div class="hint" style="text-align:center;padding:30px">No grants in this view.</div>';
+      return;
+    }
+    const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+    list.innerHTML = grants.map(g => {
+      const badge = g.status === 'pending' ? '🔴 pending'
+                  : g.status === 'active'  ? '🟢 active'
+                  : g.status === 'revoked' ? '⚪ revoked'
+                  : g.status === 'expired' ? '🟡 expired' : g.status;
+      const lastCall = g.lastCallAt ? new Date(g.lastCallAt).toLocaleString() : 'never';
+      const expiry = g.conditions && g.conditions.expiresAt
+        ? 'expires ' + new Date(g.conditions.expiresAt).toLocaleString() : 'no expiry';
+      const buttons = g.status === 'pending'
+        ? '<button class="btn btn-primary" onclick="approveGrant(\'' + esc(g.clientId) + '\',\'read_only\')">Approve read-only</button>' +
+          '<button class="btn btn-primary" onclick="approveGrant(\'' + esc(g.clientId) + '\',\'supervised\')">Approve supervised</button>' +
+          '<button class="btn btn-ghost"   onclick="denyGrant(\''    + esc(g.clientId) + '\')">Deny</button>'
+        : g.status === 'active'
+        ? '<button class="btn btn-ghost"   onclick="revokeGrant(\''  + esc(g.clientId) + '\')">Revoke</button>'
+        : '';
+      return (
+        '<div class="card" style="padding:12px;border:1px solid #333;border-radius:8px">' +
+          '<div style="display:flex;justify-content:space-between;align-items:start;gap:12px">' +
+            '<div>' +
+              '<div style="font-weight:600">' + esc(g.clientName) + ' <span style="color:#888;font-size:12px">(' + esc(g.clientId) + ')</span></div>' +
+              '<div style="font-size:12px;color:#888;margin-top:4px">' +
+                badge + ' · preset ' + esc(g.preset) + ' · ' + esc(expiry) + ' · ' + g.totalCalls + ' calls · last ' + esc(lastCall) +
+              '</div>' +
+              (g.note ? '<div style="font-size:12px;color:#aaa;margin-top:4px;font-style:italic">' + esc(g.note) + '</div>' : '') +
+            '</div>' +
+            '<div style="display:flex;gap:6px;flex-wrap:wrap">' + buttons + '</div>' +
+          '</div>' +
+        '</div>'
+      );
+    }).join('');
+  }
+
+  async function loadAgentAudit() {
+    const r = await fetch('/api/agents/audit?limit=200');
+    const body = await r.json();
+    const rows = body.rows || [];
+    const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
+    const tbody = document.getElementById('agents-audit-body');
+    if (!rows.length) {
+      tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:30px;color:#888">No calls logged yet.</td></tr>';
+      return;
+    }
+    tbody.innerHTML = rows.slice().reverse().map(r => {
+      const d = new Date(r.ts);
+      const when = d.toLocaleString('en-US', { timeZone: 'America/New_York' });
+      const ok = r.ok ? '<span style="color:#10b981">ok</span>' : '<span style="color:#ef4444">blocked: ' + esc(r.blockedReason || '?') + '</span>';
+      return '<tr>' +
+        '<td style="padding:5px;border-bottom:1px solid #222">' + esc(when) + '</td>' +
+        '<td style="padding:5px;border-bottom:1px solid #222">' + esc(r.clientName || r.clientId) + '</td>' +
+        '<td style="padding:5px;border-bottom:1px solid #222"><code>' + esc(r.tool) + '</code></td>' +
+        '<td style="padding:5px;border-bottom:1px solid #222">' + ok + '</td>' +
+        '<td style="padding:5px;border-bottom:1px solid #222;text-align:right">' + esc(r.durMs) + '</td>' +
+      '</tr>';
+    }).join('');
+  }
+
+  window.approveGrant = async function(clientId, preset) {
+    const r = await fetch('/api/agents/' + encodeURIComponent(clientId) + '/approve', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': CSRF },
+      body: JSON.stringify({ preset })
+    });
+    if (!r.ok) { alert('Approve failed: ' + (await r.text())); return; }
+    refreshAgents();
+  };
+
+  window.denyGrant = async function(clientId) {
+    if (!confirm('Deny this agent? It will be unable to call any tools.')) return;
+    const r = await fetch('/api/agents/' + encodeURIComponent(clientId) + '/deny', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': CSRF },
+      body: '{}'
+    });
+    if (!r.ok) { alert('Deny failed: ' + (await r.text())); return; }
+    refreshAgents();
+  };
+
+  window.revokeGrant = async function(clientId) {
+    if (!confirm('Revoke this agent\u2019s access? Currently running tool calls finish; the next one will be denied.')) return;
+    const r = await fetch('/api/agents/' + encodeURIComponent(clientId) + '/revoke', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': CSRF }
+    });
+    if (!r.ok) { alert('Revoke failed: ' + (await r.text())); return; }
+    refreshAgents();
+  };
+
+  // SSE subscription — live-update the Agents tab and the nav badge.
+  function subscribeAgentEvents() {
+    if (agentEventSource) return;
+    try {
+      agentEventSource = new EventSource('/api/notifications');
+      agentEventSource.onerror = () => { /* swallow — browser auto-reconnects */ };
+      const refresh = () => { updatePendingBadge(); if (document.getElementById('agents').classList.contains('active')) refreshAgents(); };
+      for (const kind of ['grant-created','grant-approved','grant-denied','grant-revoked','grant-expired']) {
+        agentEventSource.addEventListener(kind, refresh);
+      }
+    } catch (e) { /* SSE unavailable — poll-on-tab-show still works */ }
+  }
+  subscribeAgentEvents();
+  updatePendingBadge();
 
   // ── Header status ─────────────────────────────────────────────────────────
   function updateHeaderStatus(ok) {
@@ -3565,7 +3758,34 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         return;
       }
 
-      // ══ AGENT GRANTS (A1 — no UI yet; curl / programmatic access) ══════════
+      // ══ AGENT NOTIFICATIONS — SSE stream for the Agents tab ═══════════════
+      if (method === "GET" && path === "/api/notifications") {
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+        res.setHeader("X-Accel-Buffering", "no"); // disable proxy buffering
+        res.write(`: connected\n\n`);
+        const unsub = agentNotifications.subscribe((ev) => {
+          try {
+            res.write(`event: ${ev.kind}\n`);
+            res.write(`id: ${ev.seq}\n`);
+            res.write(`data: ${JSON.stringify(ev.grant)}\n\n`);
+          } catch { /* client disconnected mid-write */ }
+        });
+        // Keep-alive comments every 25 s so proxies don't tear the stream down.
+        const heartbeat = setInterval(() => {
+          try { res.write(`: heartbeat\n\n`); } catch { /* ignore */ }
+        }, 25_000);
+        req.on("close", () => {
+          clearInterval(heartbeat);
+          unsub();
+          try { res.end(); } catch { /* ignore */ }
+        });
+        return; // don't fall through to response cleanup
+      }
+
+      // ══ AGENT GRANTS (REST API — consumed by the Agents tab UI) ═══════════
       if (path === "/api/agents" || path.startsWith("/api/agents/")) {
         const grants = getAgentGrantStore();
         const audit = getAgentAuditLog();


### PR DESCRIPTION
Closes #54 (phase A2 of 5). Puts a user-facing surface on top of the A1 grant system.

## What ships

- **SSE notifications** — \`/api/notifications\` pushes \`grant-created / -approved / -denied / -revoked / -expired\` events with the full grant JSON. 25-second heartbeat keeps long-lived connections alive behind proxies.
- **Agents tab** in the settings UI with Pending / Active / Revoked / Audit filter chips, per-grant cards with Approve / Deny / Revoke buttons, a 200-row audit table in ET, a header badge that lights up when grants are pending, and live EventSource subscription so the UI stays current without reload.
- **Tray integration** — tooltip and menu surface the pending / active counts; the tray subscribes to the notification bus and rebuilds on every change.

## Tests

- \`notifications.test.ts\` covers emit sequence, unsubscribe, multiple concurrent subscribers.
- 1414 tests total; coverage 94.7 / 91.5 / 95.2 / 96.1.

## Stacked on

#55 (A1 — grant store + gate + audit). Merges cleanly once #55 is in.