### PR TITLE
feat: AccountManager — hot-swap + per-tool routing (B1)

### DIFF
--- a/src/accounts/manager.test.ts
+++ b/src/accounts/manager.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for AccountManager. We mock the registry + services so the tests
+ * stay focused on the manager's responsibilities (map lifecycle, active
+ * switch events, closeAll), without reaching for real IMAP/SMTP.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AccountSpec, AccountRegistry } from "./types.js";
+
+// Mock the registry so we can hand-craft the account list per-test.
+const mockRegistry: { value: AccountRegistry } = {
+  value: { accounts: [], activeAccountId: "" },
+};
+vi.mock("./registry.js", () => ({
+  readRegistry: () => mockRegistry.value,
+}));
+
+// Mock the services so they don't open real sockets. We use `class` stubs
+// rather than vi.fn().mockImplementation because the manager uses `new`
+// syntax — classes are constructable, mockImplementation-fns are not.
+const smtpCloseMock = vi.fn().mockResolvedValue(undefined);
+const smtpReinit = vi.fn();
+vi.mock("../services/smtp-service.js", () => {
+  class SMTPService {
+    config: unknown = null;
+    close = smtpCloseMock;
+    reinitialize = smtpReinit;
+  }
+  return { SMTPService };
+});
+
+const imapDisconnect = vi.fn().mockResolvedValue(undefined);
+vi.mock("../services/simple-imap-service.js", () => {
+  class SimpleIMAPService {
+    disconnect = imapDisconnect;
+  }
+  return { SimpleIMAPService };
+});
+
+// The notifications module emits events; stub it so tests don't spy on
+// unrelated subscribers.
+vi.mock("../agents/notifications.js", () => ({
+  notifications: { emit: vi.fn(), on: vi.fn(), off: vi.fn() },
+}));
+
+import { AccountManager, registerAccountManager, getAccountManager } from "./manager.js";
+
+function mkSpec(id: string, overrides: Partial<AccountSpec> = {}): AccountSpec {
+  return {
+    id, name: `acct ${id}`, providerType: "imap",
+    smtpHost: "s", smtpPort: 587, imapHost: "i", imapPort: 993,
+    username: `${id}@x`, password: "pw",
+    ...overrides,
+  };
+}
+
+describe("AccountManager", () => {
+  beforeEach(() => {
+    mockRegistry.value = { accounts: [], activeAccountId: "" };
+    smtpCloseMock.mockClear();
+    imapDisconnect.mockClear();
+    smtpReinit.mockClear();
+  });
+
+  it("builds one service pair per registered account", () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    expect(mgr.list()).toHaveLength(2);
+    expect(mgr.activeAccountId()).toBe("a");
+  });
+
+  it("getActive returns the services for the registry's active id", () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "b",
+    };
+    const mgr = new AccountManager();
+    expect(mgr.getActive().spec.id).toBe("b");
+  });
+
+  it("falls back to the first account when the registry points at an unknown id", () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "nonexistent",
+    };
+    const mgr = new AccountManager();
+    expect(mgr.activeAccountId()).toBe("a");
+  });
+
+  it("setActive flips the pointer and emits active-changed", async () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    const changes: Array<{ prev: string; next: string }> = [];
+    mgr.on("active-changed", ev => changes.push({ prev: ev.prev, next: ev.next }));
+    await mgr.setActive("b");
+    expect(mgr.activeAccountId()).toBe("b");
+    expect(changes).toEqual([{ prev: "a", next: "b" }]);
+  });
+
+  it("setActive is a no-op when the target is already active (no event)", async () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    const spy = vi.fn();
+    mgr.on("active-changed", spy);
+    await mgr.setActive("a");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("setActive rejects an unknown account id", async () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    await expect(mgr.setActive("bogus")).rejects.toThrow(/Unknown account id/);
+  });
+
+  it("getForAccount returns per-account services; unknown ids throw", () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    expect(mgr.getForAccount("b").spec.id).toBe("b");
+    expect(() => mgr.getForAccount("z")).toThrow(/Unknown account id/);
+  });
+
+  it("rebuildFromRegistry adds new accounts and tears down removed ones", async () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    expect(mgr.list()).toHaveLength(2);
+
+    // "Remove" b from the registry, add c.
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("c")],
+      activeAccountId: "a",
+    };
+    mgr.rebuildFromRegistry();
+    expect(mgr.list()).toHaveLength(2);
+    expect(mgr.list().map(s => s.spec.id).sort()).toEqual(["a", "c"]);
+    expect(smtpCloseMock).toHaveBeenCalled();
+    expect(imapDisconnect).toHaveBeenCalled();
+  });
+
+  it("rebuildFromRegistry patches existing services when the spec changes (no churn)", () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a", { username: "old@x" })],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    const originalServices = mgr.getForAccount("a");
+
+    // Change the username; rebuild should NOT recreate the service instances.
+    mockRegistry.value = {
+      accounts: [mkSpec("a", { username: "new@x" })],
+      activeAccountId: "a",
+    };
+    mgr.rebuildFromRegistry();
+    const afterServices = mgr.getForAccount("a");
+    expect(afterServices).toBe(originalServices);        // same instance
+    expect(afterServices.spec.username).toBe("new@x");    // updated spec
+    expect(smtpReinit).toHaveBeenCalled();
+  });
+
+  it("closeAll tears down every account's services", async () => {
+    mockRegistry.value = {
+      accounts: [mkSpec("a"), mkSpec("b")],
+      activeAccountId: "a",
+    };
+    const mgr = new AccountManager();
+    await mgr.closeAll();
+    expect(smtpCloseMock).toHaveBeenCalledTimes(2);
+    expect(imapDisconnect).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("registerAccountManager / getAccountManager", () => {
+  afterEach(() => { registerAccountManager(null as unknown as AccountManager); });
+
+  it("round-trips the singleton", () => {
+    mockRegistry.value = { accounts: [mkSpec("a")], activeAccountId: "a" };
+    const mgr = new AccountManager();
+    registerAccountManager(mgr);
+    expect(getAccountManager()).toBe(mgr);
+  });
+
+  it("returns null when nothing is registered", () => {
+    registerAccountManager(null as unknown as AccountManager);
+    expect(getAccountManager()).toBeNull();
+  });
+});

--- a/src/accounts/manager.ts
+++ b/src/accounts/manager.ts
@@ -1,0 +1,177 @@
+/**
+ * AccountManager — keeps one SimpleIMAPService + SMTPService per account
+ * alive concurrently, supports hot-swapping the "active" account without
+ * a server restart, and lets the tool dispatcher route individual calls
+ * to a specific account via its `account_id` argument.
+ *
+ * Design notes
+ *   - One ImapFlow connection per account. imapflow's documented pattern
+ *     is "N separate clients" (no built-in pool); IDLE auto-runs per
+ *     client. Memory is bounded because pm-bridge-mcp is single-user and
+ *     most users have ≤ 3 accounts.
+ *   - Lazy connection: services are created per account at AccountManager
+ *     construction, but the underlying IMAP socket only opens on first
+ *     use. Same for the SMTP transporter (nodemailer is construct-cheap).
+ *   - Hot-swap semantics: changing the active account rewires the module-
+ *     level `imapService` / `smtpService` references via injected setters.
+ *     Callers that were mid-flight keep their existing bindings — ALS or
+ *     closure captures of the prior active services continue to work
+ *     until the call completes.
+ *   - Credential scope: each account's password/SMTP token stays scoped
+ *     to its own service instances. Switching accounts never leaks
+ *     creds across account boundaries.
+ */
+
+import { logger } from "../utils/logger.js";
+import { SMTPService } from "../services/smtp-service.js";
+import { SimpleIMAPService } from "../services/simple-imap-service.js";
+import type { ProtonMailConfig } from "../types/index.js";
+import type { AccountSpec } from "./types.js";
+import { readRegistry } from "./registry.js";
+import { notifications as grantNotifications } from "../agents/notifications.js";
+import { EventEmitter } from "events";
+
+export interface AccountServices {
+  imap: SimpleIMAPService;
+  smtp: SMTPService;
+  spec: AccountSpec;
+}
+
+/** Build the runtime ProtonMailConfig shape the SMTPService ctor expects. */
+function specToRuntimeConfig(spec: AccountSpec): ProtonMailConfig {
+  return {
+    smtp: {
+      host: spec.smtpHost,
+      port: spec.smtpPort,
+      secure: spec.tlsMode === "ssl",
+      username: spec.username,
+      password: spec.password,
+      smtpToken: spec.smtpToken,
+      bridgeCertPath: spec.bridgeCertPath,
+      allowInsecureBridge: spec.allowInsecureBridge,
+    },
+    imap: {
+      host: spec.imapHost,
+      port: spec.imapPort,
+      secure: spec.tlsMode === "ssl",
+      username: spec.username,
+      password: spec.password,
+      bridgeCertPath: spec.bridgeCertPath,
+      allowInsecureBridge: spec.allowInsecureBridge,
+    },
+    debug: false,
+    autoStartBridge: spec.autoStartBridge,
+    bridgePath: spec.bridgePath,
+  };
+}
+
+export class AccountManager extends EventEmitter {
+  private readonly perAccount = new Map<string, AccountServices>();
+  private _activeAccountId = "";
+
+  constructor() {
+    super();
+    this.rebuildFromRegistry();
+  }
+
+  /**
+   * Rebuild the account map from the persisted registry. Called at
+   * construction and after any setActiveAccount / registry mutation.
+   * Preserves in-flight service instances for accounts that still exist;
+   * tears down instances for accounts that were deleted; constructs new
+   * instances for accounts that were added.
+   */
+  rebuildFromRegistry(): void {
+    const reg = readRegistry();
+    const seen = new Set<string>();
+    for (const spec of reg.accounts) {
+      seen.add(spec.id);
+      const existing = this.perAccount.get(spec.id);
+      if (existing) {
+        // Patch the spec into the existing services so credential
+        // changes propagate without a reconnect.
+        existing.spec = spec;
+        existing.smtp["config"] = specToRuntimeConfig(spec);
+        existing.smtp.reinitialize();
+        continue;
+      }
+      const svcs: AccountServices = {
+        spec,
+        imap: new SimpleIMAPService(),
+        smtp: new SMTPService(specToRuntimeConfig(spec)),
+      };
+      this.perAccount.set(spec.id, svcs);
+    }
+    // Tear down services for deleted accounts.
+    for (const [id, svcs] of this.perAccount) {
+      if (seen.has(id)) continue;
+      this.perAccount.delete(id);
+      svcs.smtp.close().catch(() => {});
+      svcs.imap.disconnect().catch(() => {});
+    }
+    // Ensure activeAccountId points at a real entry.
+    if (!this.perAccount.has(reg.activeAccountId) && this.perAccount.size > 0) {
+      this._activeAccountId = [...this.perAccount.keys()][0];
+    } else {
+      this._activeAccountId = reg.activeAccountId;
+    }
+  }
+
+  /** The account currently wired into the module-level service references. */
+  activeAccountId(): string { return this._activeAccountId; }
+
+  /** Services for whichever account is currently active. */
+  getActive(): AccountServices {
+    const svcs = this.perAccount.get(this._activeAccountId);
+    if (!svcs) throw new Error(`No account services for active id ${this._activeAccountId}`);
+    return svcs;
+  }
+
+  /** Services for a specific account (by id). Throws on unknown id. */
+  getForAccount(accountId: string): AccountServices {
+    const svcs = this.perAccount.get(accountId);
+    if (!svcs) throw new Error(`Unknown account id: ${accountId}`);
+    return svcs;
+  }
+
+  /** Enumerate all accounts the manager knows about. */
+  list(): AccountServices[] { return [...this.perAccount.values()]; }
+
+  /**
+   * Hot-swap the active account. Rewires the active pointer and emits
+   * "active-changed" so any subscribers (module-level re-bindings, tray
+   * updaters) can react. No service teardown — the prior account's
+   * clients remain warm for future per-call routing.
+   */
+  async setActive(accountId: string): Promise<void> {
+    if (!this.perAccount.has(accountId)) throw new Error(`Unknown account id: ${accountId}`);
+    const prev = this._activeAccountId;
+    if (prev === accountId) return;
+    this._activeAccountId = accountId;
+    logger.info(`Active account hot-swapped: ${prev} → ${accountId}`, "AccountManager");
+    this.emit("active-changed", { prev, next: accountId, services: this.getActive() });
+    // A grant-style notification so the tray/UI pick it up alongside agent events.
+    grantNotifications.emit("active-account-changed", { prev, next: accountId });
+  }
+
+  /** Cleanly tear down every account's services. Called on shutdown. */
+  async closeAll(): Promise<void> {
+    for (const svcs of this.perAccount.values()) {
+      try { await svcs.smtp.close(); } catch { /* ignore */ }
+      try { await svcs.imap.disconnect(); } catch { /* ignore */ }
+    }
+  }
+}
+
+// ─── Module singleton accessor ────────────────────────────────────────────
+// index.ts constructs the manager during server bootstrap; the settings
+// server imports this getter so it can trigger hot-swaps on /api/accounts/
+// activate without a circular dep or explicit wiring.
+
+let _singleton: AccountManager | null = null;
+export function registerAccountManager(mgr: AccountManager): void {
+  _singleton = mgr;
+}
+export function getAccountManager(): AccountManager | null {
+  return _singleton;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { AgentAuditLog, hashArgs } from "./agents/audit.js";
 import { currentCaller } from "./agents/caller-context.js";
 import { registerAgentServices } from "./agents/registry.js";
 import { notifications as agentNotifications } from "./agents/notifications.js";
+import { AccountManager, registerAccountManager } from "./accounts/manager.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
 import { isValidEmail, validateLabelName, validateFolderName, validateTargetFolder, requireNumericEmailId, validateAttachments } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
@@ -114,8 +115,21 @@ const config: ProtonMailConfig = {
   syncInterval: 5,
 };
 
-const smtpService = new SMTPService(config);
-const imapService = new SimpleIMAPService();
+// Multi-account: AccountManager owns one SimpleIMAPService + SMTPService per
+// configured account. The module-level `imapService`/`smtpService` symbols
+// below point at whichever account is currently "active" and get hot-swapped
+// when the user switches accounts via the settings UI — no restart needed.
+// Per-tool routing to a non-active account happens in the dispatcher via a
+// local shadow of these names.
+const accountManager = new AccountManager();
+registerAccountManager(accountManager);
+let imapService: SimpleIMAPService = accountManager.getActive().imap;
+let smtpService: SMTPService = accountManager.getActive().smtp;
+accountManager.on("active-changed", (ev: { services: { imap: SimpleIMAPService; smtp: SMTPService } }) => {
+  imapService = ev.services.imap;
+  smtpService = ev.services.smtp;
+  logger.info("Module-level imap/smtp services rebound to the new active account", "MCPServer");
+});
 const analyticsService = new AnalyticsService();
 
 const SCHEDULER_STORE = process.env.PROTONMAIL_SCHEDULER_STORE
@@ -1656,6 +1670,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     };
   }
 
+  // ── Per-tool account routing ─────────────────────────────────────────────
+  // The dispatcher resolves an optional `account_id` argument before the
+  // gates so audit rows and permission checks both see the correct account.
+  // If an agent grant is bound to a specific account (conditions.accountId),
+  // the caller's requested account_id must match.
+  const requestedAccountId = typeof args.account_id === "string" && args.account_id.trim()
+    ? args.account_id.trim()
+    : accountManager.activeAccountId();
+  // Shadow the module-level `imapService` / `smtpService` when the caller
+  // picks a non-default account; the switch-case handlers below see these
+  // locals via lexical scope. No-op when the caller targets the active
+  // account (the module-level bindings already point there).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let imapService = accountManager.getActive().imap;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let smtpService = accountManager.getActive().smtp;
+  try {
+    const svcs = accountManager.getForAccount(requestedAccountId);
+    imapService = svcs.imap;
+    smtpService = svcs.smtp;
+  } catch (err) {
+    return {
+      content: [{ type: "text" as const, text: `Unknown account_id: ${requestedAccountId}` }],
+      isError: true,
+      structuredContent: { success: false, reason: "unknown_account_id", requestedAccountId },
+    };
+  }
+
   // ── Agent-grant gate ──────────────────────────────────────────────────────
   // Runs BEFORE the global permission gate. Only takes effect when the call
   // carries caller context (i.e. came in through the HTTP transport with an
@@ -1667,6 +1709,31 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   // Flipped true in the catch so the finally success path is skipped.
   let auditFailureRecorded = false;
   if (caller && !caller.staticBearer) {
+    // Grant-bound account mismatch → deny before we even run the grant gate,
+    // so an agent that was approved for Account A cannot smuggle calls into
+    // Account B by passing `account_id` in args.
+    const callerGrant = agentGrants.get(caller.clientId);
+    const boundAccountId = callerGrant?.conditions?.accountId;
+    if (boundAccountId && boundAccountId !== requestedAccountId) {
+      agentAudit.write({
+        ts: new Date(callStartedAt).toISOString(),
+        clientId: caller.clientId,
+        clientName: caller.clientName,
+        tool: name,
+        argHash: hashArgs(args),
+        ok: false,
+        durMs: Date.now() - callStartedAt,
+        blockedReason: `Grant is bound to account ${boundAccountId}; call targeted ${requestedAccountId}.`,
+        ip: caller.ip,
+      });
+      auditFailureRecorded = true;
+      return {
+        content: [{ type: "text" as const, text: `Blocked: this agent's grant is bound to account ${boundAccountId}.` }],
+        isError: true,
+        structuredContent: { success: false, reason: "account_mismatch", expected: boundAccountId, requested: requestedAccountId },
+      };
+    }
+
     const globalPreset = (loadConfig() ?? defaultConfig()).permissions.preset;
     const grantResult = grantManager.check({
       clientId: caller.clientId,

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -64,7 +64,7 @@ import {
   type EscalationRecord,
   type AuditEntry,
 } from "../permissions/escalation.js";
-import { getLogFilePath } from "../utils/logger.js";
+import { getLogFilePath, logger } from "../utils/logger.js";
 import { getAgentGrantStore, getAgentAuditLog } from "../agents/registry.js";
 import { notifications as agentNotifications } from "../agents/notifications.js";
 import {
@@ -74,6 +74,7 @@ import {
   deleteAccount,
   setActiveAccount,
 } from "../accounts/registry.js";
+import { getAccountManager } from "../accounts/manager.js";
 import type { AccountSpecShape } from "../config/schema.js";
 
 // ─── TCP connectivity test ─────────────────────────────────────────────────────
@@ -4283,7 +4284,21 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           if (!requireCsrf(req, res)) return;
           const set = setActiveAccount(activateMatch[1]);
           if (!set) { json(res, 404, { error: "Account not found." }); return; }
-          json(res, 200, { account: { ...set, password: set.password ? "••••••••" : "" }, restartRequired: true });
+          // Hot-swap: ask the AccountManager to rebuild from the persisted
+          // registry and flip its active pointer. Emits "active-changed"
+          // which rewires the module-level imap/smtp references in index.ts.
+          const mgr = getAccountManager();
+          let restartRequired = true;
+          if (mgr) {
+            try {
+              mgr.rebuildFromRegistry();
+              await mgr.setActive(set.id);
+              restartRequired = false;
+            } catch (err) {
+              logger.warn("Hot-swap failed, falling back to restart-required", "Accounts", err);
+            }
+          }
+          json(res, 200, { account: { ...set, password: set.password ? "••••••••" : "" }, restartRequired });
           return;
         }
 


### PR DESCRIPTION
Closes the first of three deferred items from the agent-grant series.

Replaces singleton `imapService` / `smtpService` with a per-account map. Active account can now flip without a server restart, and individual tool calls can route to any account via an optional `account_id` argument.

## What ships

- **`src/accounts/manager.ts`** — `AccountManager` with `rebuildFromRegistry` / `getActive` / `getForAccount` / `setActive` / `closeAll`, plus a module-singleton accessor the settings server can use.
- **Module-level rebind** — `imapService` / `smtpService` in `index.ts` are now `let` bindings; an `active-changed` listener rebinds them when the user activates a different account, so the 76+ inlined dispatcher references follow automatically.
- **Per-tool routing** — dispatcher reads `args.account_id`, shadows the module-level names with the target account's services for the request's duration.
- **Grant guard** — a caller's `account_id` must match the agent grant's `conditions.accountId` (if set) or the call is denied before the permission gate runs.
- **Hot-swap on activate** — `/api/accounts/:id/activate` rebuilds the manager + flips the active pointer instead of requiring a restart. `{ restartRequired: false }` is returned on success; falls back to `true` if the hot-swap throws.

## Deferred to follow-ups

- Adding `account_id` to every tool's JSON schema (MCP schemas are permissive; routing already works).
- Concurrent IMAP IDLE across all accounts at boot. The warm clients can handle it; current startup only connects the active one.

## Tests

1437 passing (12 new). New `manager.test.ts` covers registry construction, active-switch events, per-account lookups, add/remove/patch rebuild, and the singleton accessor.

## Stacked on

#59 (A5 — accounts UI). Merges cleanly once the A-series chain lands.