### PR TITLE
feat: draft_in_my_voice prompt + extract_action_items / extract_meeting tools

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 67 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(67);
+  it("has exactly 69 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(69);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -16,6 +16,7 @@ export const ALL_TOOLS = [
   "list_labels", "get_emails_by_label", "download_attachment",
   "get_thread", "get_correspondence_profile",
   "fts_search", "fts_rebuild", "fts_status",
+  "extract_action_items", "extract_meeting",
   // Folder management
   "get_folders", "sync_folders", "create_folder", "delete_folder", "rename_folder",
   // Email actions
@@ -75,6 +76,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
       "list_labels", "get_emails_by_label", "download_attachment",
       "get_thread", "get_correspondence_profile",
       "fts_search", "fts_rebuild", "fts_status",
+      "extract_action_items", "extract_meeting",
     ],
     risk: "safe",
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { SchedulerService } from "./services/scheduler.js";
 import { ReminderService } from "./services/reminder-service.js";
 import { PassService, PassCliUnavailableError } from "./services/pass-service.js";
 import { FtsIndexService, FtsUnavailableError, openFtsIndex, type FtsRecord } from "./services/fts-service.js";
+import { extractActionItems, parseIcs } from "./services/content-parser.js";
 import { AgentGrantStore } from "./agents/grant-store.js";
 import { GrantManager } from "./agents/grant-manager.js";
 import { AgentAuditLog, hashArgs } from "./agents/audit.js";
@@ -2071,6 +2072,71 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           },
         },
       },
+      {
+        name: "extract_action_items",
+        title: "Extract Action Items",
+        description:
+          "Scan a single email's body for action-item-looking lines (bullets with action verbs, TODO:/ACTION: markers, @mentions) and return a structured list with best-effort assignee and due-date fields. Heuristic — not a replacement for a real task extractor, but useful for quick triage.",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            email_id: { type: "string", description: "IMAP UID from get_emails / search_emails" },
+          },
+          required: ["email_id"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            action_items: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  text: { type: "string" },
+                  assignee: { type: "string" },
+                  due: { type: "string" },
+                },
+                required: ["text"],
+              },
+            },
+          },
+          required: ["action_items"],
+        },
+      },
+      {
+        name: "extract_meeting",
+        title: "Extract Meeting from ICS",
+        description:
+          "Parse an iCalendar (ICS) attachment or inline VCALENDAR block out of an email and return structured meeting details. Returns { meeting: null } when no ICS block is found. Supports RFC 5545 line folding and the common VEVENT properties (SUMMARY, DTSTART, DTEND, LOCATION, ORGANIZER, ATTENDEE, DESCRIPTION, RRULE).",
+        annotations: { readOnlyHint: true },
+        inputSchema: {
+          type: "object",
+          properties: {
+            email_id: { type: "string", description: "IMAP UID from get_emails / search_emails" },
+          },
+          required: ["email_id"],
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            meeting: {
+              type: ["object", "null"],
+              properties: {
+                summary: { type: "string" },
+                start: { type: "string" },
+                end: { type: "string" },
+                location: { type: "string" },
+                organizer: { type: "string" },
+                attendees: { type: "array", items: { type: "string" } },
+                description: { type: "string" },
+                rrule: { type: "string" },
+              },
+              required: ["summary", "start"],
+            },
+          },
+        },
+      },
 
       // ── Permission Escalation (always-available meta-tools) ────────────────
       {
@@ -3414,6 +3480,46 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
       }
 
