### PR TITLE
feat: multi-account registry (A4) — MVP

### DIFF
--- a/src/accounts/registry.test.ts
+++ b/src/accounts/registry.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for the account registry.
+ *
+ * The registry persists via saveConfig / loadConfig, both of which touch
+ * disk. We mock the fs module so tests run in memory without polluting
+ * the user's home directory.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ServerConfig } from "../config/schema.js";
+
+// Mock fs: one in-memory "disk" shared across the loader and the registry.
+let diskByPath = new Map<string, string>();
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => diskByPath.has(String(p))),
+    readFileSync: vi.fn((p: string) => {
+      const s = diskByPath.get(String(p));
+      if (s === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return s;
+    }),
+    writeFileSync: vi.fn((p: string, data: string | Buffer) => {
+      diskByPath.set(String(p), typeof data === "string" ? data : data.toString("utf-8"));
+    }),
+    renameSync: vi.fn((from: string, to: string) => {
+      const s = diskByPath.get(String(from));
+      if (s === undefined) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      diskByPath.delete(String(from));
+      diskByPath.set(String(to), s);
+    }),
+    appendFile: vi.fn((_path: string, _data: string, _enc: string, cb: () => void) => cb()),
+  };
+});
+
+vi.mock("../security/keychain.js", () => ({
+  isKeychainAvailable: vi.fn(() => false),
+  loadCredentials: vi.fn(),
+  saveCredentials: vi.fn(),
+  migrateFromConfig: vi.fn(),
+}));
+
+import {
+  readRegistry,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  setActiveAccount,
+  listStatuses,
+} from "./registry.js";
+import { defaultConfig } from "../config/loader.js";
+
+function seedConfig(cfg: Partial<ServerConfig>): void {
+  const base = defaultConfig();
+  const merged = { ...base, ...cfg };
+  const path = `${process.env.HOME || "/home/chuck"}/.pm-bridge-mcp.json`;
+  diskByPath.set(path, JSON.stringify(merged));
+}
+
+describe("accounts registry", () => {
+  beforeEach(() => { diskByPath = new Map(); });
+
+  it("migrates a legacy single-account config into an accounts array on first read", () => {
+    seedConfig({
+      connection: {
+        smtpHost: "localhost", smtpPort: 1025,
+        imapHost: "localhost", imapPort: 1143,
+        username: "me@example.com", password: "pw", smtpToken: "",
+        bridgeCertPath: "", debug: false,
+      },
+    });
+    const reg = readRegistry();
+    expect(reg.accounts).toHaveLength(1);
+    expect(reg.accounts[0].id).toBe("primary");
+    expect(reg.accounts[0].providerType).toBe("proton-bridge");
+    expect(reg.accounts[0].username).toBe("me@example.com");
+    expect(reg.activeAccountId).toBe("primary");
+  });
+
+  it("classifies non-localhost connections as generic imap", () => {
+    seedConfig({
+      connection: {
+        smtpHost: "smtp.fastmail.com", smtpPort: 587,
+        imapHost: "imap.fastmail.com", imapPort: 993,
+        username: "me@fastmail.com", password: "pw", smtpToken: "",
+        bridgeCertPath: "", debug: false,
+      },
+    });
+    expect(readRegistry().accounts[0].providerType).toBe("imap");
+  });
+
+  it("createAccount appends, writes back, and assigns a short id", () => {
+    seedConfig({}); // minimal — triggers legacy migration to one primary account
+    const created = createAccount({
+      name: "Work Fastmail", providerType: "imap",
+      smtpHost: "smtp.fastmail.com", smtpPort: 587,
+      imapHost: "imap.fastmail.com", imapPort: 993,
+      username: "u@example.com", password: "pw",
+    });
+    expect(created.id).toMatch(/^acct-[0-9a-f]{8}$/);
+    const reg = readRegistry();
+    expect(reg.accounts).toHaveLength(2);
+    expect(reg.accounts.map(a => a.id)).toContain(created.id);
+  });
+
+  it("updateAccount patches fields and preserves the id", () => {
+    seedConfig({});
+    const created = createAccount({
+      name: "Test", providerType: "imap",
+      smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1,
+      username: "u", password: "pw",
+    });
+    const patched = updateAccount(created.id, { name: "Renamed" });
+    expect(patched?.name).toBe("Renamed");
+    expect(patched?.id).toBe(created.id);
+  });
+
+  it("updateAccount returns null for an unknown id", () => {
+    seedConfig({});
+    expect(updateAccount("acct-missing", { name: "X" })).toBeNull();
+  });
+
+  it("deleteAccount refuses to drop the last remaining account", () => {
+    seedConfig({});
+    const reg = readRegistry();
+    expect(deleteAccount(reg.activeAccountId)).toBe(false);
+    expect(readRegistry().accounts).toHaveLength(1);
+  });
+
+  it("deleteAccount drops a non-active account and leaves the rest alone", () => {
+    seedConfig({});
+    const extra = createAccount({
+      name: "Extra", providerType: "imap",
+      smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1,
+      username: "u", password: "pw",
+    });
+    expect(deleteAccount(extra.id)).toBe(true);
+    expect(readRegistry().accounts.some(a => a.id === extra.id)).toBe(false);
+  });
+
+  it("deleteAccount reassigns the active id when the active account is dropped", () => {
+    seedConfig({});
+    const extra = createAccount({
+      name: "Extra", providerType: "imap",
+      smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1,
+      username: "u", password: "pw",
+    });
+    setActiveAccount(extra.id);
+    expect(readRegistry().activeAccountId).toBe(extra.id);
+    deleteAccount(extra.id);
+    const reg = readRegistry();
+    expect(reg.activeAccountId).not.toBe(extra.id);
+    expect(reg.accounts).toHaveLength(1);
+  });
+
+  it("setActiveAccount switches which account mirrors into connection", () => {
+    seedConfig({});
+    const other = createAccount({
+      name: "Other", providerType: "imap",
+      smtpHost: "smtp.other", smtpPort: 587, imapHost: "imap.other", imapPort: 993,
+      username: "other@x", password: "pw",
+    });
+    setActiveAccount(other.id);
+    // Loading config should now show the mirrored settings.
+    const path = `${process.env.HOME || "/home/chuck"}/.pm-bridge-mcp.json`;
+    const cfg = JSON.parse(diskByPath.get(path) ?? "{}") as ServerConfig;
+    expect(cfg.connection.smtpHost).toBe("smtp.other");
+    expect(cfg.activeAccountId).toBe(other.id);
+  });
+
+  it("setActiveAccount returns null for an unknown id", () => {
+    seedConfig({});
+    expect(setActiveAccount("acct-bogus")).toBeNull();
+  });
+
+  it("listStatuses exposes the isActive flag and last-check metadata", () => {
+    seedConfig({});
+    const extra = createAccount({
+      name: "B", providerType: "imap",
+      smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1,
+      username: "u", password: "pw",
+    });
+    setActiveAccount(extra.id);
+    const statuses = listStatuses();
+    expect(statuses).toHaveLength(2);
+    const active = statuses.find(s => s.isActive);
+    expect(active?.id).toBe(extra.id);
+  });
+});

