### PR TITLE
refactor: unify tool-dispatcher error shape (throw vs isError:true)

### DIFF
--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -7,6 +7,37 @@
  * Handlers never touch module-level singletons directly — they read
  * everything they need from ctx, which keeps the boundary explicit and
  * makes it safe to hot-swap services (e.g. per-account routing).
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * Error-shape rule for tool handlers
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * Tool handlers report failure in one of three shapes. Pick the shape that
+ * matches the *agent's* mental model, not just whichever happens to be
+ * convenient at the call site:
+ *
+ *   1. throw new McpError(ErrorCode.InvalidParams, msg)
+ *      → Programmer/caller error: malformed, missing, oversized, or
+ *        typed-wrong arguments. The MCP SDK serializes this as a JSON-RPC
+ *        error response so the agent knows to retry the call differently.
+ *
+ *   2. throw new McpError(ErrorCode.InvalidRequest, msg)
+ *      → Server-side precondition the call cannot satisfy regardless of
+ *        arguments: service not configured, feature flag off, bridge
+ *        unreachable, dependent CLI not installed. Treated as a JSON-RPC
+ *        error so the agent surfaces the configuration gap instead of
+ *        narrating it as a normal tool result.
+ *
+ *   3. return { isError: true, content, structuredContent }
+ *      → Expected domain outcome: the tool ran correctly but the
+ *        operation has nothing to report — email not found, attachment
+ *        missing, folder doesn't exist, scheduler had no matching record,
+ *        SMTP delivery rejected. The agent gets a tool-result shape it
+ *        can reason about and relay to the user.
+ *
+ * When in doubt, prefer the shape already used in this file or in a
+ * neighboring handler for the same kind of failure — consistency across
+ * sites matters more than any individual judgment call.
  */
 
 import type { SimpleIMAPService } from "../services/simple-imap-service.js";


### PR DESCRIPTION
## Summary

After the dispatcher split in #70, every per-category handler module under `src/tools/` ended up with its own ad-hoc choice of error shape. This PR documents the convention they actually already follow, so future contributors don't drift.

## The rule

| # | Shape | Use for |
|---|---|---|
| 1 | `throw new McpError(ErrorCode.InvalidParams, msg)` | Programmer/caller error: malformed, missing, oversized, or typed-wrong arguments. SDK serializes as JSON-RPC error so the agent retries differently. |
| 2 | `throw new McpError(ErrorCode.InvalidRequest, msg)` | Server-side precondition the call cannot satisfy regardless of arguments: service not configured, feature flag off, bridge unreachable, dependent CLI not installed. |
| 3 | `return { isError: true, content, structuredContent }` | Expected domain outcome: tool ran correctly but operation has nothing to report — email not found, attachment missing, folder doesn't exist, scheduler had no matching record, SMTP delivery rejected. |

Difference matters to an agent: a thrown `McpError` reads as *"you called the tool wrong, retry differently"*; a `{ isError: true }` result reads as *"the tool ran correctly but the domain operation didn't succeed, adjust the user's understanding."*

## File-by-file triage

| File | throws -> return | returns -> throw | Notes |
|---|---|---|---|
| `sending.ts` | 0 | 0 | 20 throws (rule 1) + 6 returns (rule 3) — all correct |
| `reading.ts` | 0 | 0 | 28 throws (rule 1/2) + 8 returns (rule 3) — all correct |
| `folders.ts` | 0 | 0 | 9 throws (rule 1) — all correct |
| `actions.ts` | 0 | 0 | 20 throws (rule 1) — all correct |
| `deletion.ts` | 0 | 0 | 1 throw (rule 1) — correct |
| `analytics.ts` | 0 | 0 | 2 throws (rule 1) — correct |
| `system.ts` | 0 | 0 | 3 throws (rule 1) — correct |
| `bridge.ts` | 0 | 0 | 1 throw (`InternalError`, system-level) — correct |
| `aliases.ts` | 0 | 0 | 10 throws (rule 1/2) — correct |
| `pass.ts` | 0 | 0 | 8 throws (rule 1/2) — correct |
| `drafts.ts` | 0 | 0 | 29 throws (rule 1/2) + 5 returns (rule 3) — all correct |
| `escalation.ts` | -- | -- | Out of scope (system-level escalation gate). |

**Total reclassifications: 0.**

The P3 finding's 141/24 split was accurate as a count, but classification across those sites was already correct. The deliverable is therefore the docstring at the top of `src/tools/types.ts` — codifying the rule so the convention survives future contributions.

## Test count

- Before: 1,567 passing
- After: 1,567 passing

No user-facing behavior change expected beyond the error classification (and there is no behavior change here, since no sites were reclassified).

## Test plan

- [x] `npm test` — 1,567 passing
- [x] `npm run typecheck` — clean