### PR TITLE
simplify: dedupe constantTimeEqual + FTS typing + memoize permissions

### DIFF
--- a/src/agents/grant-manager.ts
+++ b/src/agents/grant-manager.ts
@@ -89,7 +89,7 @@ export class GrantManager {
 
     // No override — apply the intersection of grant preset and global preset.
     const effective = intersectPresets(grant.preset, ctx.globalPreset);
-    if (!this.presetAllows(effective, ctx.tool)) {
+    if (!this.globalAllows(effective, ctx.tool)) {
       return { allowed: false, reason: `Tool '${ctx.tool}' is outside the effective preset '${effective}' for '${grant.clientName}'.` };
     }
 
@@ -112,13 +112,19 @@ export class GrantManager {
   }
 
   private globalAllows(preset: PermissionPreset, tool: string): boolean {
-    const perms = buildPermissions(preset);
+    // Memoize on preset — buildPermissions materializes a full map per call,
+    // but the preset→permissions mapping is pure. `check()` can consult this
+    // twice per call (once for the override path, once for the preset path),
+    // and a high-QPS agent would materialize the same map over and over.
+    let perms = this.permsCache.get(preset);
+    if (!perms) {
+      perms = buildPermissions(preset);
+      this.permsCache.set(preset, perms);
+    }
     return !!perms.tools[tool as ToolName]?.enabled;
   }
 
-  private presetAllows(preset: PermissionPreset, tool: string): boolean {
-    return this.globalAllows(preset, tool);
-  }
+  private readonly permsCache = new Map<PermissionPreset, ReturnType<typeof buildPermissions>>();
 }
 
 /**

--- a/src/services/fts-service.ts
+++ b/src/services/fts-service.ts
@@ -69,7 +69,7 @@ interface SqliteStatement {
 interface SqliteDatabase {
   exec(sql: string): void;
   prepare(sql: string): SqliteStatement;
-  transaction<T extends (...args: unknown[]) => unknown>(fn: T): T;
+  transaction<F extends (...args: never[]) => unknown>(fn: F): F;
   close(): void;
   pragma(s: string): unknown;
 }
@@ -148,12 +148,12 @@ export class FtsIndexService {
   /** Bulk upsert wrapped in a single transaction. */
   upsertMany(records: FtsRecord[]): number {
     if (records.length === 0) return 0;
-    // better-sqlite3's transaction() returns a fn with the same signature as
-    // the inner fn. We feed it the whole batch and run per-row inside.
-    const tx = this.db.transaction(((batch: unknown) => {
-      for (const r of batch as FtsRecord[]) this.upsert(r);
-      return (batch as FtsRecord[]).length;
-    }) as unknown as (...args: unknown[]) => unknown) as unknown as (batch: FtsRecord[]) => number;
+    // better-sqlite3's transaction() preserves the argument signature of the
+    // inner fn, so we can write it concretely without any casts.
+    const tx = this.db.transaction((batch: FtsRecord[]) => {
+      for (const r of batch) this.upsert(r);
+      return batch.length;
+    });
     return tx(records);
   }
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -29,7 +29,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
 import { createServer as createSecureServer } from "https";
 import { readFileSync } from "fs";
-import { timingSafeEqual } from "crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { Server as McpServer } from "@modelcontextprotocol/sdk/server/index.js";
 import { logger } from "../utils/logger.js";
@@ -82,18 +81,10 @@ export interface HttpTransportHandle {
   close: () => Promise<void>;
 }
 
+import { constantTimeEqual } from "../utils/crypto.js";
+
 /** Constant-time compare, safe against length-leak. */
-function tokenMatches(actual: string, expected: string): boolean {
-  if (!expected || !actual) return false;
-  const a = Buffer.from(actual, "utf-8");
-  const b = Buffer.from(expected, "utf-8");
-  if (a.length !== b.length) {
-    const pad = Buffer.alloc(b.length, 0);
-    try { timingSafeEqual(pad, b); } catch { /* ignore */ }
-    return false;
-  }
-  return timingSafeEqual(a, b);
-}
+const tokenMatches = constantTimeEqual;
 
 function extractBearer(req: IncomingMessage): string | null {
   const raw = req.headers["authorization"];

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -20,10 +20,11 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import { createHash, timingSafeEqual } from "crypto";
+import { createHash } from "crypto";
 import { OAuthStore } from "./oauth-store.js";
 import { TokenBucketLimiter } from "./rate-limit.js";
 import { logger } from "../utils/logger.js";
+import { constantTimeEqual } from "../utils/crypto.js";
 
 const SCOPES = ["mcp:full"] as const;
 
@@ -82,24 +83,11 @@ function error(res: ServerResponse, status: number, error: string, description?:
 /** PKCE S256 verification: base64url(sha256(verifier)) must equal challenge. */
 function verifyPkceS256(verifier: string, challenge: string): boolean {
   const computed = createHash("sha256").update(verifier, "utf-8").digest("base64url");
-  const a = Buffer.from(computed, "utf-8");
-  const b = Buffer.from(challenge, "utf-8");
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
+  return constantTimeEqual(computed, challenge);
 }
 
-/** Compare two strings in constant time, safe against length-leak. */
-function safeEqual(a: string, b: string): boolean {
-  if (!a || !b) return false;
-  const aa = Buffer.from(a, "utf-8");
-  const bb = Buffer.from(b, "utf-8");
-  if (aa.length !== bb.length) {
-    const pad = Buffer.alloc(bb.length);
-    try { timingSafeEqual(pad, bb); } catch { /* ignore */ }
-    return false;
-  }
-  return timingSafeEqual(aa, bb);
-}
+// Constant-time string compare imported from ../utils/crypto.
+const safeEqual = constantTimeEqual;
 
 /** Client IP extraction — trust X-Forwarded-For only when the caller is loopback. */
 function clientIp(req: IncomingMessage): string {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared cryptographic helpers.
+ *
+ * Keep this module tiny — anything larger belongs in its own file. We
+ * reach for node:crypto directly rather than a wrapper library so the
+ * provenance of every primitive is auditable.
+ */
+
+import { Buffer } from "buffer";
+import { timingSafeEqual } from "crypto";
+
+/**
+ * Constant-time string equality, safe against both content-difference
+ * and length-difference timing side-channels. Returns false when either
+ * input is empty, so callers don't accidentally authenticate as "".
+ *
+ * Implementation notes:
+ *  - Encodes each string as UTF-8 before comparing, so equal logical
+ *    strings compare equal regardless of JS engine internal reps.
+ *  - When lengths differ, still performs a padded timingSafeEqual
+ *    against a zero buffer of the expected length. This keeps the
+ *    cost path consistent whether the lengths match or not, which
+ *    avoids leaking the expected length via early-exit timing.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  const aa = Buffer.from(a, "utf-8");
+  const bb = Buffer.from(b, "utf-8");
+  if (aa.length !== bb.length) {
+    const pad = Buffer.alloc(bb.length);
+    try { timingSafeEqual(pad, bb); } catch { /* ignore */ }
+    return false;
+  }
+  return timingSafeEqual(aa, bb);
+}


### PR DESCRIPTION
## Summary

Three simplify wins from the internal review — all zero-behavior-change:

| # | Win | Impact |
|---|---|---|
| 1 | Shared \`constantTimeEqual\` in \`src/utils/crypto.ts\` | Dedupes \`tokenMatches\` (http.ts) and \`safeEqual\` (oauth-handlers.ts). \`verifyPkceS256\` also routes through it now — drops the last copy of the buffer-eq dance. |
| 2 | FTS \`transaction()\` cast cleanup | Tightened the local better-sqlite3 shim to \`F extends (...args: never[]) => unknown\`. Drops a triple \`as unknown as\` ladder; the block is now seven lines of concrete types instead of cast soup. |
| 3 | \`buildPermissions\` memoization in GrantManager | The gate called \`buildPermissions\` twice per \`check()\`. Preset→permissions is pure; a per-manager Map cache eliminates the duplicate materialization. Also removed the identical \`presetAllows\` wrapper. |

**Deliberately not included:** \`GrantStore.revoke()\` → \`deny()\` dedup. They share an implementation but express different semantic intents (active → revoked vs pending → denied); worth the 3 LOC.

## Test plan

- [x] \`npm run build\` clean
- [x] **1,564 tests pass** (unchanged — pure refactor)
- [x] \`npm audit\` — 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)