--- a/src/accounts/registry.ts
+++ b/src/accounts/registry.ts
@@ -1,0 +1,143 @@
+/**
+ * Account registry — CRUD + active-selection over the AccountSpec array.
+ *
+ * Persistence piggybacks on the main config file (ServerConfig.accounts and
+ * ServerConfig.activeAccountId). Writes go through the existing saveConfig
+ * atomic-rename path. Migration from a pre-accounts config is lazy: when
+ * the registry is first loaded and the accounts array is empty, the
+ * top-level connection fields are lifted into a "primary" account so the
+ * existing single-account behavior is preserved byte-for-byte.
+ */
+
+import { randomBytes } from "crypto";
+import type { ServerConfig } from "../config/schema.js";
+import { loadConfig, saveConfig, defaultConfig } from "../config/loader.js";
+import type { AccountSpec, AccountRegistry, AccountStatus } from "./types.js";
+
+export function shortId(): string {
+  return `acct-${randomBytes(4).toString("hex")}`;
+}
+
+/**
+ * Build a sanitized AccountSpec from the legacy top-level connection fields
+ * on a ServerConfig. Used for the one-time migration when a user with a
+ * pre-accounts config first opens the new UI.
+ */
+function specFromLegacy(cfg: ServerConfig): AccountSpec {
+  const c = cfg.connection;
+  const isBridge =
+    (c.smtpHost === "localhost" || c.smtpHost === "127.0.0.1")
+    && (c.imapHost === "localhost" || c.imapHost === "127.0.0.1");
+  return {
+    id: "primary",
+    name: isBridge ? "Proton Mail (Bridge)" : (c.username || "Primary account"),
+    providerType: isBridge ? "proton-bridge" : "imap",
+    smtpHost: c.smtpHost, smtpPort: c.smtpPort,
+    imapHost: c.imapHost, imapPort: c.imapPort,
+    username: c.username, password: c.password,
+    smtpToken: c.smtpToken || undefined,
+    bridgeCertPath: c.bridgeCertPath || undefined,
+    allowInsecureBridge: c.allowInsecureBridge,
+    tlsMode: c.tlsMode,
+    autoStartBridge: c.autoStartBridge,
+    bridgePath: c.bridgePath || undefined,
+  };
+}
+
+export function readRegistry(): AccountRegistry {
+  const cfg = loadConfig() ?? defaultConfig();
+  if (cfg.accounts && cfg.accounts.length > 0) {
+    const activeId = cfg.activeAccountId
+      && cfg.accounts.some(a => a.id === cfg.activeAccountId)
+      ? cfg.activeAccountId
+      : cfg.accounts[0].id;
+    return { accounts: cfg.accounts, activeAccountId: activeId };
+  }
+  // Legacy migration path — lift the singleton connection into an account.
+  const primary = specFromLegacy(cfg);
+  return { accounts: [primary], activeAccountId: primary.id };
+}
+
+/** Persist the registry into the server config file. */
+export function writeRegistry(reg: AccountRegistry): void {
+  const cfg = loadConfig() ?? defaultConfig();
+  cfg.accounts = reg.accounts;
+  cfg.activeAccountId = reg.activeAccountId;
+  // Mirror the *active* account's connection fields back into the
+  // legacy top-level shape so the existing service bootstrap still
+  // finds them at startup. This is how switching account without
+  // refactoring every consumer can work.
+  const active = reg.accounts.find(a => a.id === reg.activeAccountId) ?? reg.accounts[0];
+  if (active) {
+    cfg.connection = {
+      ...cfg.connection,
+      smtpHost: active.smtpHost, smtpPort: active.smtpPort,
+      imapHost: active.imapHost, imapPort: active.imapPort,
+      username: active.username, password: active.password,
+      smtpToken: active.smtpToken ?? "",
+      bridgeCertPath: active.bridgeCertPath ?? "",
+      allowInsecureBridge: active.allowInsecureBridge,
+      tlsMode: active.tlsMode,
+      autoStartBridge: active.autoStartBridge,
+      bridgePath: active.bridgePath,
+    };
+  }
+  saveConfig(cfg);
+}
+
+export function listStatuses(): AccountStatus[] {
+  const reg = readRegistry();
+  return reg.accounts.map(a => ({
+    id: a.id,
+    name: a.name,
+    providerType: a.providerType,
+    isActive: a.id === reg.activeAccountId,
+    lastCheckedAt: a.lastCheckedAt,
+    lastCheckResult: a.lastCheckResult,
+  }));
+}
+
+export function createAccount(spec: Omit<AccountSpec, "id">): AccountSpec {
+  const reg = readRegistry();
+  const account: AccountSpec = { ...spec, id: shortId() };
+  reg.accounts.push(account);
+  writeRegistry(reg);
+  return account;
+}
+
+/** Patch fields on an existing account. Unknown IDs return null. */
+export function updateAccount(id: string, patch: Partial<AccountSpec>): AccountSpec | null {
+  const reg = readRegistry();
+  const idx = reg.accounts.findIndex(a => a.id === id);
+  if (idx < 0) return null;
+  const merged = { ...reg.accounts[idx], ...patch, id };
+  reg.accounts[idx] = merged;
+  writeRegistry(reg);
+  return merged;
+}
+
+export function deleteAccount(id: string): boolean {
+  const reg = readRegistry();
+  if (reg.accounts.length <= 1) {
+    // Refuse to delete the last account — leaves the server without
+    // anywhere to connect.
+    return false;
+  }
+  const before = reg.accounts.length;
+  reg.accounts = reg.accounts.filter(a => a.id !== id);
+  if (reg.accounts.length === before) return false;
+  if (reg.activeAccountId === id) {
+    reg.activeAccountId = reg.accounts[0].id;
+  }
+  writeRegistry(reg);
+  return true;
+}
+
+export function setActiveAccount(id: string): AccountSpec | null {
+  const reg = readRegistry();
+  const match = reg.accounts.find(a => a.id === id);
+  if (!match) return null;
+  reg.activeAccountId = id;
+  writeRegistry(reg);
+  return match;
+}

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Multi-account data model.
+ *
+ * Each AccountSpec is a self-contained mail-server definition: provider
+ * type, IMAP/SMTP host+port, credentials, optional TLS cert. The overall
+ * server picks one "active" account to wire into the singleton IMAP/SMTP
+ * services. Switching the active account currently requires a server
+ * restart — a full service-layer refactor that lets a single running
+ * process speak to multiple accounts concurrently is tracked as future
+ * work (would let tools take an optional `account_id` argument).
+ *
+ * The shape is deliberately similar to the existing top-level
+ * ConnectionSettings so migration is mechanical.
+ */
+
+export type AccountProviderType = "proton-bridge" | "imap";
+
+export interface AccountSpec {
+  /** Stable ID, user-editable. Used in notifications and audit rows. */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** What kind of mail server this points at. Controls UI hints + defaults. */
+  providerType: AccountProviderType;
+  smtpHost: string;
+  smtpPort: number;
+  imapHost: string;
+  imapPort: number;
+  username: string;
+  /** Stored in the config file (mode 0600) or keychain when available. */
+  password: string;
+  /** Optional direct-SMTP submission token (Proton paid-plan feature). */
+  smtpToken?: string;
+  /** Path to a pinned TLS certificate (required for Bridge; generally unused for public IMAP). */
+  bridgeCertPath?: string;
+  /** Legacy opt-out to allow insecure-TLS connections. Default false. */
+  allowInsecureBridge?: boolean;
+  /** Which TLS mode to use on the SMTP side. */
+  tlsMode?: "starttls" | "ssl";
+  /** For Bridge accounts only: auto-start the binary if not reachable. */
+  autoStartBridge?: boolean;
+  /** For Bridge accounts only: override the binary path. */
+  bridgePath?: string;
+  /** ISO-8601 timestamp of the last successful connection test. */
+  lastCheckedAt?: string;
+  /** Last connection-test result ("ok" | error message). */
+  lastCheckResult?: string;
+}
+
+export interface AccountRegistry {
+  /** 0+ accounts. The primary/default is picked by `activeAccountId`. */
+  accounts: AccountSpec[];
+  /** Which account drives the singleton IMAP/SMTP services. */
+  activeAccountId: string;
+}
+
+/** Runtime-visible status (not persisted). */
+export interface AccountStatus {
+  id: string;
+  name: string;
+  providerType: AccountProviderType;
+  isActive: boolean;
+  lastCheckedAt?: string;
+  lastCheckResult?: string;
+}

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -389,7 +389,7 @@ describe("loadConfig", () => {
     const cfg = loadConfig();
     expect(cfg!.connection.allowInsecureBridge).toBe(true);
     // Loaded config is migrated to the current schema version
-    expect(cfg!.configVersion).toBe(2);
+    expect(cfg!.configVersion).toBe(3);
   });
 
   it("does NOT grandfather v1 configs that already set allowInsecureBridge explicitly", () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -234,6 +234,8 @@ export function loadConfig(): ServerConfig | null {
       // set the field.
       requireDestructiveConfirm: parsed.requireDestructiveConfirm !== false,
       tosAcknowledged: parsed.tosAcknowledged,
+      accounts: Array.isArray(parsed.accounts) ? parsed.accounts : undefined,
+      activeAccountId: typeof parsed.activeAccountId === "string" ? parsed.activeAccountId : undefined,
     };
     tags.found = true;
     return result;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -79,8 +79,8 @@ describe("TOOL_CATEGORIES", () => {
 });
 
 describe("CONFIG_VERSION", () => {
-  it("is 2", () => {
-    expect(CONFIG_VERSION).toBe(2);
+  it("is 3", () => {
+    expect(CONFIG_VERSION).toBe(3);
   });
 });
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -244,8 +244,38 @@ export const DEFAULT_RESPONSE_LIMITS: ResponseLimits = {
  *        silently disabled when no cert was configured).
  *   v2 → 2026-04 hardening — allowInsecureBridge is required to keep the legacy
  *        behavior. v1 configs are grandfathered in the loader with a warning.
+ *   v3 → 2026-04 multi-account — adds accounts[] + activeAccountId. Legacy
+ *        configs auto-migrate: the top-level connection fields are promoted
+ *        into a "primary" account on first read and mirrored back on each
+ *        save so single-account consumers keep working during the transition.
  */
-export const CONFIG_VERSION = 2;
+export const CONFIG_VERSION = 3;
+
+/** Shape-only declaration for schema.ts — see src/accounts/types.ts AccountSpec. */
+export interface AccountSpecShape {
+  id: string;
+  name: string;
+  providerType: "proton-bridge" | "imap";
+  smtpHost: string;
+  smtpPort: number;
+  imapHost: string;
+  imapPort: number;
+  username: string;
+  password: string;
+  smtpToken?: string;
+  bridgeCertPath?: string;
+  allowInsecureBridge?: boolean;
+  tlsMode?: "starttls" | "ssl";
+  autoStartBridge?: boolean;
+  bridgePath?: string;
+  lastCheckedAt?: string;
+  lastCheckResult?: string;
+}
+
+// The schema module stays dependency-free; AccountSpec is defined alongside
+// the registry in src/accounts/types.ts and is structurally compatible with
+// what we persist. We type it as `unknown[]` here to avoid a circular
+// import; the accounts registry validates the shape on read.
 
 export interface ServerConfig {
   configVersion: number;
@@ -257,6 +287,16 @@ export interface ServerConfig {
   responseLimits?: ResponseLimits;
   /** Port the settings UI server listens on (default 8765). */
   settingsPort?: number;
+  /**
+   * Multi-account registry. When present, the active account's connection
+   * fields are mirrored back into `connection` on save so the singleton
+   * IMAP/SMTP services continue to read from the familiar location while
+   * the UI manages the list. Shape matches src/accounts/types.ts
+   * AccountSpec; validated on read.
+   */
+  accounts?: AccountSpecShape[];
+  /** Which entry in `accounts` drives the singleton IMAP/SMTP services. */
+  activeAccountId?: string;
   /**
    * Require an explicit { confirmed: true } argument on destructive tool calls.
    * Default true. Intended to keep the workflow user-initiated (per Proton

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -67,6 +67,14 @@ import {
 import { getLogFilePath } from "../utils/logger.js";
 import { getAgentGrantStore, getAgentAuditLog } from "../agents/registry.js";
 import { notifications as agentNotifications } from "../agents/notifications.js";
+import {
+  readRegistry,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  setActiveAccount,
+} from "../accounts/registry.js";
+import type { AccountSpecShape } from "../config/schema.js";
 
 // ─── TCP connectivity test ─────────────────────────────────────────────────────
 
@@ -3996,6 +4004,84 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         }
 
         json(res, 404, { error: "Unknown agent endpoint." });
+        return;
+      }
+
+      // ══ ACCOUNTS (A4 — CRUD + active-account switch) ══════════════════════
+      if (path === "/api/accounts" || path.startsWith("/api/accounts/")) {
+        // GET /api/accounts — list (sanitized, no passwords)
+        if (method === "GET" && path === "/api/accounts") {
+          const reg = readRegistry();
+          const sanitized = reg.accounts.map(a => ({ ...a, password: a.password ? "••••••••" : "" }));
+          json(res, 200, { accounts: sanitized, activeAccountId: reg.activeAccountId });
+          return;
+        }
+
+        // POST /api/accounts — create
+        if (method === "POST" && path === "/api/accounts") {
+          if (!requireCsrf(req, res)) return;
+          let body: Record<string, unknown>;
+          try { body = JSON.parse(await readBodySafe(req)) as Record<string, unknown>; }
+          catch { json(res, 400, { error: "Body must be JSON." }); return; }
+          if (typeof body.name !== "string" || !body.name) { json(res, 400, { error: "name is required" }); return; }
+          if (body.providerType !== "proton-bridge" && body.providerType !== "imap") {
+            json(res, 400, { error: "providerType must be 'proton-bridge' or 'imap'" }); return;
+          }
+          const created = createAccount({
+            name: body.name,
+            providerType: body.providerType,
+            smtpHost: String(body.smtpHost ?? ""),
+            smtpPort: Number(body.smtpPort ?? 0),
+            imapHost: String(body.imapHost ?? ""),
+            imapPort: Number(body.imapPort ?? 0),
+            username: String(body.username ?? ""),
+            password: String(body.password ?? ""),
+            smtpToken: typeof body.smtpToken === "string" ? body.smtpToken : undefined,
+            bridgeCertPath: typeof body.bridgeCertPath === "string" ? body.bridgeCertPath : undefined,
+            allowInsecureBridge: typeof body.allowInsecureBridge === "boolean" ? body.allowInsecureBridge : undefined,
+            tlsMode: body.tlsMode === "ssl" || body.tlsMode === "starttls" ? body.tlsMode : undefined,
+            autoStartBridge: typeof body.autoStartBridge === "boolean" ? body.autoStartBridge : undefined,
+            bridgePath: typeof body.bridgePath === "string" ? body.bridgePath : undefined,
+          });
+          json(res, 201, { account: { ...created, password: created.password ? "••••••••" : "" } });
+          return;
+        }
+
+        // PATCH /api/accounts/:id
+        const patchMatch = /^\/api\/accounts\/([A-Za-z0-9_\-]+)$/.exec(path);
+        if (method === "PATCH" && patchMatch) {
+          if (!requireCsrf(req, res)) return;
+          let body: Record<string, unknown>;
+          try { body = JSON.parse(await readBodySafe(req)) as Record<string, unknown>; }
+          catch { json(res, 400, { error: "Body must be JSON." }); return; }
+          // Strip placeholder passwords — only overwrite when a real value arrives.
+          if (body.password === "" || body.password === "••••••••") delete body.password;
+          const updated = updateAccount(patchMatch[1], body as Partial<AccountSpecShape>);
+          if (!updated) { json(res, 404, { error: "Account not found." }); return; }
+          json(res, 200, { account: { ...updated, password: updated.password ? "••••••••" : "" } });
+          return;
+        }
+
+        // DELETE /api/accounts/:id
+        if (method === "DELETE" && patchMatch) {
+          if (!requireCsrf(req, res)) return;
+          const ok = deleteAccount(patchMatch[1]);
+          if (!ok) { json(res, 400, { error: "Cannot delete — unknown account id or last remaining account." }); return; }
+          json(res, 200, { ok: true });
+          return;
+        }
+
+        // POST /api/accounts/:id/activate
+        const activateMatch = /^\/api\/accounts\/([A-Za-z0-9_\-]+)\/activate$/.exec(path);
+        if (method === "POST" && activateMatch) {
+          if (!requireCsrf(req, res)) return;
+          const set = setActiveAccount(activateMatch[1]);
+          if (!set) { json(res, 404, { error: "Account not found." }); return; }
+          json(res, 200, { account: { ...set, password: set.password ? "••••••••" : "" }, restartRequired: true });
+          return;
+        }
+
+        json(res, 404, { error: "Unknown account endpoint." });
         return;
       }
 


### PR DESCRIPTION
Closes #54 (phase A4 of 5). Adds the data model + REST API for running pm-bridge-mcp against multiple mail providers. This is the MVP — concurrent per-tool account routing and service hot-swap are future work.

## What ships

- **\`src/accounts/\`** — AccountSpec types + CRUD registry. Legacy single-account configs auto-migrate on first read (top-level connection fields lift into a \"primary\" account).
- **Schema** — \`CONFIG_VERSION\` 2 → 3, adds \`accounts?\` + \`activeAccountId?\`. \`loadConfig\` now preserves both on round-trip (previously stripped → silently dropped every new account on the next save).
- **Settings REST API** — GET / POST / PATCH / DELETE / activate endpoints, CSRF-gated, password placeholders stripped on update.

## Switching behavior

Switching the active account mirrors its connection fields back into the legacy top-level \`connection\` object — the singleton IMAP/SMTP services read from there, so **the switch requires a restart**. The API response includes \`{ restartRequired: true }\`. Hot-swap (re-initializing services in place, or plumbing account_id through the tool dispatcher) is a natural next PR.

## Tests

1425 passing across 34 files. New \`registry.test.ts\` covers legacy migration, CRUD, active-switch, and the refuses-to-drop-last-account guard.

## Stacked on

#57 (A3 modal). Merges cleanly once the chain lands.