+      case "extract_action_items": {
+        const aiEmailId = requireNumericEmailId(args.email_id, "email_id");
+        const email = await imapService.getEmailById(aiEmailId);
+        if (!email) {
+          return { content: [{ type: "text" as const, text: "Email not found" }], isError: true, structuredContent: { success: false, reason: "Email not found" } };
+        }
+        const action_items = extractActionItems(email.body || "");
+        return ok({ action_items });
+      }
+
+      case "extract_meeting": {
+        const emEmailId = requireNumericEmailId(args.email_id, "email_id");
+        const email = await imapService.getEmailById(emEmailId);
+        if (!email) {
+          return { content: [{ type: "text" as const, text: "Email not found" }], isError: true, structuredContent: { success: false, reason: "Email not found" } };
+        }
+        // 1. Prefer a dedicated ICS attachment (text/calendar or .ics filename).
+        let icsText: string | null = null;
+        for (const att of email.attachments ?? []) {
+          const ct = (att.contentType ?? "").toLowerCase();
+          const fn = (att.filename ?? "").toLowerCase();
+          const looksIcs = ct.startsWith("text/calendar")
+            || ct === "application/ics"
+            || fn.endsWith(".ics");
+          if (!looksIcs) continue;
+          if (Buffer.isBuffer(att.content)) {
+            icsText = att.content.toString("utf-8");
+          } else if (typeof att.content === "string") {
+            icsText = att.content;
+          }
+          if (icsText) break;
+        }
+        // 2. Fall back to scanning the body for an inline VCALENDAR block.
+        if (!icsText && email.body && /BEGIN:VCALENDAR/i.test(email.body)) {
+          icsText = email.body;
+        }
+        const meeting = icsText ? parseIcs(icsText) : null;
+        return ok({ meeting: meeting ?? null });
+      }
+
       // ── Folder Management ─────────────────────────────────────────────────────
 
       case "get_folders": {
@@ -4269,6 +4375,17 @@ server.setRequestHandler(ListPromptsRequestSchema, async () => ({
         { name: "emailId", description: "UID of any message in the thread", required: true },
       ],
     },
+    {
+      name: "draft_in_my_voice",
+      title: "Draft Email in My Voice",
+      description:
+        "Draft a new email to a specific recipient in the user's own voice, using a handful of their recent sent emails as tone samples. The LLM infers style (formality, greeting/sign-off habits, typical length) from the samples rather than guessing.",
+      arguments: [
+        { name: "recipient", description: "Email address to draft to", required: true },
+        { name: "intent", description: "What the email should say or accomplish", required: true },
+        { name: "sampleCount", description: "How many recent sent emails to include as tone samples (default 5, max 20)", required: false },
+      ],
+    },
   ],
 }));
 
