### PR TITLE
docs: README refresh + CHANGELOG for v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,126 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] — 2026-04-18
+
+Adds multi-account support, per-agent permission grants, a remote HTTP
+transport with OAuth 2.1, local full-text search, and integrations with
+SimpleLogin and Proton Pass. The product is renamed from
+`protonmail-agentic-mcp` to `pm-bridge-mcp`. Tool count: 49 → 67.
+
+### Added
+
+- **Multi-account registry** (#63) — `accounts[]` + `activeAccountId` in
+  the config; `AccountManager` owns one `{imap, smtp, spec}` per account
+  and hot-swaps the module-level service symbols on `active-changed`
+  events (no restart). Per-tool routing via an `account_id` arg. Accounts
+  tab in the Settings UI. Legacy single-account configs auto-migrate to a
+  "primary" account.
+- **Per-agent permission grants** (#63) — per-caller gate with grants
+  that progress pending → active → revoked/expired. Conditions:
+  `expiresAt`, `folderAllowlist`, `ipPins`, `maxCallsPerHourByTool`,
+  `accountId`, `toolOverrides`. Append-only audit log (hashed args only,
+  never values; 10 MB rotation, 3 compressed generations). Approve / deny
+  / revoke and approve-with-conditions modal in the Agents tab.
+- **Notification channels** (#63) — `DesktopNotifier` (macOS `osascript`,
+  Linux `notify-send`, Windows `powershell.exe` toast; no dep).
+  `WebhookDispatcher` with CloudEvents 1.0 default, Slack/Discord
+  auto-detection, HMAC-signed `X-PMBridge-Signature-256`, 8-attempt
+  exponential backoff with ±20 % jitter. Triggered by a
+  `NotificationBroker` that emits grant-created/approved/denied/revoked/
+  expired events.
+- **HTTP transport with OAuth 2.1** (#53) — `StreamableHTTPServerTransport`
+  in remote mode. Either static bearer (`remoteBearerToken`) or the full
+  OAuth suite: `/oauth/register` (RFC 7591 DCR), `/oauth/authorize` (PKCE
+  S256 consent flow gated by admin password), `/oauth/token` (RFC 8707
+  resource indicator validation), `/oauth/revoke`,
+  `/.well-known/oauth-authorization-server` (RFC 8414),
+  `/.well-known/oauth-protected-resource` (RFC 9728). Per-caller
+  token-bucket rate limit (20 req/s sustained, 40 burst; 3× bucket for
+  authenticated). Stdio transport unchanged for Claude Desktop.
+- **Local FTS5 search index** (#52) — three tools (`fts_search`,
+  `fts_rebuild`, `fts_status`) backed by `better-sqlite3` (optional
+  native dep). BM25 ranking, FTS5 syntax (phrase, boolean, prefix, column
+  filters), snippet output. Graceful degradation when `better-sqlite3`
+  isn't installed — `fts_status` reports `available: false`, other tools
+  return `InvalidRequest`; mail tools unaffected.
+- **Proton Pass integration** (#51) — three tools: `pass_list`,
+  `pass_search` (both safe), `pass_get` (destructive, audit-logged).
+  Subprocess wrapper around `pass-cli` with a Personal Access Token.
+  Every `pass_get` call is appended to
+  `~/.pm-bridge-mcp-pass-audit.jsonl` (no arg values, no response
+  bodies).
+- **Reminder scheduler** (#50) — `remind_if_no_reply`,
+  `list_pending_reminders`, `cancel_reminder`, `check_reminders`. JSONL
+  persistence at `~/.pm-bridge-mcp-reminders.json`.
+- **Content tools** (#49) — `get_thread` (IMAP
+  `References`/`In-Reply-To` walk with a 200-message cap) and
+  `get_correspondence_profile` (volume, first/last interaction, average
+  response time for a single address).
+- **Progressive tool tiering** (#48) — three tiers (`core` / `extended`
+  / `complete`); `PM_BRIDGE_MCP_TIER` env var and `toolTier` config
+  field control how many tools appear in ListTools. Reduces context
+  bloat for agents that only need a subset.
+- **MCP elicitation for destructive tools** (#47) — destructive tool
+  calls trigger an elicitation request to the client before executing.
+  Older clients without elicitation fall back to the
+  `{ confirmed: true }` argument flow (preserves the pre-elicitation
+  behavior).
+- **SimpleLogin alias tools** (#46) — six tools for managing aliases on
+  Proton-owned SimpleLogin (optional; requires API key). `alias_delete`
+  is destructive.
+- **"Works best with…" companion MCP servers** (#45) — README section
+  listing complementary MCP servers that pair well with pm-bridge-mcp.
+
+### Changed
+
+- **Product rename** (#34) — `protonmail-agentic-mcp` → `pm-bridge-mcp`.
+  Config path prefers `~/.pm-bridge-mcp.json`, falls back to the legacy
+  `~/.protonmail-mcp.json`. npm binary and homepage URLs updated.
+- **Bridge TLS hardening** (#31) — production default now requires a
+  loaded Bridge TLS cert; localhost Bridge without a cert needs explicit
+  `allowInsecureBridge` opt-in (config field or
+  `PROTONMAIL_MCP_INSECURE_BRIDGE=1`). Bridge version floor bumped to
+  v3.22.0 (detected via IMAP ID).
+- **Compliance UX** (#33) — destructive-tool confirmation gate (on by
+  default; `requireDestructiveConfirm`) + ToS §2.10 acknowledgement
+  recorded on first launch.
+- **SMTP abuse-signal backoff** (#35) — exponential backoff (base 5 s,
+  cap 5 min, with jitter) when SMTP returns 421/450/454. Prevents
+  accidental hammering of Bridge after Proton rate-limits us.
+- **Build tooling** — TypeScript 5.9 → 6.0 (#13),
+  `moduleResolution: NodeNext` switch.
+
+### Fixed
+
+- **`chore(deps)`** (#62) — resolved three transitive CVEs from
+  `@modelcontextprotocol/sdk@1.29.0` via `package.json` `overrides`:
+  `hono >=4.12.14` (6 moderate advisories),
+  `@hono/node-server >=1.19.13` (moderate), `path-to-regexp >=8.4.2`
+  (high ReDoS).
+- **`TOOL_CATEGORY_TIER` gap** — the `aliases` category was missing from
+  the tier map after #46 and #48 interleaved on main, leaving alias
+  tools unreachable from `toolsForTier("complete")`. Fixed while
+  rebasing #49.
+
+### Dependency bumps (Dependabot)
+
+- `@modelcontextprotocol/sdk` 1.27.1 → 1.29.0 (#19)
+- `imapflow` 1.2.15 → 1.3.1 (#25)
+- `mailparser` 3.9.4 → 3.9.8 (#27)
+- `@types/nodemailer` 6.4.19 → 8.0.0
+- `@types/node` 25.5.0 → 25.6.0 (#26)
+- `vitest` 4.1.0 → 4.1.4 (#30)
+- `@vitest/coverage-v8` 4.1.0 → 4.1.4 (#28)
+
+### Coverage notes
+
+- Test count: 1,021 → **1,525** across 41 files.
+- Thresholds relaxed as new subsystems brought defensive error paths
+  that are hard to exercise without stubbing native deps: statements
+  95 → 94, branches 94 → 90, functions 94 → 93, lines 96 → 96.
+  Backfilling these is a follow-up.
+
 ## [2.0.4] — 2026-03-19
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
-[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.27+-green.svg)](https://github.com/modelcontextprotocol/sdk)
-[![Tests](https://img.shields.io/badge/tests-1%2C251%20passing-brightgreen.svg)](#development)
+[![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29+-green.svg)](https://github.com/modelcontextprotocol/sdk)
+[![Tests](https://img.shields.io/badge/tests-1%2C525%20passing-brightgreen.svg)](#development)
 
-**Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — with human-controlled permissions.**
+**Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — over stdio or remote HTTP — with human-controlled permissions.**
 
 ---
 
@@ -23,7 +23,7 @@ Proton's Terms of Service ([proton.me/legal/terms](https://proton.me/legal/terms
 This server is designed to keep access **user-initiated**, not autonomous:
 
 - Default permission preset is `read_only`. Sending, deletion, and folder mutation require explicit user opt-in via the settings UI.
-- Destructive tools (delete / move-to-trash / move-to-spam) require a per-call `{ confirmed: true }` argument so the user sees the intent in their MCP client and can cancel it.
+- Destructive tools (delete / move-to-trash / move-to-spam / `alias_delete` / `pass_get`) require explicit confirmation. With MCP elicitation-capable clients, the server prompts the user out-of-band before executing; non-elicitation clients must pass `{ confirmed: true }`.
 - Elevated permissions require out-of-band human approval (settings UI button or terminal), not an agent-only grant.
 - The settings UI shows a first-run ToS acknowledgement the user must click through before credentials are accepted.
 
@@ -35,23 +35,29 @@ You remain the operator of your Proton account. Running this server against your
 
 ProtonMail encrypts your email end-to-end, which means no third-party API can read it. [Proton Bridge](https://proton.me/mail/bridge) solves this by decrypting email locally. This MCP server connects to Bridge and gives Claude (or any MCP host) structured, permission-gated access to your inbox.
 
-Your emails are decrypted on your own machine by Proton Bridge. This server never stores email content — everything stays in memory and is cleared on restart. You control exactly what the AI can do through a preset permission system with human-gated escalation for anything sensitive.
+Your emails are decrypted on your own machine by Proton Bridge. This server never persists email content — everything stays in memory and is cleared on restart. You control exactly what the AI can do through a preset permission system with human-gated escalation for anything sensitive.
 
 ---
 
 ## Key Features
 
-- **51 tools** covering reading, search, analytics, sending, scheduling, drafts, folders, labels, bulk operations, and Bridge/server lifecycle control (49 permission-managed + 2 always-available escalation tools)
-- **5 permission presets** — read-only by default; write access requires explicit opt-in
-- **Human-gated escalation** — agents request elevated permissions, you approve via browser UI or terminal; the agent cannot approve its own requests
-- **Browser-based settings UI** at `localhost:8765` — auto-starts with the daemon; setup wizard, live connection test, per-tool toggles, escalation approval panel
-- **System tray icon** — always visible; toggle the settings UI on/off or quit from the tray without touching the terminal
-- **5 MCP prompts** — triage inbox, compose reply, daily briefing, find subscriptions, thread summary
-- **MCP Resources** — individual emails and folders addressable via `email://` and `folder://` URIs
-- **Scheduled email delivery** — queue emails for future sending, survives server restarts
-- **10-layer security model** — CSRF protection, origin validation, CRLF injection prevention, path traversal guards, rate limiting, audit log
-- **1,251 tests passing** — comprehensive unit coverage (96% line coverage, 95% branch coverage) including all security validation paths
-- **Zero `any` type annotations** in production TypeScript source
+- **67 tools** across 11 categories — reading, search, analytics, sending, drafts, scheduling, follow-up reminders, folder management, bulk actions, deletion, Bridge/server lifecycle, plus optional companion services (SimpleLogin aliases, Proton Pass, local FTS5 search). See [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS`, `TOOL_CATEGORIES`) for the canonical inventory.
+- **Two transports** — stdio (default, Claude Desktop) and HTTP (remote / self-host). HTTP supports a static bearer **and/or** OAuth 2.1 with PKCE-S256, RFC 7591 Dynamic Client Registration, RFC 8414 authorization-server metadata, and RFC 9728 protected-resource metadata. Per-caller token-bucket rate limiting on every endpoint.
+- **Progressive tool tiering** — `core` / `extended` / `complete` controls how many tools land in the client's `ListTools` response, so context isn't burned on tools you don't use. Configurable via `toolTier` or `PM_BRIDGE_MCP_TIER`.
+- **Destructive-tool confirmation** — uses MCP elicitation when the client supports it (Claude Desktop, Cline) so the user sees a prompt before any delete / trash / spam / `alias_delete` / `pass_get` runs. Falls back to a required `{ confirmed: true }` argument for clients without elicitation.
+- **5 permission presets** — read-only by default; write access requires explicit opt-in. Per-tool overrides and rate limits via the **Custom** preset.
+- **Human-gated escalation** — agents request elevated permissions, you approve via browser UI or terminal; the agent cannot approve its own requests.
+- **Browser-based settings UI** at `localhost:8765` — auto-starts with the daemon; setup wizard, live connection test, per-tool toggles, escalation approval panel, OAuth admin password.
+- **System tray icon** — always visible; toggle the settings UI on/off or quit from the tray without touching the terminal.
+- **5 MCP prompts** — triage inbox, compose reply, daily briefing, find subscriptions, thread summary.
+- **MCP Resources** — individual emails and folders addressable via `email://` and `folder://` URIs.
+- **Scheduled email delivery** — queue emails for future sending; survives server restarts. Plus `remind_if_no_reply` for outbound follow-ups gated on inbox replies.
+- **Optional companion services** — SimpleLogin alias management (6 tools, requires API key), Proton Pass via pass-cli (3 tools, requires PAT), local FTS5 full-text index (3 tools, requires `better-sqlite3`).
+- **TLS-strict by default** — refuses to connect to localhost Bridge without a pinned cert, requires Bridge ≥ `3.22.0`, exponential backoff on SMTP abuse-signal responses.
+- **Multi-account** — configure more than one Proton / IMAP account; hot-swap the active account from the Settings UI with no server restart. Tools accept an optional `account_id` argument to route a single call to a specific account. See [`src/accounts/`](src/accounts/).
+- **Per-agent grants** — each MCP client (identified by its OAuth `client_id`) is gated by its own approvable grant, with optional folder allowlists, IP pins, per-tool rate caps, expiry, and account binding. Separate from the global preset and the escalation flow. See [`src/agents/`](src/agents/).
+- **Live notifications** — desktop toasts (no extra deps) and outbound webhooks (CloudEvents / Slack / Discord, HMAC-signed, retried) fire on grant-state changes. See [`src/notifications/`](src/notifications/).
+- **1,525 tests passing** (Vitest); zero `any` type annotations in production source.
 
 ---
 
@@ -65,6 +71,7 @@ Ask Claude things like:
 "Move all order confirmations to my Shopping folder"
 "What's my average email response time this month?"
 "Schedule a follow-up email to alice@example.com for next Monday at 9am"
+"Remind me if there's no reply within 3 business days"
 ```
 
 With read-only permissions (the default), Claude can read, search, and analyse your inbox but cannot send, move, delete, or change anything.
@@ -77,9 +84,9 @@ With read-only permissions (the default), Claude can read, search, and analyse y
 |---|---|---|
 | **Node.js** | >= 20.0.0 | Check with `node --version` · [nodejs.org](https://nodejs.org) |
 | **npm** | >= 9.0.0 | Bundled with Node.js |
-| **Proton Bridge** | Latest | Must be running and signed in · [proton.me/mail/bridge](https://proton.me/mail/bridge) |
-| **ProtonMail account** | Any plan | Free accounts supported |
-| **Claude Desktop** | Latest | Or any MCP-compatible host · [claude.ai/download](https://claude.ai/download) |
+| **Proton Bridge** | >= 3.22.0 | Must be running and signed in · [proton.me/mail/bridge](https://proton.me/mail/bridge) |
+| **Proton Mail account** | **Paid plan** | Bridge requires a paid Proton plan (Mail Plus, Unlimited, etc.) |
+| **MCP client** | Latest | Claude Desktop, Cline, or any MCP-compatible host · [claude.ai/download](https://claude.ai/download) |
 
 Supported on macOS, Windows, and Linux.
 
@@ -113,6 +120,18 @@ npm install
 npm run build
 ```
 
+### Optional companions
+
+Install only if you plan to use the corresponding tool group:
+
+| Optional dep | Enables | Install |
+|---|---|---|
+| `better-sqlite3` | `fts_search` / `fts_rebuild` / `fts_status` (local FTS5 index) | `npm install better-sqlite3` |
+| `pass-cli` (Proton's Go CLI) | `pass_list` / `pass_search` / `pass_get` | See [`pass-cli`](https://github.com/ProtonMail/pass-cli); set a Pass PAT in the settings UI |
+| SimpleLogin API key | `alias_*` tools | Generate at [app.simplelogin.io](https://app.simplelogin.io/dashboard/api_key); paste in settings UI |
+
+Tools in unconfigured groups return a clean configuration error rather than failing silently.
+
 ---
 
 ## Setup Wizard
@@ -126,20 +145,20 @@ npx pm-bridge-mcp-settings
 
 The **6-step wizard** walks you through everything automatically:
 
-1. **Welcome** — overview and prerequisites checklist
+1. **Welcome** — overview, ToS acknowledgement, and prerequisites checklist
 2. **Bridge health check** — live TCP test to ports 1025 and 1143; blocks progress until Bridge is reachable
-3. **Credentials** — your ProtonMail address and Bridge password (found in Bridge app under Settings → IMAP/SMTP → Password — this is **not** your ProtonMail login password)
+3. **Credentials** — your Proton Mail address and Bridge password (Bridge app → Settings → IMAP/SMTP → Password — this is **not** your Proton login password)
 4. **Permission preset** — choose what the AI is allowed to do (see table below)
 5. **Review** — confirm your settings before saving
-6. **Done** — displays the exact JSON snippet to paste into your Claude Desktop config; optionally writes it for you automatically
+6. **Done** — displays the exact JSON snippet to paste into your MCP client config; optionally writes it for you automatically
 
-Settings are saved to `~/.protonmail-mcp.json` with mode `0600` (owner read/write only).
+Settings are saved to `~/.protonmail-mcp.json` with mode `0600` (owner read/write only). Bridge passwords, OAuth admin passwords, and Pass PATs prefer the OS keychain when available.
 
 ---
 
-## Claude Desktop Configuration
+## Claude Desktop Configuration (stdio)
 
-**Use the settings wizard to get the correct snippet for your machine.** The final step of the wizard (or the Status tab → MCP Config Snippet) generates and copies the exact JSON to use — the path to the installed package differs per machine and OS, so a static snippet here would be wrong.
+**Use the settings wizard to get the correct snippet for your machine.** The final step of the wizard (or the Status tab → MCP Config Snippet) generates and copies the exact JSON to use — the path to the installed package differs per machine and OS.
 
 The config file locations are:
 
@@ -160,11 +179,88 @@ The generated entry looks like this (your path will differ):
 }
 ```
 
-The wizard can also write this entry to your Claude Desktop config automatically — click **Write to Claude Desktop** on the Done step. Restart Claude Desktop after saving.
+The wizard can also write this entry to your client config automatically — click **Write to Claude Desktop** on the Done step. Restart the client after saving.
+
+---
+
+## Multi-Account
+
+More than one mail account can be configured in the same server — handy for juggling a personal Proton address, a work Proton address, and a generic IMAP account from a single MCP client.
+
+The config file grows two fields alongside the existing `connection` block:
+
+```json
+{
+  "accounts": [
+    { "id": "primary", "name": "Personal", "providerType": "proton-bridge",
+      "smtpHost": "127.0.0.1", "smtpPort": 1025,
+      "imapHost": "127.0.0.1", "imapPort": 1143,
+      "username": "me@proton.me", "password": "<bridge-pw>" },
+    { "id": "acct-7b1c", "name": "Work", "providerType": "imap", "...": "..." }
+  ],
+  "activeAccountId": "primary"
+}
+```
+
+- The **Accounts** tab in the settings UI handles add / edit / activate / delete. The server refuses to delete the last remaining account.
+- `AccountManager` keeps one `{ imap, smtp, spec }` triple per configured account. Saving a new active selection emits an `active-changed` event and the module-level service references hot-swap — no restart required.
+- Tools accept an optional `account_id` argument. When omitted, the call runs against `activeAccountId`; when present, the dispatcher routes to the named account. Agent grants can pin a client to a single `accountId` via `conditions`.
+- Legacy single-account configs are migrated lazily: the first load with `accounts: []` lifts the top-level `connection` fields into a `primary` account. No manual migration step.
+
+Canonical code: [`src/accounts/registry.ts`](src/accounts/registry.ts), [`src/accounts/manager.ts`](src/accounts/manager.ts), [`src/accounts/types.ts`](src/accounts/types.ts).
+
+---
+
+## Remote / HTTP Transport
+
+For headless boxes, phones, or sharing one Bridge across multiple devices, switch to HTTP transport. The same binary listens on a port instead of stdio.
+
+Enable it via the Setup tab → **Remote (HTTP) mode**, or by setting these in `~/.protonmail-mcp.json`:
+
+```json
+{
+  "connection": {
+    "remoteMode": true,
+    "remoteHost": "127.0.0.1",
+    "remotePort": 8788,
+    "remotePath": "/mcp",
+    "remoteBearerToken": "<long-random-string>",
+    "remoteTlsCertPath": "/path/to/cert.pem",
+    "remoteTlsKeyPath":  "/path/to/key.pem",
+    "remoteOauthEnabled": true,
+    "remoteOauthAdminPassword": "<consent-password>",
+    "remoteOauthIssuer": "https://mcp.example.com",
+    "remoteRateLimitPerSecond": 20,
+    "remoteRateLimitBurst": 40
+  }
+}
+```
+
+**Auth modes** (mix freely on the same listener):
+
+- **Static bearer** — programmatic clients send `Authorization: Bearer <token>`. Constant-time comparison.
+- **OAuth 2.1 + PKCE-S256** — MCP hosts self-register via `POST /oauth/register` (RFC 7591), discover endpoints via `GET /.well-known/oauth-authorization-server` (RFC 8414) and `GET /.well-known/oauth-protected-resource` (RFC 9728), then run a PKCE consent flow gated on the admin password. Refresh and revocation supported.
+
+**Rate limiting** — token-bucket per caller (per IP for unauthed paths, per token key for `/mcp`). A compromised token can't DoS Bridge.
+
+**TLS** — provide `remoteTlsCertPath` + `remoteTlsKeyPath` for HTTPS. Required for any non-loopback exposure.
+
+A static-bearer client config looks like:
+
+```json
+{
+  "mcpServers": {
+    "protonmail-remote": {
+      "url": "https://mcp.example.com/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
 
 ### Environment variables
 
-Configuration (credentials, SMTP/IMAP hosts, etc.) is stored in `~/.protonmail-mcp.json` and managed via the settings UI — not environment variables. The following env vars are available for advanced/optional overrides:
+Configuration is stored in `~/.protonmail-mcp.json` and managed via the settings UI — not environment variables. The following env vars are available for advanced/optional overrides:
 
 | Variable | Default | Description |
 |---|---|---|
@@ -173,116 +269,37 @@ Configuration (credentials, SMTP/IMAP hosts, etc.) is stored in `~/.protonmail-m
 | `PROTONMAIL_LOG_FILE` | `~/.protonmail-mcp.log` | Override log file path |
 | `PROTONMAIL_MCP_PENDING` | `~/.protonmail-mcp.pending.json` | Override pending escalations file path |
 | `PROTONMAIL_MCP_AUDIT` | `~/.protonmail-mcp.audit.jsonl` | Override escalation audit log path |
+| `PROTONMAIL_MCP_INSECURE_BRIDGE` | unset | Per-launch opt-in to localhost Bridge without a pinned cert |
+| `PM_BRIDGE_MCP_TIER` | `complete` | Tool-tier override: `core` / `extended` / `complete` |
 | `PORT` | `8765` | Override settings UI HTTP server port |
 
 ---
 
 ## Available Tools
 
-51 tools across 9 categories.
+**67 tools across 11 categories.** This README lists categories and counts; see [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS` and `TOOL_CATEGORIES`) for the canonical, machine-checkable inventory.
 
-### Reading — always available
+| Category | Tools | Default tier | Risk | Permission required |
+|---|---:|---|---|---|
+| Reading | 12 | `core` | safe | always available |
+| Sending | 4 | `core` | moderate | `supervised`, `send_only`, `full` |
+| Analytics | 4 | `core` | safe | always available |
+| System | 4 | `core` | safe | always available |
+| Drafts & Scheduling | 9 | `extended` | moderate | `supervised`, `send_only`, `full` |
+| Folder Management | 5 | `extended` | moderate | `supervised`, `full` |
+| Email Actions | 14 | `extended` | moderate | `supervised`, `full` |
+| SimpleLogin Aliases *(optional)* | 6 | `extended` | moderate | enabled when API key present |
+| Proton Pass *(optional)* | 3 | `extended` | moderate | enabled when PAT + `pass-cli` present |
+| Deletion | 3 | `complete` | destructive | `full` (capped at 5/hr in `supervised`) |
+| Bridge & Server Control | 3 | `complete` | destructive | mixed; `start_bridge` always available |
 
-| Tool | Description |
-|---|---|
-| `get_emails` | Fetch emails from any folder with cursor-based pagination |
-| `get_email_by_id` | Fetch a single email with full body and headers |
-| `search_emails` | Search by subject, sender, body, date range, read status, attachments; pass `folders: ["*"]` to search all folders |
-| `get_folders` | List all folders with message and unread counts |
-| `get_unread_count` | Fast per-folder unread count — call before `get_emails` to avoid unnecessary fetches |
-| `list_labels` | List all ProtonMail labels with message counts |
-| `get_emails_by_label` | Fetch emails from a specific label folder with cursor pagination |
-| `download_attachment` | Download attachment content as base64 (use the index from `get_email_by_id`) |
+Plus **2 always-available escalation tools** (`request_permission_escalation`, `check_escalation_status`) outside the category registry.
 
-### Analytics — always available
+### Notable tools worth calling out
 
-| Tool | Description |
-|---|---|
-| `get_email_stats` | Total, unread, sent, starred counts and cache status |
-| `get_email_analytics` | Full analytics: top senders, volume trends, response time stats |
-| `get_contacts` | Contact interaction frequency (received from / sent to) |
-| `get_volume_trends` | Email volume by day of week and hour of day |
-
-### System — always available
-
-| Tool | Description |
-|---|---|
-| `get_connection_status` | SMTP/IMAP health including live NOOP probe (`imap.healthy`), `insecureTls` flags, config path, and current preset |
-| `get_logs` | Recent server log entries for debugging |
-| `sync_emails` | Refresh the email cache from IMAP (configurable limit, default 100) |
-| `clear_cache` | Clear the in-memory email and analytics cache |
-
-### Sending — requires `supervised`, `send_only`, or `full`
-
-| Tool | Description |
-|---|---|
-| `send_email` | Send email with HTML/text body, attachments, CC, BCC, reply-to |
-| `send_test_email` | Send a test email to verify SMTP connectivity |
-| `reply_to_email` | Reply with correct `In-Reply-To` and `References` headers for proper threading |
-| `forward_email` | Forward an email to new recipients with an optional prepended message |
-
-### Drafts & Scheduling — requires `supervised`, `send_only`, or `full`
-
-| Tool | Description |
-|---|---|
-| `save_draft` | Save an email as a draft via IMAP APPEND to the Drafts folder |
-| `schedule_email` | Queue an email for delivery at a future time (ISO 8601, 60 s – 30 days out); survives server restarts |
-| `list_scheduled_emails` | List all MCP-scheduled emails with status and retry count |
-| `list_proton_scheduled` | List emails natively scheduled via the Proton Mail app (reads the "All Scheduled" IMAP folder) |
-| `cancel_scheduled_email` | Cancel a pending scheduled email before it sends |
-
-### Actions — requires `supervised` or `full`
-
-| Tool | Description |
-|---|---|
-| `mark_email_read` | Mark one email read or unread |
-| `star_email` | Star or unstar an email |
-| `move_email` | Move an email to any folder |
-| `archive_email` | Move an email to the Archive folder |
-| `move_to_trash` | Move an email to Trash |
-| `move_to_spam` | Move an email to Spam |
-| `move_to_folder` | Move an email to a custom folder (`Folders/<name>`) |
-| `move_to_label` | Apply a ProtonMail label to an email (`Labels/<name>`) |
-| `remove_label` | Remove a label and move the email back to INBOX (or a specified folder) |
-| `bulk_mark_read` | Mark up to 200 emails read/unread |
-| `bulk_star` | Star/unstar up to 200 emails |
-| `bulk_move_emails` | Move up to 200 emails to a folder |
-| `bulk_move_to_label` | Apply a label to up to 200 emails |
-| `bulk_remove_label` | Remove a label from up to 200 emails |
-
-### Folders — requires `supervised` or `full`
-
-| Tool | Description |
-|---|---|
-| `sync_folders` | Refresh the folder list from IMAP |
-| `create_folder` | Create a new folder or label |
-| `rename_folder` | Rename an existing folder |
-| `delete_folder` | Delete a folder (must be empty first) |
-
-### Deletion — requires `full` (capped at 5/hr under `supervised`)
-
-| Tool | Description |
-|---|---|
-| `delete_email` | Permanently delete an email |
-| `bulk_delete_emails` | Permanently delete up to 200 emails |
-| `bulk_delete` | Alias for `bulk_delete_emails` |
-
-### Bridge & Server Control
-
-| Tool | Description | Permission |
-|---|---|---|
-| `start_bridge` | Launch Proton Mail Bridge if it is not running; waits up to 15 s for SMTP/IMAP ports to become reachable | Always available |
-| `shutdown_server` | Gracefully shut down the MCP server — terminates Bridge, disconnects IMAP/SMTP, scrubs credentials from memory | `supervised` or `full` (capped at 2/hr in supervised) |
-| `restart_server` | Terminate Bridge, shut down the current process, and spawn a fresh MCP server process; Bridge is re-launched automatically if `autoStartBridge` is enabled | `supervised` or `full` (capped at 2/hr in supervised) |
-
-> **Auto-start & watchdog:** If `autoStartBridge` is enabled in settings, the server launches Bridge automatically on startup and runs a background watchdog every 30 s that will attempt up to 3 restarts if Bridge becomes unreachable.
-
-### Escalation — always available
-
-| Tool | Description |
-|---|---|
-| `request_permission_escalation` | Ask the human to grant a higher permission preset temporarily |
-| `check_escalation_status` | Poll the status of a pending escalation challenge |
+- **Reading** includes `get_thread`, `get_correspondence_profile`, and the `fts_*` family (local SQLite FTS5 index — much faster than IMAP search for repeat queries).
+- **Drafts & Scheduling** includes `remind_if_no_reply` (queue an outbound, fire a follow-up reminder if no reply lands within N days), `list_pending_reminders`, `cancel_reminder`, `check_reminders`. JSONL persistence so reminders survive restarts.
+- **Bridge & Server Control** — if `autoStartBridge` is enabled, the server launches Bridge automatically on startup and runs a 30 s watchdog that attempts up to 3 restarts on outage. `shutdown_server` and `restart_server` are capped at 2/hr in `supervised`.
 
 ---
 
@@ -292,11 +309,11 @@ Pre-built prompt templates for common tasks:
 
 | Prompt | Description | Arguments |
 |---|---|---|
-| `triage_inbox` | Review unread emails, assess urgency, and suggest actions (reply / archive / delete / snooze) | `limit` (default 20), `focus` (sender or topic to prioritize) |
+| `triage_inbox` | Review unread emails, assess urgency, suggest actions | `limit` (default 20), `focus` |
 | `compose_reply` | Draft a contextual reply to an email thread | `emailId` (required), `intent` |
-| `daily_briefing` | Summarize today's inbox: unread count, key senders, action items, deadline mentions | — |
-| `find_subscriptions` | Identify mailing lists and newsletters, and offer to archive or unsubscribe | `folder` (default: INBOX) |
-| `thread_summary` | Fetch all messages in a thread and produce a concise summary with open action items | `emailId` (required) |
+| `daily_briefing` | Summarize today's inbox: unread, key senders, action items | — |
+| `find_subscriptions` | Identify mailing lists / newsletters; offer to archive or unsubscribe | `folder` (default: INBOX) |
+| `thread_summary` | Fetch all messages in a thread; produce a concise summary with open action items | `emailId` (required) |
 
 ---
 
@@ -305,12 +322,12 @@ Pre-built prompt templates for common tasks:
 | Preset | What's allowed | Best for |
 |---|---|---|
 | **Read-Only** *(default)* | Read, search, analytics, connection status, logs, Bridge start | Starting out; untrusted or new agents |
-| **Supervised** | All tools; deletion 5/hr, sending 20/hr, bulk actions 10/hr, server lifecycle 2/hr; read-heavy tools also rate-limited (`get_emails` 60/hr, `search_emails` 30/hr, `get_email_by_id` 200/hr) | Day-to-day agentic use |
-| **Send-Only** | Reading + sending + drafts + scheduling + `get_folders` + `get_connection_status` + `get_logs` + Bridge start; no deletion, no folder writes, no server lifecycle | Agents that only need to compose and send |
+| **Supervised** | All tools; deletion 5/hr, sending 20/hr, bulk actions 10/hr, server lifecycle 2/hr; read-heavy tools rate-limited (`get_emails` 60/hr, `search_emails` 30/hr, `get_email_by_id` 200/hr) | Day-to-day agentic use |
+| **Send-Only** | Reading + sending + drafts + scheduling + connection status + logs + Bridge start; no deletion, no folder writes, no server lifecycle | Agents that only need to compose and send |
 | **Full Access** | All tools, no rate limits | Trusted workflows where you review actions |
-| **Custom** | User-defined per-tool toggles and rate limits (set via the Permissions tab) | Advanced: fine-grained control beyond the 4 presets |
+| **Custom** | User-defined per-tool toggles and rate limits (set via the Permissions tab) | Fine-grained control beyond the 4 presets |
 
-Change the preset at any time from the **Permissions** tab in the settings UI.
+Change the preset at any time from the **Permissions** tab in the settings UI; changes take effect within 15 s without restart.
 
 ---
 
@@ -327,7 +344,8 @@ The escalation system lets an agent request broader permissions without permanen
 5. After 5 minutes, permissions revert automatically.
 
 **Security properties:**
-- The agent requests via MCP (unattended process); approval can only happen via browser or terminal — channels the agent cannot write to
+
+- The agent requests via MCP; approval can only happen via browser or terminal — channels the agent cannot write to
 - You must type `APPROVE` before the button activates — no accidental clicks
 - CSRF-protected: the approval API requires a session token embedded only in the rendered HTML page
 - Rate-limited: max 5 escalation requests per hour, max 1 pending at a time
@@ -338,9 +356,9 @@ The escalation system lets an agent request broader permissions without permanen
 
 ## Settings UI
 
-The settings UI starts automatically on `http://localhost:8765` whenever Claude Desktop runs the MCP server. A system tray icon (purple envelope) appears in your taskbar — right-click it to open the UI, disable it temporarily, or quit.
+The settings UI starts automatically on `http://localhost:8765` whenever your MCP client runs the server. A system tray icon (purple envelope) appears in your taskbar — right-click it to open the UI, disable it temporarily, or quit.
 
-To run the settings UI standalone (useful for initial setup before Claude Desktop is configured, or on headless/SSH systems):
+To run the settings UI standalone (useful for initial setup, headless / SSH systems, or a dedicated remote-mode host):
 
 ```bash
 npx pm-bridge-mcp-settings           # auto-detects display; opens browser if available
@@ -352,45 +370,86 @@ npx pm-bridge-mcp-settings --plain       # plain readline menus (no ANSI colors/
 npx pm-bridge-mcp-settings --no-open     # start server but don't auto-open browser
 ```
 
-The port can also be overridden with the `PORT` environment variable, or saved persistently via the settings UI itself.
+Tabs:
 
-Three tabs:
+- **Setup** — credentials, SMTP/IMAP hosts and ports, Bridge TLS certificate, remote/HTTP mode, OAuth admin password, SimpleLogin / Pass tokens, debug mode
+- **Permissions** — preset selector, per-tool enable/rate-limit toggles, tool-tier (`core` / `extended` / `complete`), destructive-confirm toggle
+- **Status** — server info, MCP config snippet, live connectivity check, escalation audit log, config reset
 
-- **Setup** — credentials, SMTP/IMAP hosts and ports, Bridge TLS certificate, debug mode
-- **Permissions** — preset selector and per-tool enable/rate-limit toggles
-- **Status** — server info, Claude Desktop config snippet, live connectivity check, escalation audit log, config reset
-
-Pending escalation requests appear as a full-page banner above the tabs — no separate tab needed. A **Logs** tab also appears automatically when debug mode is enabled.
-
-Changes take effect in the running MCP server within 15 seconds — no restart required.
+Pending escalation requests appear as a full-page banner above the tabs. A **Logs** tab appears automatically when debug mode is enabled. Changes propagate to the running MCP server within 15 s — no restart required.
 
 ---
 
 ## Security
 
-This server gives AI agents *controlled* access to sensitive email data. The security model has 10 layers:
+This server gives AI agents *controlled* access to sensitive email data. The security model has these layers:
 
 | Layer | Mechanism |
 |---|---|
 | Permission gate | Every tool call checked against `~/.protonmail-mcp.json` (refreshed every 15 s) |
-| Rate limiting | Per-tool sliding-window rate limits enforced in the MCP server process |
+| Tool tiering | `core` / `extended` / `complete` controls the `ListTools` surface — agents can't call what they can't see |
+| Rate limiting | Per-tool sliding-window limits in-process; per-caller token-bucket on the HTTP transport |
+| Destructive confirmation | MCP elicitation prompt (or required `{ confirmed: true }`) on delete / trash / spam / `alias_delete` / `pass_get` |
 | Escalation gate | Privilege increases require explicit human approval via a separate channel |
 | Audit log | Append-only log of all escalation events at `~/.protonmail-mcp.audit.jsonl` |
+| OAuth 2.1 + PKCE-S256 | Spec-compliant DCR + consent flow gated on admin password (HTTP transport) |
 | CSRF protection | All mutating settings API calls require a session token (timing-safe comparison) |
 | Origin validation | Settings server validates `Origin`/`Referer` headers; rejects unknown origins |
-| Input validation | All inputs validated: email addresses, folder names, attachment sizes, hostnames |
-| Injection prevention | CRLF stripped from all SMTP headers, subjects, filenames, and custom header values |
-| Config file isolation | Config written atomically at mode `0600`; preset and tool names validated on load |
-| Memory safety | Email cache capped at 500 entries and 50 MB; rate-limiter buckets capped at 10,000 keys |
+| Input validation | Email addresses, folder names, attachment sizes, hostnames, label names |
+| Injection prevention | CRLF stripped from all SMTP headers, subjects, filenames, custom headers |
+| TLS-strict Bridge | Refuses to connect to localhost Bridge without a pinned cert by default |
+| Bridge version floor | Warns when Bridge < `3.22.0` (FIDO2 + 50 MB import cap hardening) |
+| SMTP backoff | Exponential backoff on abuse-signal SMTP responses (4xx 421/450/451 throttle codes) |
+| Config file isolation | Mode `0600`; preset and tool names validated on load; config schema versioned |
+| Memory safety | Email cache capped at 500 entries / 50 MB; rate-limiter buckets capped at 10,000 keys |
+| Keychain storage | OS keychain preferred for Bridge password, OAuth admin password, Pass PAT |
 
 **What agents cannot do:**
 - Approve their own escalation requests
-- Bypass the permission gate (it runs in the MCP server process, not the agent)
+- Bypass the permission gate (it runs in the server process, not the agent)
 - Read or modify `~/.protonmail-mcp.json` directly (not an exposed tool)
 - Erase the audit log
 - Inject headers into outgoing email via crafted subjects, filenames, or custom headers
+- Execute destructive tools without surfacing the intent to the user
 
-**Credentials:** Stored in `~/.protonmail-mcp.json` with `0600` permissions. Never commit this file. The settings UI never displays or transmits your Bridge password.
+**Credentials:** Stored in `~/.protonmail-mcp.json` with `0600` permissions (or in the OS keychain). Never commit this file. The settings UI never displays or transmits high-value secrets after they are first saved.
+
+---
+
+## Agent Grants
+
+The global permission preset gates *what tools exist*; an **agent grant** gates *which MCP client gets to use them*. When an MCP host completes OAuth Dynamic Client Registration, pm-bridge-mcp creates a `pending` grant keyed by the new `client_id`. Nothing that client calls will succeed until you approve it.
+
+Grant lifecycle: `pending` → `active` → `revoked` | `expired`. Each grant carries:
+
+| Field | Purpose |
+|---|---|
+| `preset` | Effective preset for this agent; intersected with the global preset (grants can never widen the ceiling) |
+| `toolOverrides` | Per-tool allow/deny that trumps the preset, still bounded by the global config |
+| `conditions.expiresAt` | ISO-8601 auto-expiry; checked at call time |
+| `conditions.folderAllowlist` | Restrict which IMAP folders the agent may touch |
+| `conditions.ipPins` | Allowed remote IPs (OAuth/bearer path only) |
+| `conditions.maxCallsPerHourByTool` | Per-tool hourly rate cap |
+| `conditions.accountId` | Bind the agent to a single multi-account id |
+
+Approve, deny, revoke, and "approve-with-conditions" all live in the **Agents** tab of the settings UI. The tab streams live updates over SSE from `GET /api/notifications` — new pending grants surface without a reload.
+
+Every gated tool call writes one row to an append-only JSONL audit log at `~/.pm-bridge-mcp-agent-audit.jsonl` (mode `0600`). Rows carry a truncated sha256 `argHash` — **never argument values, never response bodies** — so "same call repeated" patterns are observable without creating a parallel on-disk copy of your email. The log rotates at 10 MB and keeps 3 gzipped generations.
+
+Caller identity propagates through the dispatcher via `AsyncLocalStorage` (see [`src/agents/caller-context.ts`](src/agents/caller-context.ts)); stdio callers (default Claude Desktop) have no context and bypass the grant gate as the local trusted caller.
+
+Canonical code: [`src/agents/grant-store.ts`](src/agents/grant-store.ts), [`grant-manager.ts`](src/agents/grant-manager.ts), [`audit.ts`](src/agents/audit.ts), [`caller-context.ts`](src/agents/caller-context.ts), [`notifications.ts`](src/agents/notifications.ts), [`registry.ts`](src/agents/registry.ts).
+
+---
+
+## Notification Channels
+
+Grant-state transitions (`grant-created` / `-approved` / `-denied` / `-revoked` / `-expired`) fan out through an in-process `NotificationBroker` to two optional channels:
+
+- **Desktop toasts** — platform-native, no extra dependency. macOS shells to `osascript`, Linux to `notify-send` (libnotify), Windows to `powershell.exe` driving the WinRT toast API. Fire-and-forget; missing tooling degrades to a debug log.
+- **Outbound webhooks** — `WebhookDispatcher` POSTs a JSON body to each configured endpoint. Format defaults to **CloudEvents 1.0**; URLs on `hooks.slack.com` auto-select the Slack shape and `discord.com` / `discordapp.com` auto-select the Discord shape (explicit `format: "raw"` is also available). When an endpoint has a secret configured, every body is HMAC-signed as `X-PMBridge-Signature-256: sha256=<hex>` (GitHub-webhook convention). Delivery retries up to 8 times with exponential backoff (1 / 2 / 4 / 8 / 16 / 32 / 64 / 128 s) plus ±20 % jitter; 4xx responses other than 408 and 429 stop retries immediately.
+
+Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), [`src/notifications/webhooks.ts`](src/notifications/webhooks.ts).
 
 ---
 
@@ -405,7 +464,7 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 
 ### "Authentication failed" or IMAP login error
 
-- Use the **Bridge password**, not your ProtonMail login password.
+- Use the **Bridge password**, not your Proton Mail login password.
 - Find it in the Bridge app: **Settings → IMAP/SMTP → Password** (a long random string).
 - If you recently reinstalled Bridge, it generates a new password — update it in the settings UI.
 
@@ -420,13 +479,24 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 - Export the Bridge TLS certificate: Bridge app → **Settings → Export TLS certificates**.
 - Set the path in the settings UI under **Setup → Bridge TLS Certificate**.
 
-> As of v2.1 the server refuses to connect to a localhost Bridge without a pinned TLS certificate — this matches Proton Bridge's own v3.21.2+ hardening. If you cannot provide a cert, set **Allow insecure Bridge connection** under Setup (or launch with `PROTONMAIL_MCP_INSECURE_BRIDGE=1`) to opt back into the legacy behavior. Configs that predate this change are grandfathered into the legacy mode with a startup warning until the opt-in is set explicitly.
+> The server refuses to connect to a localhost Bridge without a pinned TLS certificate — this matches Proton Bridge's own v3.21.2+ hardening. If you cannot provide a cert, set **Allow insecure Bridge connection** under Setup (or launch with `PROTONMAIL_MCP_INSECURE_BRIDGE=1`) to opt back into the legacy behavior. Configs that predate this change are grandfathered into the legacy mode with a startup warning until the opt-in is set explicitly.
 
 ### Bridge version warning on startup
 
-- The server issues an IMAP `ID` request after connect and warns when Bridge is older than **3.22.0** (the minimum supported). Upgrade from the Bridge app → **Check for updates** to pick up the v3.21.2 strict-TLS and v3.22 FIDO2 hardening.
+- The server issues an IMAP `ID` request after connect and warns when Bridge is older than **3.22.0** (the minimum supported). Upgrade from the Bridge app → **Check for updates**.
 
-### Claude Desktop doesn't show ProtonMail tools
+### Tool list looks short / missing tools
+
+- Check your **tool tier** under Permissions. `core` exposes ~24 tools; `extended` adds drafts, folders, actions, aliases, Pass; `complete` (default) exposes everything.
+- Optional companion tools (`alias_*`, `pass_*`, `fts_*`) only appear when their dependency / token is configured.
+
+### Remote / HTTP client returns 401
+
+- Verify the `Authorization: Bearer <token>` header matches `remoteBearerToken`.
+- For OAuth clients, check that `/oauth/register` succeeded and the access token has not been revoked or expired.
+- The `WWW-Authenticate` header on the 401 response carries the failure reason per RFC 6750.
+
+### Claude Desktop doesn't show pm-bridge-mcp tools
 
 - Confirm the `mcpServers` block is valid JSON (no trailing commas).
 - Fully quit and reopen Claude Desktop.
@@ -435,7 +505,7 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 
 ### Analytics show zero or empty data
 
-- Run `sync_emails` in Claude first to populate the cache.
+- Run `sync_emails` first to populate the cache.
 - Response time stats only appear when sent emails have `In-Reply-To` headers matching inbox messages.
 
 ---
@@ -449,7 +519,7 @@ npm install
 
 npm run build          # compile TypeScript to dist/
 npm run dev            # watch mode (recompiles on save)
-npm run test           # run test suite (Vitest, 1,198 tests)
+npm run test           # run test suite (Vitest, 1,525 tests)
 npm run test:coverage  # coverage report
 npm run lint           # TypeScript type check (tsc --noEmit)
 npm run settings       # start standalone settings UI (after build)
@@ -459,12 +529,12 @@ npm run settings       # start standalone settings UI (after build)
 
 ```
 src/
-  index.ts                    # Unified daemon: MCP server (51 tools, resources, prompts) + settings HTTP server + system tray
+  index.ts                    # Unified daemon: MCP server (67 tools, resources, prompts) + settings + tray
   settings-main.ts            # Standalone settings UI CLI (for headless/SSH environments)
   tray.ts                     # System tray icon (systray2)
   config/
-    schema.ts                 # Config types, tool names, category definitions
-    loader.ts                 # Config file load/save, preset builder
+    schema.ts                 # Tool registry, categories, tiers, destructive set, response limits
+    loader.ts                 # Config load/save, preset builder, keychain migration
   permissions/
     manager.ts                # Per-tool permission checks and rate limiting
     escalation.ts             # Human-gated escalation challenge system
@@ -472,18 +542,28 @@ src/
     keychain.ts               # OS keychain integration (@napi-rs/keyring)
     memory.ts                 # Credential wipe helpers
   services/
-    smtp-service.ts           # Email sending via Nodemailer
+    smtp-service.ts           # Email sending via Nodemailer (with abuse-signal backoff)
     simple-imap-service.ts    # Email reading via ImapFlow
     analytics-service.ts      # Email analytics computation
-    scheduler.ts              # Scheduled email delivery
+    scheduler.ts              # Scheduled email delivery (JSONL persistence)
+    reminder-service.ts       # remind_if_no_reply queue
+    fts-service.ts            # Local SQLite FTS5 index (optional better-sqlite3)
+    simplelogin-service.ts    # SimpleLogin alias API client
+    pass-service.ts           # Proton Pass via pass-cli subprocess
   settings/
     server.ts                 # Browser-based settings UI server
-    security.ts               # Rate limiting, CSRF, origin validation, TLS
+    security.ts               # CSRF, origin validation, TLS
     tui.ts                    # Terminal UI for settings
+  transports/
+    http.ts                   # HTTP transport (bearer + optional OAuth)
+    oauth-handlers.ts         # /.well-known + /oauth/* (RFC 7591/8414/9728)
+    oauth-store.ts            # Client / authorization-code / token store
+    rate-limit.ts             # Token-bucket per-caller limiter
   utils/
     helpers.ts                # ID generation, email validation, log sanitisation
     logger.ts                 # Structured log store
     tracer.ts                 # Lightweight request tracing
+    backoff.ts                # Exponential backoff helper
   types/
     index.ts                  # Shared TypeScript types
 ```
@@ -520,4 +600,4 @@ MIT — see [LICENSE](LICENSE)
 
 *Unofficial third-party server. Not affiliated with or endorsed by Proton AG.*
 
-[GitHub](https://github.com/chandshy/protonmail-agentic-mcp) · [npm](https://www.npmjs.com/package/protonmail-agentic-mcp) · [Issues](https://github.com/chandshy/protonmail-agentic-mcp/issues) · [Model Context Protocol](https://modelcontextprotocol.io)
+[GitHub](https://github.com/chandshy/protonmail-agentic-mcp) · [npm](https://www.npmjs.com/package/pm-bridge-mcp) · [Issues](https://github.com/chandshy/protonmail-agentic-mcp/issues) · [Model Context Protocol](https://modelcontextprotocol.io)


### PR DESCRIPTION
## Summary

- README gains three sections for subsystems that landed in #45–#63: Multi-Account, Agent Grants, Notification Channels. Tool count (67) and test count (1,525) updated everywhere they appeared.
- CHANGELOG gains a \`[2.1.0] — 2026-04-18\` entry grouping every PR merged since 2.0.4.

## Test plan

- [x] README renders correctly in GitHub preview (standard markdown, no plugins)
- [x] CHANGELOG dates are consistent with merge commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)