### PR TITLE
chore(deps): resolve transitive vulns via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "protonmail-agentic-mcp",
-  "version": "2.0.4",
+  "name": "pm-bridge-mcp",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "protonmail-agentic-mcp",
-      "version": "2.0.4",
+      "name": "pm-bridge-mcp",
+      "version": "2.1.0",
       "license": "MIT",
       "os": [
         "darwin",
@@ -20,8 +20,8 @@
         "nodemailer": "~8.0.2"
       },
       "bin": {
-        "protonmail-agentic-mcp": "dist/index.js",
-        "protonmail-agentic-mcp-settings": "dist/settings-main.js"
+        "pm-bridge-mcp": "dist/index.js",
+        "pm-bridge-mcp-settings": "dist/settings-main.js"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1724,9 +1724,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
-      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2546,9 +2546,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,10 @@
     "package.json"
   ],
   "overrides": {
-    "fast-xml-parser": ">=5.5.6"
+    "fast-xml-parser": ">=5.5.6",
+    "hono": ">=4.12.14",
+    "@hono/node-server": ">=1.19.13",
+    "path-to-regexp": ">=8.4.2"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Three CVEs surfaced by `npm audit`, all transitive through `@modelcontextprotocol/sdk@1.29.0`:

| Package | Severity | Issue | Fixed version |
|---|---|---|---|
| `hono` <=4.12.13 | moderate | cookie name validation, IP matching, path traversal, JSX escaping (6 advisories) | >=4.12.14 |
| `@hono/node-server` <1.19.13 | moderate | serveStatic slash bypass | >=1.19.13 |
| `path-to-regexp` 8.0.0–8.3.0 | high | ReDoS via sequential optional groups / multiple wildcards | >=8.4.2 |

Upstream MCP SDK hasn't rolled a release that pulls in the patches yet, so pinning via `package.json` `overrides`. All bumps are patch-level within the same major — no API surface change.

## Test plan

- [x] `npm audit` reports `0 vulnerabilities`
- [x] 1328 tests pass (`npm test`)
- [x] `tsc` clean (build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)