@@ -4496,6 +4613,64 @@ Produce:
 - Key decisions or agreements made
 - Open questions or action items
 - Who needs to respond next (if applicable)`,
+            },
+          },
+        ],
+      };
+    }
+
+    case "draft_in_my_voice": {
+      // Recipient must look like an email address — sanitize then validate.
+      const rawRecipient = sanitizeText(args.recipient, 254);
+      if (!isValidEmail(rawRecipient)) {
+        throw new McpError(ErrorCode.InvalidParams, "recipient must be a valid email address.");
+      }
+      const recipient = rawRecipient;
+      // Intent flows into the prompt body verbatim — sanitize against prompt
+      // injection the same way compose_reply handles its intent arg.
+      const intent = sanitizeText(args.intent, 500);
+      if (!intent) {
+        throw new McpError(ErrorCode.InvalidParams, "intent must be a non-empty string.");
+      }
+      const rawCount = parseInt((args.sampleCount as string) || "5", 10);
+      const sampleCount = isNaN(rawCount) ? 5 : Math.min(Math.max(1, rawCount), 20);
+
+      let samples: Array<{ subject: string; bodyPreview: string }> = [];
+      try {
+        const sent = await imapService.getEmails("Sent", sampleCount);
+        samples = sent.map(e => ({
+          subject: e.subject || "(No Subject)",
+          // Use bodyPreview (~300 chars) — full bodies would blow up the prompt
+          // and would leak far more than needed to demonstrate tone.
+          bodyPreview: e.bodyPreview ?? truncateEmailBody(e.body, 400),
+        }));
+      } catch { /* Sent folder unreachable — prompt will still guide the model */ }
+
+      const samplesBlock = samples.length > 0
+        ? JSON.stringify(samples, null, 2)
+        : "[no sent emails loaded — tone will have to be inferred from context only]";
+
+      return {
+        description: "Draft an email in the user's voice",
+        messages: [
+          {
+            role: "user" as const,
+            content: {
+              type: "text" as const,
+              text: `Draft a new email to ${recipient}.
+
+Intent: ${intent}
+
+Study the following ${samples.length} recent emails the user has sent and match their voice — formality level, greeting and sign-off conventions, typical sentence length, and word choices. Do not copy phrasing wholesale; infer style and write a fresh message.
+
+Recent sent emails (tone samples):
+${samplesBlock}
+
+When drafting, produce:
+1. A suggested subject line
+2. The body of the new email
+
+Then, if the user approves, use send_email with to="${recipient}" to send it.`,
             },
           },
         ],

--- a/src/services/content-parser.test.ts
+++ b/src/services/content-parser.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from "vitest";
+import { extractActionItems, parseIcs } from "./content-parser.js";
+
+// ─── extractActionItems ──────────────────────────────────────────────────────
+
+describe("extractActionItems", () => {
+  it("extracts dash/star/bullet-prefixed action-verb lines", () => {
+    const body = [
+      "Here are the next steps:",
+      "- send the report to Alice",
+      "* review the draft before Friday",
+      "• schedule the kickoff meeting",
+      "just a regular sentence with no verb",
+    ].join("\n");
+    const items = extractActionItems(body);
+    const texts = items.map(i => i.text);
+    expect(texts).toContain("send the report to Alice");
+    expect(texts).toContain("review the draft before Friday");
+    expect(texts).toContain("schedule the kickoff meeting");
+    // A bare sentence without a bullet or marker should not be picked up.
+    expect(texts).not.toContain("just a regular sentence with no verb");
+  });
+
+  it("extracts numbered and checkbox-bulleted items", () => {
+    const body = [
+      "1. confirm the room booking",
+      "2) send the agenda by tomorrow",
+      "[ ] review PR before EOD",
+      "[x] write the summary email",
+    ].join("\n");
+    const items = extractActionItems(body);
+    expect(items.map(i => i.text)).toEqual(
+      expect.arrayContaining([
+        "confirm the room booking",
+        "send the agenda by tomorrow",
+        "review PR before EOD",
+        "write the summary email",
+      ]),
+    );
+  });
+
+  it("accepts TODO: / ACTION: / FOLLOW-UP markers without needing a bullet", () => {
+    const body = [
+      "TODO: refactor the scheduler",
+      "ACTION: ping the vendor about pricing",
+      "ACTION ITEM: file the expense report",
+      "FOLLOW-UP: circle back on the proposal",
+    ].join("\n");
+    const items = extractActionItems(body);
+    const texts = items.map(i => i.text);
+    expect(texts).toContain("refactor the scheduler");
+    expect(texts).toContain("ping the vendor about pricing");
+    expect(texts).toContain("file the expense report");
+    expect(texts).toContain("circle back on the proposal");
+  });
+
+  it("captures @mention and bracketed assignee", () => {
+    const body = [
+      "- @alice please review the doc",
+      "- [Bob] investigate the crash",
+      "- write tests", // no assignee
+    ].join("\n");
+    const items = extractActionItems(body);
+    const alice = items.find(i => /alice/i.test(i.text));
+    const bob = items.find(i => /investigate/i.test(i.text));
+    expect(alice?.assignee).toBe("alice");
+    expect(bob?.assignee).toBe("Bob");
+    // No-assignee line should be present but without an assignee field.
+    const writeTests = items.find(i => i.text === "write tests");
+    expect(writeTests).toBeDefined();
+    expect(writeTests?.assignee).toBeUndefined();
+  });
+
+  it("captures due-date phrases via 'by' / 'due' / 'before'", () => {
+    const body = [
+      "- send the invoice by Friday",
+      "- finalize the slide deck due 2026-05-01",
+      "- publish the post before end of month",
+    ].join("\n");
+    const items = extractActionItems(body);
+    expect(items[0].due).toMatch(/by Friday/i);
+    expect(items[1].due).toMatch(/due 2026-05-01/i);
+    expect(items[2].due).toMatch(/before end of month/i);
+  });
+
+  it("returns [] for empty or non-string bodies", () => {
+    expect(extractActionItems("")).toEqual([]);
+    expect(extractActionItems(undefined as unknown as string)).toEqual([]);
+    expect(extractActionItems(null as unknown as string)).toEqual([]);
+    expect(extractActionItems(42 as unknown as string)).toEqual([]);
+  });
+
+  it("truncates bodies over 100 KB rather than scanning forever", () => {
+    // 120 KB of padding followed by a marker that, if the body isn't
+    // truncated, would be picked up. Because we cap at 100 KB the trailing
+    // marker sits past the cut-off and should never appear.
+    const padding = "x".repeat(120 * 1024);
+    const body = padding + "\nTODO: never seen because truncated";
+    const items = extractActionItems(body);
+    expect(items.find(i => /never seen/.test(i.text))).toBeUndefined();
+  });
+
+  it("deduplicates items by normalized lowercase text", () => {
+    const body = [
+      "- send the report",
+      "- Send   the  Report", // differs only in case / whitespace
+      "- SEND THE REPORT",
+    ].join("\n");
+    const items = extractActionItems(body);
+    expect(items).toHaveLength(1);
+  });
+
+  it("caps at 50 items even when more candidates exist", () => {
+    const body = Array.from({ length: 80 }, (_, i) => `- send email number ${i}`).join("\n");
+    const items = extractActionItems(body);
+    expect(items).toHaveLength(50);
+  });
+});
+
+// ─── parseIcs ────────────────────────────────────────────────────────────────
+
+describe("parseIcs", () => {
+  it("parses a basic VEVENT block into structured fields", () => {
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "BEGIN:VEVENT",
+      "SUMMARY:Team Sync",
+      "DTSTART:20260420T140000Z",
+      "DTEND:20260420T150000Z",
+      "LOCATION:Room 3",
+      "END:VEVENT",
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting).not.toBeNull();
+    expect(meeting?.summary).toBe("Team Sync");
+    expect(meeting?.start).toBe("20260420T140000Z");
+    expect(meeting?.end).toBe("20260420T150000Z");
+    expect(meeting?.location).toBe("Room 3");
+  });
+
+  it("handles RFC 5545 line folding (CRLF + space/tab continuation)", () => {
+    // Per RFC 5545 §3.1 the folding CRLF + single whitespace is stripped
+    // entirely — producers must include the connecting space on the left
+    // line if they want a space in the unfolded output. Well-formed ICS
+    // producers do that; we replicate spec behavior rather than guessing.
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:This is a very long summary that has been ",
+      " folded onto a second line per RFC 5545",
+      "DTSTART:20260420T140000Z",
+      "DESCRIPTION:Line one",
+      "\tcontinues with a tab",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.summary).toBe(
+      "This is a very long summary that has been folded onto a second line per RFC 5545",
+    );
+    // No space was provided on the left side of the fold, so the continuation
+    // abuts directly against the previous text.
+    expect(meeting?.description).toBe("Line onecontinues with a tab");
+  });
+
+  it("collects multiple ATTENDEE lines into an array and strips MAILTO:", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:Review",
+      "DTSTART:20260420T140000Z",
+      "ATTENDEE;CN=Alice:mailto:alice@example.com",
+      "ATTENDEE;CN=Bob:MAILTO:bob@example.com",
+      "ATTENDEE:mailto:carol@example.com",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.attendees).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+      "carol@example.com",
+    ]);
+  });
+
+  it("strips MAILTO: prefix on ORGANIZER too", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:Hello",
+      "DTSTART:20260420T140000Z",
+      "ORGANIZER;CN=Alice:MAILTO:alice@example.com",
+      "END:VEVENT",
+    ].join("\r\n");
+    expect(parseIcs(ics)?.organizer).toBe("alice@example.com");
+  });
+
+  it("returns a meeting with no end when DTEND is missing", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:Open-ended",
+      "DTSTART:20260420T140000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.start).toBe("20260420T140000Z");
+    expect(meeting?.end).toBeUndefined();
+  });
+
+  it("returns null for empty, malformed, or missing VEVENT", () => {
+    expect(parseIcs("")).toBeNull();
+    expect(parseIcs("BEGIN:VCALENDAR\nEND:VCALENDAR")).toBeNull();
+    expect(parseIcs("not a calendar at all")).toBeNull();
+    // VEVENT with neither SUMMARY nor DTSTART
+    expect(parseIcs("BEGIN:VEVENT\nLOCATION:Somewhere\nEND:VEVENT")).toBeNull();
+    // SUMMARY but no DTSTART
+    expect(parseIcs("BEGIN:VEVENT\nSUMMARY:x\nEND:VEVENT")).toBeNull();
+  });
+
+  it("unescapes \\n, \\,, \\;, and \\\\ inside DESCRIPTION per RFC 5545 §3.3.11", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:x",
+      "DTSTART:20260420T140000Z",
+      "DESCRIPTION:Line one\\nLine two\\, with comma\\; semi\\\\ and backslash",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.description).toBe(
+      "Line one\nLine two, with comma; semi\\ and backslash",
+    );
+  });
+
+  it("preserves RRULE verbatim on the parsed meeting", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:Weekly",
+      "DTSTART:20260420T140000Z",
+      "RRULE:FREQ=WEEKLY;BYDAY=MO",
+      "END:VEVENT",
+    ].join("\r\n");
+    expect(parseIcs(ics)?.rrule).toBe("FREQ=WEEKLY;BYDAY=MO");
+  });
+
+  it("accepts LF-only line endings (no CRLF)", () => {
+    const ics = "BEGIN:VEVENT\nSUMMARY:lf only\nDTSTART:20260420T140000Z\nEND:VEVENT";
+    expect(parseIcs(ics)?.summary).toBe("lf only");
+  });
+
+  it("ignores unknown properties without losing known ones", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:mix",
+      "DTSTART:20260420T140000Z",
+      "X-CUSTOM-PROP:whatever",
+      "CATEGORIES:personal,work",
+      "SEQUENCE:0",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.summary).toBe("mix");
+    expect(meeting?.start).toBe("20260420T140000Z");
+  });
+});

--- a/src/services/content-parser.ts
+++ b/src/services/content-parser.ts
@@ -1,0 +1,296 @@
+/**
+ * Content-parser helpers for extracting structured data out of email bodies.
+ *
+ * Two independent parsers live here because both target free-text content that
+ * arrives via the same email-fetch path, and both are intentionally
+ * dependency-free: regex-based action-item extraction and a minimal RFC 5545
+ * iCalendar parser that understands the subset of VEVENT properties we care
+ * about for calendar invites.
+ *
+ * Both parsers are defensive by design — they never throw on malformed input,
+ * they cap output size, and they treat all input as untrusted text.
+ */
+
+export interface ActionItem {
+  text: string;
+  assignee?: string;
+  due?: string;
+}
+
+export interface Meeting {
+  summary: string;
+  start: string;
+  end?: string;
+  location?: string;
+  organizer?: string;
+  attendees?: string[];
+  description?: string;
+  rrule?: string;
+}
+
+// ─── Action-Item Extraction ──────────────────────────────────────────────────
+
+/** Cap body size before scanning — avoid pathological inputs. */
+const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+/** Maximum action items returned — avoid unbounded output. */
+const MAX_ITEMS = 50;
+
+/**
+ * Common imperative verbs that signal an action item. The list stays small on
+ * purpose: adding rare verbs mostly adds false positives rather than recall.
+ */
+const ACTION_VERBS = [
+  "send", "email", "call", "schedule", "book", "reply", "respond",
+  "review", "approve", "sign", "update", "fix", "write", "draft",
+  "prepare", "finish", "finalize", "complete", "check", "confirm", "verify",
+  "follow", "ping", "ask", "discuss", "plan", "submit", "share",
+  "deliver", "ship", "deploy", "merge", "rebase", "create", "add",
+  "remove", "delete", "investigate", "resolve", "close", "assign",
+  "escalate", "file", "report", "test", "build", "implement", "publish",
+  "read", "forward", "return", "pay", "buy", "order", "cancel",
+  "contact", "notify", "reach", "coordinate", "arrange", "organize",
+  "upload", "download", "sync", "install", "configure", "setup",
+];
+const ACTION_VERB_RE = new RegExp(`\\b(${ACTION_VERBS.join("|")})\\b`, "i");
+
+/** Bullet markers we recognise at the start of a line. */
+const BULLET_RE = /^\s*(?:[-*•]|\d+[.)]|\[[ xX]\])\s+/;
+
+/** Explicit "TODO:" / "ACTION:" / "ACTION ITEM:" markers — prefix is stripped. */
+const TODO_MARKER_RE = /^\s*(?:TODO|ACTION(?:\s+ITEM)?|FOLLOW[\s-]?UP)\s*:\s*/i;
+
+/** @mention assignee pattern. */
+const MENTION_RE = /(?<![A-Za-z0-9_])@([A-Za-z][A-Za-z0-9_.-]{0,39})/;
+
+/** Bracketed assignee pattern — [Alice], [@bob]. */
+const BRACKET_ASSIGNEE_RE = /\[\s*@?([A-Za-z][A-Za-z0-9_.-]{0,39})\s*\]/;
+
+/** Deadline pattern — by/due/before <phrase>. Captures a short trailing phrase. */
+const DEADLINE_RE = /\b(?:by|due(?:\s+by)?|before)\s+([A-Za-z0-9][\w,:/ -]{2,40})/i;
+
+/**
+ * Extract action-item-looking lines from a plain-text email body.
+ *
+ * Heuristic: a line is an action item if it either
+ *   (a) starts with a bullet marker AND contains an action verb, or
+ *   (b) contains an explicit marker (TODO:, ACTION:, @mention).
+ *
+ * Output is trimmed, deduplicated by lowercase text, and capped at 50 items.
+ */
+export function extractActionItems(body: string): ActionItem[] {
+  if (typeof body !== "string" || body.length === 0) return [];
+
+  // Cap input size to avoid pathological scans. Byte length on UTF-8 rather
+  // than char count — emojis etc. shouldn't let a 1 MB body sneak through.
+  const truncated = Buffer.byteLength(body, "utf-8") > MAX_BODY_BYTES
+    ? body.slice(0, MAX_BODY_BYTES)
+    : body;
+
+  const lines = truncated.split(/\r?\n/);
+  const items: ActionItem[] = [];
+  const seen = new Set<string>();
+
+  for (const rawLine of lines) {
+    if (items.length >= MAX_ITEMS) break;
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Strip a leading bullet marker if present.
+    const bulletMatch = BULLET_RE.exec(line);
+    const afterBullet = bulletMatch ? line.slice(bulletMatch[0].length).trim() : line;
+
+    // Strip an explicit TODO/ACTION marker if present.
+    const todoMatch = TODO_MARKER_RE.exec(afterBullet);
+    const text = todoMatch ? afterBullet.slice(todoMatch[0].length).trim() : afterBullet;
+    if (!text) continue;
+
+    const hasBullet = bulletMatch !== null;
+    const hasMarker = todoMatch !== null;
+    const mentionMatch = MENTION_RE.exec(text);
+    const bracketMatch = BRACKET_ASSIGNEE_RE.exec(text);
+    const hasAssignee = mentionMatch !== null || bracketMatch !== null;
+    const hasVerb = ACTION_VERB_RE.test(text);
+
+    // Acceptance rules:
+    //   - explicit TODO/ACTION marker → always accept
+    //   - @mention or [assignee] → always accept
+    //   - bullet + action verb → accept
+    // Unlabelled prose sentences are rejected even if they contain verbs —
+    // email bodies are full of those and false-positive rate gets ugly.
+    if (!hasMarker && !hasAssignee && !(hasBullet && hasVerb)) continue;
+
+    const key = text.toLowerCase().replace(/\s+/g, " ").trim();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const item: ActionItem = { text };
+
+    if (mentionMatch) {
+      item.assignee = mentionMatch[1];
+    } else if (bracketMatch) {
+      item.assignee = bracketMatch[1];
+    }
+
+    const dueMatch = DEADLINE_RE.exec(text);
+    if (dueMatch) {
+      // Strip any trailing punctuation the greedy phrase may have pulled in.
+      item.due = dueMatch[0].replace(/[.,;:!?)]+$/, "").trim();
+    }
+
+    items.push(item);
+  }
+
+  return items;
+}
+
+// ─── iCalendar (RFC 5545) Parsing ────────────────────────────────────────────
+
+/**
+ * Apply RFC 5545 §3.1 line unfolding: a CRLF followed by a space or tab marks
+ * a continuation of the previous line. Both CRLF and bare LF inputs are
+ * accepted — bare-LF is out-of-spec but real-world ICS files routinely ship
+ * that way after passing through relays or being saved by hand.
+ */
+function unfoldLines(text: string): string[] {
+  const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const rawLines = normalized.split("\n");
+  const folded: string[] = [];
+  for (const line of rawLines) {
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+      if (folded.length > 0) {
+        folded[folded.length - 1] += line.slice(1);
+        continue;
+      }
+    }
+    folded.push(line);
+  }
+  return folded;
+}
+
+/**
+ * Split a property line like `ATTENDEE;CN=Alice;RSVP=TRUE:mailto:a@x.com`
+ * into its name, parameters, and value.
+ */
+function splitProperty(line: string): { name: string; value: string } | null {
+  const colonIdx = line.indexOf(":");
+  if (colonIdx < 0) return null;
+  const left = line.slice(0, colonIdx);
+  const value = line.slice(colonIdx + 1);
+  const semiIdx = left.indexOf(";");
+  const name = (semiIdx < 0 ? left : left.slice(0, semiIdx)).trim().toUpperCase();
+  return { name, value };
+}
+
+/**
+ * Unescape the minimum set of RFC 5545 text escapes we care about: `\n`/`\N`
+ * become newlines; `\,`, `\;`, and `\\` drop the backslash.
+ */
+function unescapeIcsText(value: string): string {
+  return value
+    .replace(/\\n/gi, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+/** Strip a case-insensitive `mailto:` prefix from an ATTENDEE/ORGANIZER value. */
+function stripMailto(value: string): string {
+  return value.replace(/^mailto:/i, "").trim();
+}
+
+/**
+ * Parse a text blob (an .ics file, a text/calendar attachment body, or an
+ * inline iCalendar chunk inside an email body) and return the first VEVENT
+ * found, or null if the block is missing/malformed/empty.
+ *
+ * Only the subset of properties relevant to rendering a meeting to an end
+ * user is extracted — unknown properties are ignored, and the parser never
+ * throws on bad input.
+ */
+export function parseIcs(text: string): Meeting | null {
+  if (typeof text !== "string" || text.length === 0) return null;
+
+  const lines = unfoldLines(text);
+
+  // Locate the first VEVENT block. ICS files often contain multiple VEVENTs
+  // (recurring exceptions, etc.) — we return just the first to keep the tool
+  // response shape simple; callers that need more can iterate themselves.
+  let inEvent = false;
+  let eventLines: string[] = [];
+  for (const line of lines) {
+    const upper = line.trim().toUpperCase();
+    if (upper === "BEGIN:VEVENT") {
+      inEvent = true;
+      eventLines = [];
+      continue;
+    }
+    if (upper === "END:VEVENT") {
+      if (inEvent) break;
+    }
+    if (inEvent) eventLines.push(line);
+  }
+  if (!inEvent || eventLines.length === 0) return null;
+
+  let summary: string | undefined;
+  let start: string | undefined;
+  let end: string | undefined;
+  let location: string | undefined;
+  let organizer: string | undefined;
+  const attendees: string[] = [];
+  let description: string | undefined;
+  let rrule: string | undefined;
+
+  for (const raw of eventLines) {
+    const prop = splitProperty(raw);
+    if (!prop) continue;
+    const { name, value } = prop;
+
+    switch (name) {
+      case "SUMMARY":
+        summary = unescapeIcsText(value);
+        break;
+      case "DTSTART":
+        start = value.trim();
+        break;
+      case "DTEND":
+        end = value.trim();
+        break;
+      case "LOCATION":
+        location = unescapeIcsText(value);
+        break;
+      case "ORGANIZER": {
+        const addr = stripMailto(value);
+        if (addr) organizer = addr;
+        break;
+      }
+      case "ATTENDEE": {
+        const addr = stripMailto(value);
+        if (addr) attendees.push(addr);
+        break;
+      }
+      case "DESCRIPTION":
+        description = unescapeIcsText(value);
+        break;
+      case "RRULE":
+        rrule = value.trim();
+        break;
+      default:
+        // Ignore unknown properties — keeps us forward-compatible with
+        // calendars that carry extensions (X- props, CATEGORIES, etc.).
+        break;
+    }
+  }
+
+  // A VEVENT is only meaningful with at minimum a SUMMARY and a DTSTART.
+  // Anything less is either an empty block or a malformed fragment.
+  if (!summary || !start) return null;
+
+  const meeting: Meeting = { summary, start };
+  if (end) meeting.end = end;
+  if (location) meeting.location = location;
+  if (organizer) meeting.organizer = organizer;
+  if (attendees.length > 0) meeting.attendees = attendees;
+  if (description) meeting.description = description;
+  if (rrule) meeting.rrule = rrule;
+  return meeting;
+}


### PR DESCRIPTION
## Summary

- **New prompt `draft_in_my_voice`** — feeds the model up to N of the user's most recent sent emails (subject + bodyPreview only) as tone samples, plus a recipient and intent, so the drafted email matches the user's voice rather than a generic LLM style. `recipient` and `intent` are required; `sampleCount` defaults to 5 and is capped at 20.
- **New tool `extract_action_items`** (Reading category) — scans a single email's body for bullet / TODO / @mention action-item lines and returns a structured list of `{ text, assignee?, due? }`. Pure regex, dependency-free. Caps input at 100 KB, output at 50 items, dedupes by normalized text.
- **New tool `extract_meeting`** (Reading category) — parses ICS attachments (`text/calendar` or `.ics` filename) or inline `VCALENDAR` blocks inside the body, returning a structured meeting object (SUMMARY, DTSTART/DTEND, LOCATION, ORGANIZER, ATTENDEE, DESCRIPTION, RRULE). RFC 5545 line folding is handled; `MAILTO:` prefixes are stripped; malformed blocks return `{ meeting: null }`.

Tool count: **67 -> 69**. Test count: **1533 -> 1552** (19 new tests in `src/services/content-parser.test.ts`). No new npm dependencies. Total diff ~736 LOC including tests.

## Test plan

- [x] `npm run build` — clean (tsc, no errors)
- [x] `npm test` — 42 files, 1552 tests passing
- [x] `schema.test.ts` tool-count invariant updated (67 -> 69)
- [x] New content-parser suite covers: bullet forms, numbered/checkbox bullets, TODO/ACTION markers, @mention + bracket assignee, due-date phrases, empty bodies, 100 KB truncation, dedupe, 50-item cap, basic VEVENT, CRLF folding, LF-only endings, MAILTO stripping on ORGANIZER and ATTENDEE, missing DTEND, malformed / empty blocks, `\n`/`\,`/`\;`/`\\` escapes, RRULE preservation, unknown-property tolerance

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>