### PR TITLE
feat(rename): mailpouch — rename + keychain migration + env-var aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-# pm-bridge-mcp — Environment Variable Reference
+# mailpouch — Environment Variable Reference
 #
-# NOTE: Credentials and connection settings live in ~/.pm-bridge-mcp.json
-# (mode 0600), managed via the settings UI (`npx pm-bridge-mcp-settings`).
+# NOTE: Credentials and connection settings live in ~/.mailpouch.json
+# (mode 0600), managed via the settings UI (`npx mailpouch-settings`).
 # They are NOT loaded from environment variables, on purpose, to avoid
 # accidental exposure to other processes.
 #
@@ -9,17 +9,18 @@
 # to .env if you need any of them; leave it unset otherwise.
 
 # ── Optional path overrides ──────────────────────────────────────────────
-# PM_BRIDGE_MCP_CONFIG=~/.pm-bridge-mcp.json
-# PM_BRIDGE_MCP_SCHEDULER_STORE=~/.pm-bridge-mcp-scheduled.json
-# PM_BRIDGE_MCP_LOG_FILE=~/.pm-bridge-mcp.log
-# PM_BRIDGE_MCP_PENDING=~/.pm-bridge-mcp.pending.json
-# PM_BRIDGE_MCP_AUDIT=~/.pm-bridge-mcp.audit.jsonl
+# MAILPOUCH_CONFIG=~/.mailpouch.json
+# MAILPOUCH_SCHEDULER_STORE=~/.mailpouch-scheduled.json
+# MAILPOUCH_LOG_FILE=~/.mailpouch.log
+# MAILPOUCH_PENDING=~/.mailpouch.pending.json
+# MAILPOUCH_AUDIT=~/.mailpouch.audit.jsonl
 
 # ── Per-launch behavior ──────────────────────────────────────────────────
-# PM_BRIDGE_MCP_INSECURE_BRIDGE=1   # opt into localhost Bridge w/o pinned cert
-# PM_BRIDGE_MCP_TIER=complete       # core / extended / complete
-# PORT=8765                         # settings UI HTTP server port
+# MAILPOUCH_INSECURE_BRIDGE=1   # opt into localhost Bridge w/o pinned cert
+# MAILPOUCH_TIER=complete       # core / extended / complete
+# PORT=8765                     # settings UI HTTP server port
 
-# Legacy PROTONMAIL_* names for the path/tier/insecure variables are still
-# honored for one release (silent alias). New installs should use the
-# PM_BRIDGE_MCP_* forms above.
+# Legacy PM_BRIDGE_MCP_* (v2.1) and PROTONMAIL_MCP_* (original) names are
+# still honored through v3.0.0 (silent aliases). New installs should use
+# the MAILPOUCH_* forms above. Precedence if multiple are set:
+# MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_MCP_*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] — 2026-04-18
+### Changed
+- **Product renamed to `mailpouch`** — the name better reflects the product's
+  positioning (a sealed, private pouch for mail in transit between your
+  provider and your agent). The `pm-bridge-mcp` name was descriptive but
+  trademark-adjacent; `mailpouch` is era-neutral and brand-safe.
+- Package name, bin names, config path, env vars, log file, webhook
+  signature header, MCP server name, and OS keychain service name all
+  rename in lockstep.
+### Added
+- **One-shot keychain migration** at startup — existing installs carry
+  their stored Bridge password forward from `protonmail-mcp-server` or
+  `pm-bridge-mcp` service entries to `mailpouch`. No re-entry required.
+- **Legacy env-var aliases honored** through v3.0: `MAILPOUCH_X` wins,
+  but `PM_BRIDGE_MCP_X` and `PROTONMAIL_MCP_X` still read.
+- **Legacy file-path aliases honored**: reads fall back to
+  `~/.pm-bridge-mcp-*` and `~/.protonmail-mcp-*` if the new path is
+  absent. Writes always use the new path.
+### Breaking
+- Webhook signature header renamed `X-PMBridge-Signature-256` →
+  `X-Mailpouch-Signature-256`. Downstream verifiers must update. The
+  CloudEvents `source` and `type` prefix changed too (`pm-bridge-mcp` →
+  `mailpouch`, `com.pmbridge.*` → `com.mailpouch.*`), and the outbound
+  `User-Agent` is now `mailpouch/1 (+https://github.com/chandshy/mailpouch)`.
+- Binary names changed: `pm-bridge-mcp` → `mailpouch`,
+  `pm-bridge-mcp-settings` → `mailpouch-settings`.
+
 ## [2.1.0] — 2026-04-18
 
 Adds multi-account support, per-agent permission grants, a remote HTTP

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to pm-bridge-mcp
+# Contributing to mailpouch
 
-Thank you for your interest in contributing to pm-bridge-mcp! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to mailpouch! This document provides guidelines and information for contributors.
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Thank you for your interest in contributing to pm-bridge-mcp! This document prov
 1. Fork the repository on GitHub
 2. Clone your fork locally:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/pm-bridge-mcp.git
-   cd pm-bridge-mcp
+   git clone https://github.com/YOUR_USERNAME/mailpouch.git
+   cd mailpouch
    ```
 
 3. Install dependencies:
@@ -30,7 +30,7 @@ Thank you for your interest in contributing to pm-bridge-mcp! This document prov
    npm run build
    npm run settings    # opens http://localhost:8765
    ```
-   Complete the setup wizard to save credentials to `~/.pm-bridge-mcp.json`. Alternatively, create that file directly with the required `connection` fields (see `src/config/schema.ts` for the shape).
+   Complete the setup wizard to save credentials to `~/.mailpouch.json`. Alternatively, create that file directly with the required `connection` fields (see `src/config/schema.ts` for the shape).
 
 5. Build the project:
    ```bash
@@ -253,7 +253,7 @@ If you discover a security vulnerability:
 ### Security Best Practices
 
 - Never commit credentials or API keys
-- Store credentials in `~/.pm-bridge-mcp.json` (mode 0600) or OS keychain — never in env vars or source code
+- Store credentials in `~/.mailpouch.json` (mode 0600) or OS keychain — never in env vars or source code
 - Validate all user inputs
 - Handle errors securely
 - Follow principle of least privilege
@@ -263,7 +263,7 @@ If you discover a security vulnerability:
 ## Questions?
 
 - Open a GitHub Discussion for general questions
-- Open an [Issue](https://github.com/chandshy/pm-bridge-mcp/issues) for bug reports or feature requests
+- Open an [Issue](https://github.com/chandshy/mailpouch/issues) for bug reports or feature requests
 - Check existing issues and discussions first
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# pm-bridge-mcp
+# mailpouch
 
 **MCP server for Proton Mail via Proton Bridge.** An unofficial, user-initiated bridge between agentic MCP clients and Proton Bridge's local IMAP/SMTP surface.
 
-[![CI](https://github.com/chandshy/pm-bridge-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/pm-bridge-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v2.1.0-blue.svg)](https://www.npmjs.com/package/pm-bridge-mcp)
+[![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/badge/npm-v2.2.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
@@ -43,7 +43,7 @@ Your emails are decrypted on your own machine by Proton Bridge. This server neve
 
 - **67 tools** across 11 categories — reading, search, analytics, sending, drafts, scheduling, follow-up reminders, folder management, bulk actions, deletion, Bridge/server lifecycle, plus optional companion services (SimpleLogin aliases, Proton Pass, local FTS5 search). See [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS`, `TOOL_CATEGORIES`) for the canonical inventory.
 - **Two transports** — stdio (default, Claude Desktop) and HTTP (remote / self-host). HTTP supports a static bearer **and/or** OAuth 2.1 with PKCE-S256, RFC 7591 Dynamic Client Registration, RFC 8414 authorization-server metadata, and RFC 9728 protected-resource metadata. Per-caller token-bucket rate limiting on every endpoint.
-- **Progressive tool tiering** — `core` / `extended` / `complete` controls how many tools land in the client's `ListTools` response, so context isn't burned on tools you don't use. Configurable via `toolTier` or `PM_BRIDGE_MCP_TIER`.
+- **Progressive tool tiering** — `core` / `extended` / `complete` controls how many tools land in the client's `ListTools` response, so context isn't burned on tools you don't use. Configurable via `toolTier` or `MAILPOUCH_TIER`.
 - **Destructive-tool confirmation** — uses MCP elicitation when the client supports it (Claude Desktop, Cline) so the user sees a prompt before any delete / trash / spam / `alias_delete` / `pass_get` runs. Falls back to a required `{ confirmed: true }` argument for clients without elicitation.
 - **5 permission presets** — read-only by default; write access requires explicit opt-in. Per-tool overrides and rate limits via the **Custom** preset.
 - **Human-gated escalation** — agents request elevated permissions, you approve via browser UI or terminal; the agent cannot approve its own requests.
@@ -108,14 +108,14 @@ Bridge listens locally on:
 ### Option A — npm (recommended)
 
 ```bash
-npm install -g github:chandshy/pm-bridge-mcp
+npm install -g github:chandshy/mailpouch
 ```
 
 ### Option B — From source
 
 ```bash
-git clone https://github.com/chandshy/pm-bridge-mcp.git
-cd pm-bridge-mcp
+git clone https://github.com/chandshy/mailpouch.git
+cd mailpouch
 npm install
 npm run build
 ```
@@ -139,7 +139,7 @@ Tools in unconfigured groups return a clean configuration error rather than fail
 Run the settings server to complete first-time setup:
 
 ```bash
-npx pm-bridge-mcp-settings
+npx mailpouch-settings
 # Then open http://localhost:8765
 ```
 
@@ -152,7 +152,7 @@ The **6-step wizard** walks you through everything automatically:
 5. **Review** — confirm your settings before saving
 6. **Done** — displays the exact JSON snippet to paste into your MCP client config; optionally writes it for you automatically
 
-Settings are saved to `~/.pm-bridge-mcp.json` with mode `0600` (owner read/write only). Bridge passwords, OAuth admin passwords, and Pass PATs prefer the OS keychain when available.
+Settings are saved to `~/.mailpouch.json` with mode `0600` (owner read/write only). Bridge passwords, OAuth admin passwords, and Pass PATs prefer the OS keychain when available.
 
 ---
 
@@ -171,9 +171,9 @@ The generated entry looks like this (your path will differ):
 ```json
 {
   "mcpServers": {
-    "pm-bridge": {
+    "mailpouch": {
       "command": "node",
-      "args": ["/path/to/node_modules/pm-bridge-mcp/dist/index.js"]
+      "args": ["/path/to/node_modules/mailpouch/dist/index.js"]
     }
   }
 }
@@ -215,7 +215,7 @@ Canonical code: [`src/accounts/registry.ts`](src/accounts/registry.ts), [`src/ac
 
 For headless boxes, phones, or sharing one Bridge across multiple devices, switch to HTTP transport. The same binary listens on a port instead of stdio.
 
-Enable it via the Setup tab → **Remote (HTTP) mode**, or by setting these in `~/.pm-bridge-mcp.json`:
+Enable it via the Setup tab → **Remote (HTTP) mode**, or by setting these in `~/.mailpouch.json`:
 
 ```json
 {
@@ -250,7 +250,7 @@ A static-bearer client config looks like:
 ```json
 {
   "mcpServers": {
-    "pm-bridge-remote": {
+    "mailpouch-remote": {
       "url": "https://mcp.example.com/mcp",
       "headers": { "Authorization": "Bearer <token>" }
     }
@@ -260,20 +260,20 @@ A static-bearer client config looks like:
 
 ### Environment variables
 
-Configuration is stored in `~/.pm-bridge-mcp.json` and managed via the settings UI — not environment variables. The following env vars are available for advanced/optional overrides:
+Configuration is stored in `~/.mailpouch.json` and managed via the settings UI — not environment variables. The following env vars are available for advanced/optional overrides:
 
 | Variable | Default | Description |
 |---|---|---|
-| `PM_BRIDGE_MCP_CONFIG` | `~/.pm-bridge-mcp.json` | Override config file path |
-| `PM_BRIDGE_MCP_SCHEDULER_STORE` | `~/.pm-bridge-mcp-scheduled.json` | Scheduled email persistence file |
-| `PM_BRIDGE_MCP_LOG_FILE` | `~/.pm-bridge-mcp.log` | Override log file path |
-| `PM_BRIDGE_MCP_PENDING` | `~/.pm-bridge-mcp.pending.json` | Override pending escalations file path |
-| `PM_BRIDGE_MCP_AUDIT` | `~/.pm-bridge-mcp.audit.jsonl` | Override escalation audit log path |
-| `PM_BRIDGE_MCP_INSECURE_BRIDGE` | unset | Per-launch opt-in to localhost Bridge without a pinned cert |
-| `PM_BRIDGE_MCP_TIER` | `complete` | Tool-tier override: `core` / `extended` / `complete` |
+| `MAILPOUCH_CONFIG` | `~/.mailpouch.json` | Override config file path |
+| `MAILPOUCH_SCHEDULER_STORE` | `~/.mailpouch-scheduled.json` | Scheduled email persistence file |
+| `MAILPOUCH_LOG_FILE` | `~/.mailpouch.log` | Override log file path |
+| `MAILPOUCH_PENDING` | `~/.mailpouch.pending.json` | Override pending escalations file path |
+| `MAILPOUCH_AUDIT` | `~/.mailpouch.audit.jsonl` | Override escalation audit log path |
+| `MAILPOUCH_INSECURE_BRIDGE` | unset | Per-launch opt-in to localhost Bridge without a pinned cert |
+| `MAILPOUCH_TIER` | `complete` | Tool-tier override: `core` / `extended` / `complete` |
 | `PORT` | `8765` | Override settings UI HTTP server port |
 
-> The legacy `PROTONMAIL_*` forms of the first six variables are still honored for one release to avoid breaking existing installs; new docs and CLI help only mention the `PM_BRIDGE_MCP_*` names.
+> The legacy `PM_BRIDGE_MCP_*` (v2.1) and `PROTONMAIL_MCP_*` (original) forms are still honored through v3.0.0 to avoid breaking existing installs; new docs and CLI help only mention the `MAILPOUCH_*` names. Precedence if multiple are set: `MAILPOUCH_*` > `PM_BRIDGE_MCP_*` > `PROTONMAIL_MCP_*`.
 
 ---
 
@@ -351,8 +351,8 @@ The escalation system lets an agent request broader permissions without permanen
 - You must type `APPROVE` before the button activates — no accidental clicks
 - CSRF-protected: the approval API requires a session token embedded only in the rendered HTML page
 - Rate-limited: max 5 escalation requests per hour, max 1 pending at a time
-- Audit trail: every request, approval, and denial is appended to `~/.pm-bridge-mcp.audit.jsonl`
-- Approve from another device: `npx pm-bridge-mcp-settings --lan`
+- Audit trail: every request, approval, and denial is appended to `~/.mailpouch.audit.jsonl`
+- Approve from another device: `npx mailpouch-settings --lan`
 
 ---
 
@@ -363,13 +363,13 @@ The settings UI starts automatically on `http://localhost:8765` whenever your MC
 To run the settings UI standalone (useful for initial setup, headless / SSH systems, or a dedicated remote-mode host):
 
 ```bash
-npx pm-bridge-mcp-settings           # auto-detects display; opens browser if available
-npx pm-bridge-mcp-settings --port 9000   # custom port (default: 8765)
-npx pm-bridge-mcp-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
-npx pm-bridge-mcp-settings --browser     # force browser UI even if no display detected
-npx pm-bridge-mcp-settings --tui         # force interactive terminal UI
-npx pm-bridge-mcp-settings --plain       # plain readline menus (no ANSI colors/escapes)
-npx pm-bridge-mcp-settings --no-open     # start server but don't auto-open browser
+npx mailpouch-settings           # auto-detects display; opens browser if available
+npx mailpouch-settings --port 9000   # custom port (default: 8765)
+npx mailpouch-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
+npx mailpouch-settings --browser     # force browser UI even if no display detected
+npx mailpouch-settings --tui         # force interactive terminal UI
+npx mailpouch-settings --plain       # plain readline menus (no ANSI colors/escapes)
+npx mailpouch-settings --no-open     # start server but don't auto-open browser
 ```
 
 Tabs:
@@ -388,12 +388,12 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 
 | Layer | Mechanism |
 |---|---|
-| Permission gate | Every tool call checked against `~/.pm-bridge-mcp.json` (refreshed every 15 s) |
+| Permission gate | Every tool call checked against `~/.mailpouch.json` (refreshed every 15 s) |
 | Tool tiering | `core` / `extended` / `complete` controls the `ListTools` surface — agents can't call what they can't see |
 | Rate limiting | Per-tool sliding-window limits in-process; per-caller token-bucket on the HTTP transport |
 | Destructive confirmation | MCP elicitation prompt (or required `{ confirmed: true }`) on delete / trash / spam / `alias_delete` / `pass_get` |
 | Escalation gate | Privilege increases require explicit human approval via a separate channel |
-| Audit log | Append-only log of all escalation events at `~/.pm-bridge-mcp.audit.jsonl` |
+| Audit log | Append-only log of all escalation events at `~/.mailpouch.audit.jsonl` |
 | OAuth 2.1 + PKCE-S256 | Spec-compliant DCR + consent flow gated on admin password (HTTP transport) |
 | CSRF protection | All mutating settings API calls require a session token (timing-safe comparison) |
 | Origin validation | Settings server validates `Origin`/`Referer` headers; rejects unknown origins |
@@ -409,18 +409,18 @@ This server gives AI agents *controlled* access to sensitive email data. The sec
 **What agents cannot do:**
 - Approve their own escalation requests
 - Bypass the permission gate (it runs in the server process, not the agent)
-- Read or modify `~/.pm-bridge-mcp.json` directly (not an exposed tool)
+- Read or modify `~/.mailpouch.json` directly (not an exposed tool)
 - Erase the audit log
 - Inject headers into outgoing email via crafted subjects, filenames, or custom headers
 - Execute destructive tools without surfacing the intent to the user
 
-**Credentials:** Stored in `~/.pm-bridge-mcp.json` with `0600` permissions (or in the OS keychain). Never commit this file. The settings UI never displays or transmits high-value secrets after they are first saved.
+**Credentials:** Stored in `~/.mailpouch.json` with `0600` permissions (or in the OS keychain). Never commit this file. The settings UI never displays or transmits high-value secrets after they are first saved.
 
 ---
 
 ## Agent Grants
 
-The global permission preset gates *what tools exist*; an **agent grant** gates *which MCP client gets to use them*. When an MCP host completes OAuth Dynamic Client Registration, pm-bridge-mcp creates a `pending` grant keyed by the new `client_id`. Nothing that client calls will succeed until you approve it.
+The global permission preset gates *what tools exist*; an **agent grant** gates *which MCP client gets to use them*. When an MCP host completes OAuth Dynamic Client Registration, mailpouch creates a `pending` grant keyed by the new `client_id`. Nothing that client calls will succeed until you approve it.
 
 Grant lifecycle: `pending` → `active` → `revoked` | `expired`. Each grant carries:
 
@@ -436,7 +436,7 @@ Grant lifecycle: `pending` → `active` → `revoked` | `expired`. Each grant ca
 
 Approve, deny, revoke, and "approve-with-conditions" all live in the **Agents** tab of the settings UI. The tab streams live updates over SSE from `GET /api/notifications` — new pending grants surface without a reload.
 
-Every gated tool call writes one row to an append-only JSONL audit log at `~/.pm-bridge-mcp-agent-audit.jsonl` (mode `0600`). Rows carry a truncated sha256 `argHash` — **never argument values, never response bodies** — so "same call repeated" patterns are observable without creating a parallel on-disk copy of your email. The log rotates at 10 MB and keeps 3 gzipped generations.
+Every gated tool call writes one row to an append-only JSONL audit log at `~/.mailpouch-agent-audit.jsonl` (mode `0600`). Rows carry a truncated sha256 `argHash` — **never argument values, never response bodies** — so "same call repeated" patterns are observable without creating a parallel on-disk copy of your email. The log rotates at 10 MB and keeps 3 gzipped generations.
 
 Caller identity propagates through the dispatcher via `AsyncLocalStorage` (see [`src/agents/caller-context.ts`](src/agents/caller-context.ts)); stdio callers (default Claude Desktop) have no context and bypass the grant gate as the local trusted caller.
 
@@ -449,7 +449,7 @@ Canonical code: [`src/agents/grant-store.ts`](src/agents/grant-store.ts), [`gran
 Grant-state transitions (`grant-created` / `-approved` / `-denied` / `-revoked` / `-expired`) fan out through an in-process `NotificationBroker` to two optional channels:
 
 - **Desktop toasts** — platform-native, no extra dependency. macOS shells to `osascript`, Linux to `notify-send` (libnotify), Windows to `powershell.exe` driving the WinRT toast API. Fire-and-forget; missing tooling degrades to a debug log.
-- **Outbound webhooks** — `WebhookDispatcher` POSTs a JSON body to each configured endpoint. Format defaults to **CloudEvents 1.0**; URLs on `hooks.slack.com` auto-select the Slack shape and `discord.com` / `discordapp.com` auto-select the Discord shape (explicit `format: "raw"` is also available). When an endpoint has a secret configured, every body is HMAC-signed as `X-PMBridge-Signature-256: sha256=<hex>` (GitHub-webhook convention). Delivery retries up to 8 times with exponential backoff (1 / 2 / 4 / 8 / 16 / 32 / 64 / 128 s) plus ±20 % jitter; 4xx responses other than 408 and 429 stop retries immediately.
+- **Outbound webhooks** — `WebhookDispatcher` POSTs a JSON body to each configured endpoint. Format defaults to **CloudEvents 1.0**; URLs on `hooks.slack.com` auto-select the Slack shape and `discord.com` / `discordapp.com` auto-select the Discord shape (explicit `format: "raw"` is also available). When an endpoint has a secret configured, every body is HMAC-signed as `X-Mailpouch-Signature-256: sha256=<hex>` (GitHub-webhook convention). Delivery retries up to 8 times with exponential backoff (1 / 2 / 4 / 8 / 16 / 32 / 64 / 128 s) plus ±20 % jitter; 4xx responses other than 408 and 429 stop retries immediately.
 
 Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), [`src/notifications/webhooks.ts`](src/notifications/webhooks.ts).
 
@@ -481,7 +481,7 @@ Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), 
 - Export the Bridge TLS certificate: Bridge app → **Settings → Export TLS certificates**.
 - Set the path in the settings UI under **Setup → Bridge TLS Certificate**.
 
-> The server refuses to connect to a localhost Bridge without a pinned TLS certificate — this matches Proton Bridge's own v3.21.2+ hardening. If you cannot provide a cert, set **Allow insecure Bridge connection** under Setup (or launch with `PM_BRIDGE_MCP_INSECURE_BRIDGE=1`) to opt back into the legacy behavior. Configs that predate this change are grandfathered into the legacy mode with a startup warning until the opt-in is set explicitly.
+> The server refuses to connect to a localhost Bridge without a pinned TLS certificate — this matches Proton Bridge's own v3.21.2+ hardening. If you cannot provide a cert, set **Allow insecure Bridge connection** under Setup (or launch with `MAILPOUCH_INSECURE_BRIDGE=1`) to opt back into the legacy behavior. Configs that predate this change are grandfathered into the legacy mode with a startup warning until the opt-in is set explicitly.
 
 ### Bridge version warning on startup
 
@@ -498,12 +498,12 @@ Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), 
 - For OAuth clients, check that `/oauth/register` succeeded and the access token has not been revoked or expired.
 - The `WWW-Authenticate` header on the 401 response carries the failure reason per RFC 6750.
 
-### Claude Desktop doesn't show pm-bridge-mcp tools
+### Claude Desktop doesn't show mailpouch tools
 
 - Confirm the `mcpServers` block is valid JSON (no trailing commas).
 - Fully quit and reopen Claude Desktop.
 - Check MCP logs: **Help → Show Logs**.
-- Verify the server starts manually: `npx pm-bridge-mcp` — it should stay running silently.
+- Verify the server starts manually: `npx mailpouch` — it should stay running silently.
 
 ### Analytics show zero or empty data
 
@@ -515,8 +515,8 @@ Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), 
 ## Development
 
 ```bash
-git clone https://github.com/chandshy/pm-bridge-mcp.git
-cd pm-bridge-mcp
+git clone https://github.com/chandshy/mailpouch.git
+cd mailpouch
 npm install
 
 npm run build          # compile TypeScript to dist/
@@ -574,9 +574,9 @@ src/
 
 ## Works Best With…
 
-pm-bridge-mcp is deliberately scoped to email. Chain it with these MCP servers to cover the rest of an agentic workflow:
+mailpouch is deliberately scoped to email. Chain it with these MCP servers to cover the rest of an agentic workflow:
 
-| MCP server | Use with pm-bridge-mcp |
+| MCP server | Use with mailpouch |
 |---|---|
 | [`filesystem`](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem) (reference) | Save attachments to disk; read local files to attach to outgoing mail |
 | [`fetch`](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) (reference) | Follow links the agent reads in an email without leaving the chat |
@@ -602,4 +602,4 @@ MIT — see [LICENSE](LICENSE)
 
 *Unofficial third-party server. Not affiliated with or endorsed by Proton AG.*
 
-[GitHub](https://github.com/chandshy/pm-bridge-mcp) · [npm](https://www.npmjs.com/package/pm-bridge-mcp) · [Issues](https://github.com/chandshy/pm-bridge-mcp/issues) · [Model Context Protocol](https://modelcontextprotocol.io)
+[GitHub](https://github.com/chandshy/mailpouch) · [npm](https://www.npmjs.com/package/mailpouch) · [Issues](https://github.com/chandshy/mailpouch/issues) · [Model Context Protocol](https://modelcontextprotocol.io)

--- a/README_FIRST_AI.md
+++ b/README_FIRST_AI.md
@@ -1,7 +1,7 @@
-# pm-bridge-mcp — AI Agent Guide
+# mailpouch — AI Agent Guide
 
 > **Read this before using any tools.** This document is written for AI agents
-> (Claude, GPT, Gemini, etc.) operating through the pm-bridge-mcp server. It
+> (Claude, GPT, Gemini, etc.) operating through the mailpouch server. It
 > covers what each tool does, when to use it, the permission model, limits you
 > must respect, and how to handle errors correctly.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ If you discover a security vulnerability, please send an email to **chandshy@gma
 The server implements a 10-layer defense-in-depth security model:
 
 ### 1. Permission Gate
-- Every tool call checked against `~/.pm-bridge-mcp.json` (refreshed every 15s)
+- Every tool call checked against `~/.mailpouch.json` (refreshed every 15s)
 - 4 presets: read_only (default), supervised, send_only, full
 - Per-tool enable/disable and rate limiting
 
@@ -46,7 +46,7 @@ The server implements a 10-layer defense-in-depth security model:
 - Human must type "APPROVE" before confirmation button activates
 
 ### 4. Audit Trail
-- Append-only log at `~/.pm-bridge-mcp.audit.jsonl`
+- Append-only log at `~/.mailpouch.audit.jsonl`
 - Records all escalation requests, approvals, and denials
 
 ### 5. CSRF Protection
@@ -82,7 +82,7 @@ When using this MCP server:
 
 ### Credential Management
 - **Never commit** credentials to version control
-- Credentials are stored in `~/.pm-bridge-mcp.json` (mode 0600) or your OS keychain — never in environment variables or `.env` files
+- Credentials are stored in `~/.mailpouch.json` (mode 0600) or your OS keychain — never in environment variables or `.env` files
 - Use **Proton Bridge passwords**, not your main Proton Mail password
 - Rotate credentials regularly
 
@@ -92,14 +92,14 @@ When using this MCP server:
 - The server accepts self-signed certificates for localhost only when no cert is configured
 
 ### Access Control
-- Config file at `~/.pm-bridge-mcp.json` is written with mode 0600
+- Config file at `~/.mailpouch.json` is written with mode 0600
 - Start with **read_only** preset and escalate only as needed
 - Use **supervised** preset for day-to-day agent use (rate-limited writes)
 - Reserve **full** preset for trusted, supervised workflows
 
 ### Data Protection
 - Email data is **cached in memory** only (cleared on restart, capped at 500 entries per fetch)
-- **Scheduled emails** are persisted to `~/.pm-bridge-mcp-scheduled.json` (mode 0600, atomic writes) so they survive restarts. This file contains email metadata (recipients, subject, body) — protect it accordingly.
+- **Scheduled emails** are persisted to `~/.mailpouch-scheduled.json` (mode 0600, atomic writes) so they survive restarts. This file contains email metadata (recipients, subject, body) — protect it accordingly.
 - No persistent storage of email content beyond the scheduled email queue
 - Logs are sanitized (no full email bodies)
 - Audit log contains escalation metadata only (no email content)
@@ -126,4 +126,4 @@ Security patches will be released as:
 
 ---
 
-Thank you for helping keep pm-bridge-mcp secure!
+Thank you for helping keep mailpouch secure!

--- a/docs/agentic-mcp-design-review.md
+++ b/docs/agentic-mcp-design-review.md
@@ -1,4 +1,4 @@
-# Agentic MCP Design Review — pm-bridge-mcp
+# Agentic MCP Design Review — mailpouch
 
 **Researched:** 2026-03-17 | **Updated:** 2026-03-17 | **Sources:** modelcontextprotocol.io specification (2025-11-25)
 
@@ -37,7 +37,7 @@ Settings UI (browser or TUI)
   ↓
 Choose preset or configure per-tool
   ↓
-Config saved to ~/.pm-bridge-mcp.json (mode 0600)
+Config saved to ~/.mailpouch.json (mode 0600)
   ↓
 MCP server reloads every 15s → takes effect immediately
 ```
@@ -54,7 +54,7 @@ MCP server reloads every 15s → takes effect immediately
 1. Permission gate — every tool checked against config (15s refresh)
 2. Rate limiting — per-tool limits enforced in MCP server
 3. Escalation gate — privilege increases require explicit human approval (separate channel)
-4. Audit log — append-only at `~/.pm-bridge-mcp.audit.jsonl`
+4. Audit log — append-only at `~/.mailpouch.audit.jsonl`
 5. CSRF protection — all mutating API calls require session token
 6. Origin validation — settings server checks Origin/Referer headers
 7. Input validation — email addresses, folder names, attachment sizes, hostnames

--- a/docs/proton-bridge-security-model.md
+++ b/docs/proton-bridge-security-model.md
@@ -21,7 +21,7 @@ Proton Mail Bridge is a desktop app that runs locally, connects to Proton's serv
 | Mailbox password | Hashed + salted, stored in OS keychain |
 | Bridge password | Stored in OS keychain |
 
-Bridge generates a **unique Bridge password** for email client access. This is different from the Proton Mail account password and is the `password` field in `~/.pm-bridge-mcp.json`.
+Bridge generates a **unique Bridge password** for email client access. This is different from the Proton Mail account password and is the `password` field in `~/.mailpouch.json`.
 
 ---
 

--- a/docs/smtp-imap-config-reference.md
+++ b/docs/smtp-imap-config-reference.md
@@ -67,7 +67,7 @@ The Bridge setting to switch: **Bridge Settings → Connection method → STARTT
 
 ## Configuration for This Project
 
-Connection settings and credentials are stored in `~/.pm-bridge-mcp.json` (mode 0600).
+Connection settings and credentials are stored in `~/.mailpouch.json` (mode 0600).
 **No environment variables are used for credentials** — this prevents accidental exposure to
 other processes and shell history. Run `npm run settings` to open the settings UI and configure.
 
@@ -95,4 +95,4 @@ other processes and shell history. Run `npm run settings` to open the settings U
 - `bridgeCertPath` — path to the TLS certificate exported from Bridge → Settings → Export TLS certificates. Leave empty to skip cert validation (not recommended).
 - `tlsMode` — `"starttls"` (default, correct for Bridge on ports 1025/1143) or `"ssl"` (implicit TLS, for ports 465/993 if Bridge is configured for SSL mode).
 
-The config file path can be overridden with the `PM_BRIDGE_MCP_CONFIG` environment variable (must point to a path within the home directory). The legacy `PROTONMAIL_MCP_CONFIG` name is still accepted for one release.
+The config file path can be overridden with the `MAILPOUCH_CONFIG` environment variable (must point to a path within the home directory). The legacy `PM_BRIDGE_MCP_CONFIG` and `PROTONMAIL_MCP_CONFIG` names are still accepted through v3.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "pm-bridge-mcp",
-  "version": "2.1.0",
+  "name": "mailpouch",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pm-bridge-mcp",
-      "version": "2.1.0",
+      "name": "mailpouch",
+      "version": "2.2.0",
       "license": "MIT",
       "os": [
         "darwin",
@@ -20,8 +20,8 @@
         "nodemailer": "~8.0.2"
       },
       "bin": {
-        "pm-bridge-mcp": "dist/index.js",
-        "pm-bridge-mcp-settings": "dist/settings-main.js"
+        "mailpouch": "dist/index.js",
+        "mailpouch-settings": "dist/settings-main.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "pm-bridge-mcp",
-  "version": "2.1.0",
-  "description": "MCP server that exposes Proton Mail via Proton Bridge — 51 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
+  "name": "mailpouch",
+  "version": "2.2.0",
+  "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 51 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "pm-bridge-mcp": "dist/index.js",
-    "pm-bridge-mcp-settings": "dist/settings-main.js"
+    "mailpouch": "dist/index.js",
+    "mailpouch-settings": "dist/settings-main.js"
   },
   "scripts": {
     "build": "tsc",
@@ -25,7 +25,9 @@
     "typecheck": "tsc --noEmit"
   },
   "keywords": [
+    "mailpouch",
     "proton-bridge",
+    "proton-mail",
     "mcp",
     "model-context-protocol",
     "email",
@@ -48,13 +50,13 @@
     "email": "chandshy@gmail.com"
   },
   "license": "MIT",
-  "homepage": "https://github.com/chandshy/pm-bridge-mcp#readme",
+  "homepage": "https://github.com/chandshy/mailpouch#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chandshy/pm-bridge-mcp.git"
+    "url": "git+https://github.com/chandshy/mailpouch.git"
   },
   "bugs": {
-    "url": "https://github.com/chandshy/pm-bridge-mcp/issues"
+    "url": "https://github.com/chandshy/mailpouch/issues"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/accounts/manager.ts
+++ b/src/accounts/manager.ts
@@ -7,7 +7,7 @@
  * Design notes
  *   - One ImapFlow connection per account. imapflow's documented pattern
  *     is "N separate clients" (no built-in pool); IDLE auto-runs per
- *     client. Memory is bounded because pm-bridge-mcp is single-user and
+ *     client. Memory is bounded because mailpouch is single-user and
  *     most users have ≤ 3 accounts.
  *   - Lazy connection: services are created per account at AccountManager
  *     construction, but the underlying IMAP socket only opens on first

--- a/src/accounts/registry.test.ts
+++ b/src/accounts/registry.test.ts
@@ -55,7 +55,7 @@ import { defaultConfig } from "../config/loader.js";
 function seedConfig(cfg: Partial<ServerConfig>): void {
   const base = defaultConfig();
   const merged = { ...base, ...cfg };
-  const path = `${process.env.HOME || "/home/chuck"}/.pm-bridge-mcp.json`;
+  const path = `${process.env.HOME || "/home/chuck"}/.mailpouch.json`;
   diskByPath.set(path, JSON.stringify(merged));
 }
 
@@ -164,7 +164,7 @@ describe("accounts registry", () => {
     });
     setActiveAccount(other.id);
     // Loading config should now show the mirrored settings.
-    const path = `${process.env.HOME || "/home/chuck"}/.pm-bridge-mcp.json`;
+    const path = `${process.env.HOME || "/home/chuck"}/.mailpouch.json`;
     const cfg = JSON.parse(diskByPath.get(path) ?? "{}") as ServerConfig;
     expect(cfg.connection.smtpHost).toBe("smtp.other");
     expect(cfg.activeAccountId).toBe(other.id);

--- a/src/agents/audit.test.ts
+++ b/src/agents/audit.test.ts
@@ -7,7 +7,7 @@ import { randomBytes } from "crypto";
 import { gunzipSync } from "zlib";
 
 function tmpPath(): string {
-  return join(tmpdir(), `pm-bridge-audit-${randomBytes(6).toString("hex")}.jsonl`);
+  return join(tmpdir(), `mailpouch-audit-${randomBytes(6).toString("hex")}.jsonl`);
 }
 
 describe("hashArgs", () => {

--- a/src/agents/audit.ts
+++ b/src/agents/audit.ts
@@ -7,7 +7,7 @@
  * a truncated sha256 hash of the args instead so "same call repeated" is
  * observable without content leakage.
  *
- * File: ~/.pm-bridge-mcp-agent-audit.jsonl (0600)
+ * File: ~/.mailpouch-agent-audit.jsonl (0600)
  * Rotation: when current file exceeds ROTATE_BYTES, rename to .1.gz and
  *           start fresh. Keep KEEP_GENERATIONS compressed generations.
  */
@@ -105,7 +105,7 @@ export class AgentAuditLog {
 /**
  * Truncated sha256 of JSON.stringify(args). Gives us a stable "same args"
  * fingerprint without storing the content. 16 hex chars = 64 bits of
- * collision resistance, plenty for a dedup hint at pm-bridge scale.
+ * collision resistance, plenty for a dedup hint at mailpouch scale.
  */
 export function hashArgs(args: unknown): string {
   if (args === undefined || args === null) return "";

--- a/src/agents/grant-manager.test.ts
+++ b/src/agents/grant-manager.test.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "os";
 import { randomBytes } from "crypto";
 
 function tmpPath(): string {
-  return join(tmpdir(), `pm-bridge-grant-mgr-${randomBytes(6).toString("hex")}.json`);
+  return join(tmpdir(), `mailpouch-grant-mgr-${randomBytes(6).toString("hex")}.json`);
 }
 
 describe("GrantManager.check", () => {

--- a/src/agents/grant-store.test.ts
+++ b/src/agents/grant-store.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "os";
 import { randomBytes } from "crypto";
 
 function tmpPath(): string {
-  return join(tmpdir(), `pm-bridge-agents-${randomBytes(6).toString("hex")}.json`);
+  return join(tmpdir(), `mailpouch-agents-${randomBytes(6).toString("hex")}.json`);
 }
 
 describe("AgentGrantStore", () => {

--- a/src/agents/grant-store.ts
+++ b/src/agents/grant-store.ts
@@ -1,7 +1,7 @@
 /**
  * Persistence for {@link AgentGrant} records.
  *
- * A single JSON file (`~/.pm-bridge-mcp-agents.json`) holds every grant the
+ * A single JSON file (`~/.mailpouch-agents.json`) holds every grant the
  * server has ever seen, across all three statuses. Writes are atomic via
  * tmp→rename, consistent with the rest of the project's credential-hygiene
  * story. The file is mode 0600.

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the agent-grant system.
  *
- * A pm-bridge-mcp deployment typically serves more than one MCP client
+ * A mailpouch deployment typically serves more than one MCP client
  * (Claude Desktop, Claude Code, other hosts). Every client identifies
  * itself via an OAuth client_id issued by DCR. An AgentGrant records the
  * user's decision about that specific client: is it approved, what can

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -169,66 +169,96 @@ describe("defaultConfig", () => {
 });
 
 describe("getConfigPath", () => {
-  it("returns default path when no env var is set and no legacy file exists", () => {
-    const existsMock = vi.mocked(existsSync);
-    const saved = process.env.PROTONMAIL_MCP_CONFIG;
-    const saved2 = process.env.PM_BRIDGE_MCP_CONFIG;
-    delete process.env.PROTONMAIL_MCP_CONFIG;
-    delete process.env.PM_BRIDGE_MCP_CONFIG;
-    existsMock.mockReturnValue(false);
-    try {
-      expect(getConfigPath()).toBe(join(homedir(), ".pm-bridge-mcp.json"));
-    } finally {
-      if (saved !== undefined) process.env.PROTONMAIL_MCP_CONFIG = saved;
-      if (saved2 !== undefined) process.env.PM_BRIDGE_MCP_CONFIG = saved2;
-      existsMock.mockReset();
+  const ENV_KEYS = ["MAILPOUCH_CONFIG", "PM_BRIDGE_MCP_CONFIG", "PROTONMAIL_MCP_CONFIG"] as const;
+  function withCleanEnv<T>(fn: () => T): T {
+    const saved: Record<string, string | undefined> = {};
+    for (const k of ENV_KEYS) { saved[k] = process.env[k]; delete process.env[k]; }
+    try { return fn(); } finally {
+      for (const k of ENV_KEYS) {
+        if (saved[k] !== undefined) process.env[k] = saved[k];
+        else delete process.env[k];
+      }
     }
+  }
+
+  it("returns the new ~/.mailpouch.json default when no env var is set and no legacy file exists", () => {
+    const existsMock = vi.mocked(existsSync);
+    existsMock.mockReturnValue(false);
+    withCleanEnv(() => {
+      expect(getConfigPath()).toBe(join(homedir(), ".mailpouch.json"));
+    });
+    existsMock.mockReset();
   });
 
-  it("falls back to the legacy ~/.protonmail-mcp.json when the new path doesn't exist and the legacy one does", () => {
+  it("falls back to ~/.pm-bridge-mcp.json when only the v2.1 legacy path exists", () => {
     const existsMock = vi.mocked(existsSync);
-    const saved = process.env.PROTONMAIL_MCP_CONFIG;
-    const saved2 = process.env.PM_BRIDGE_MCP_CONFIG;
-    delete process.env.PROTONMAIL_MCP_CONFIG;
-    delete process.env.PM_BRIDGE_MCP_CONFIG;
+    const legacy = join(homedir(), ".pm-bridge-mcp.json");
+    existsMock.mockImplementation((p: unknown) => p === legacy);
+    withCleanEnv(() => {
+      expect(getConfigPath()).toBe(legacy);
+    });
+    existsMock.mockReset();
+  });
+
+  it("falls back to ~/.protonmail-mcp.json when only the original legacy path exists", () => {
+    const existsMock = vi.mocked(existsSync);
     const legacy = join(homedir(), ".protonmail-mcp.json");
     existsMock.mockImplementation((p: unknown) => p === legacy);
-    try {
+    withCleanEnv(() => {
       expect(getConfigPath()).toBe(legacy);
-    } finally {
-      if (saved !== undefined) process.env.PROTONMAIL_MCP_CONFIG = saved;
-      if (saved2 !== undefined) process.env.PM_BRIDGE_MCP_CONFIG = saved2;
-      existsMock.mockReset();
-    }
+    });
+    existsMock.mockReset();
   });
 
-  it("respects PROTONMAIL_MCP_CONFIG env var when path is within home dir", () => {
-    const saved = process.env.PROTONMAIL_MCP_CONFIG;
-    const customPath = join(homedir(), "custom-config.json");
-    process.env.PROTONMAIL_MCP_CONFIG = customPath;
-    try {
+  it("prefers the v2.1 legacy path over the original when both legacies exist", () => {
+    const existsMock = vi.mocked(existsSync);
+    const pmBridge = join(homedir(), ".pm-bridge-mcp.json");
+    const proton = join(homedir(), ".protonmail-mcp.json");
+    existsMock.mockImplementation((p: unknown) => p === pmBridge || p === proton);
+    withCleanEnv(() => {
+      expect(getConfigPath()).toBe(pmBridge);
+    });
+    existsMock.mockReset();
+  });
+
+  it("respects MAILPOUCH_CONFIG env var when path is within home dir (new name wins)", () => {
+    withCleanEnv(() => {
+      const customPath = join(homedir(), "custom-mailpouch.json");
+      process.env.MAILPOUCH_CONFIG = customPath;
       expect(getConfigPath()).toBe(customPath);
-    } finally {
-      if (saved !== undefined) {
-        process.env.PROTONMAIL_MCP_CONFIG = saved;
-      } else {
-        delete process.env.PROTONMAIL_MCP_CONFIG;
-      }
-    }
+    });
   });
 
-  it("throws when PROTONMAIL_MCP_CONFIG points outside home dir", () => {
-    const saved = process.env.PROTONMAIL_MCP_CONFIG;
-    process.env.PROTONMAIL_MCP_CONFIG = "/tmp/evil-config.json";
-    try {
+  it("honors PM_BRIDGE_MCP_CONFIG when MAILPOUCH_CONFIG is absent", () => {
+    withCleanEnv(() => {
+      const customPath = join(homedir(), "custom-v21.json");
+      process.env.PM_BRIDGE_MCP_CONFIG = customPath;
+      expect(getConfigPath()).toBe(customPath);
+    });
+  });
+
+  it("honors PROTONMAIL_MCP_CONFIG when the newer env names are absent", () => {
+    withCleanEnv(() => {
+      const customPath = join(homedir(), "custom-v1.json");
+      process.env.PROTONMAIL_MCP_CONFIG = customPath;
+      expect(getConfigPath()).toBe(customPath);
+    });
+  });
+
+  it("MAILPOUCH_CONFIG wins when every alias is set (priority chain)", () => {
+    withCleanEnv(() => {
+      process.env.MAILPOUCH_CONFIG = join(homedir(), "a.json");
+      process.env.PM_BRIDGE_MCP_CONFIG = join(homedir(), "b.json");
+      process.env.PROTONMAIL_MCP_CONFIG = join(homedir(), "c.json");
+      expect(getConfigPath()).toBe(join(homedir(), "a.json"));
+    });
+  });
+
+  it("throws when MAILPOUCH_CONFIG points outside home dir", () => {
+    withCleanEnv(() => {
+      process.env.MAILPOUCH_CONFIG = "/tmp/evil-config.json";
       expect(() => getConfigPath()).toThrow("must point to a path within the home directory");
-    } finally {
-      if (saved !== undefined) {
-        process.env.PROTONMAIL_MCP_CONFIG = saved;
-      } else {
-        delete process.env.PROTONMAIL_MCP_CONFIG;
-      }
-    }
+    });
   });
 });
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,10 +1,11 @@
 /**
- * Config file loader / saver for pm-bridge-mcp.
+ * Config file loader / saver for mailpouch.
  *
- * Config is persisted to a single JSON file (default: ~/.pm-bridge-mcp.json,
- * with read-fallback to the legacy ~/.protonmail-mcp.json for installs that
- * predate the rename). Override the path with the PM_BRIDGE_MCP_CONFIG env var
- * (the legacy PROTONMAIL_MCP_CONFIG name is also accepted for one release).
+ * Config is persisted to a single JSON file (default: ~/.mailpouch.json),
+ * with read-fallback to ~/.pm-bridge-mcp.json (v2.1) and ~/.protonmail-mcp.json
+ * (original) for installs that predate the rename. Override the path with the
+ * MAILPOUCH_CONFIG env var — the legacy PM_BRIDGE_MCP_CONFIG / PROTONMAIL_MCP_CONFIG
+ * names are also accepted through v3.0.
  *
  * On Unix systems the file is written with mode 0600 (owner-read/write only)
  * to reduce the risk of credential exposure.
@@ -43,7 +44,11 @@ function clamp(value: number, min: number, max: number): number {
 // ─── Config path ───────────────────────────────────────────────────────────────
 
 export function getConfigPath(): string {
-  const envPath = process.env.PM_BRIDGE_MCP_CONFIG ?? process.env.PROTONMAIL_MCP_CONFIG;
+  // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_MCP_*. First
+  // truthy wins. Legacy names honored through v3.0.
+  const envPath = process.env.MAILPOUCH_CONFIG
+    ?? process.env.PM_BRIDGE_MCP_CONFIG
+    ?? process.env.PROTONMAIL_MCP_CONFIG;
   if (envPath) {
     // Resolve to absolute path and ensure it stays within the user's home
     // directory — prevents path-traversal attacks (e.g. "../../etc/passwd").
@@ -51,16 +56,21 @@ export function getConfigPath(): string {
     const home = homedir();
     if (!resolved.startsWith(home + "/") && !resolved.startsWith(home + "\\") && resolved !== home) {
       throw new Error(
-        `PM_BRIDGE_MCP_CONFIG must point to a path within the home directory (${home}). Got: ${resolved}`
+        `MAILPOUCH_CONFIG must point to a path within the home directory (${home}). Got: ${resolved}`
       );
     }
     return resolved;
   }
-  // Prefer the new path, but fall back to the legacy ~/.protonmail-mcp.json
-  // if it exists and the new one doesn't — keeps existing installs working.
-  const preferred = join(homedir(), ".pm-bridge-mcp.json");
-  const legacy = join(homedir(), ".protonmail-mcp.json");
-  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  // Prefer the new path; fall back through the rename chain if only a legacy
+  // path exists — keeps existing installs working. Writes always use the new
+  // path, so this only fires once per install.
+  const preferred = join(homedir(), ".mailpouch.json");
+  const legacyV2 = join(homedir(), ".pm-bridge-mcp.json");
+  const legacyV1 = join(homedir(), ".protonmail-mcp.json");
+  if (!existsSync(preferred)) {
+    if (existsSync(legacyV2)) return legacyV2;
+    if (existsSync(legacyV1)) return legacyV1;
+  }
   return preferred;
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Configuration schema for pm-bridge-mcp
+ * Configuration schema for mailpouch
  * Covers connection settings and per-tool agentic access permissions.
  */
 
@@ -173,7 +173,7 @@ export interface ConnectionSettings {
   /**
    * Explicit opt-in to run IMAP/SMTP against localhost Bridge without a pinned cert.
    * Default false — the services throw at startup if localhost is used with neither
-   * a loaded cert nor this flag. Override per-launch with PM_BRIDGE_MCP_INSECURE_BRIDGE=1.
+   * a loaded cert nor this flag. Override per-launch with MAILPOUCH_INSECURE_BRIDGE=1.
    */
   allowInsecureBridge?: boolean;
   /**
@@ -187,7 +187,7 @@ export interface ConnectionSettings {
   /** Explicit path to the Proton Bridge executable. Leave blank to auto-detect. */
   bridgePath?: string;
   /**
-   * Remote (HTTP) transport mode. When true, pm-bridge-mcp listens on an
+   * Remote (HTTP) transport mode. When true, mailpouch listens on an
    * HTTP port for MCP requests instead of stdio, gated by a bearer token.
    * Default false — stdio transport, which is what Claude Desktop spawns.
    */
@@ -353,7 +353,7 @@ export interface ServerConfig {
    *   "core"     — reading / sending / analytics / system (~20 tools)
    *   "extended" — core + drafts / folders / actions
    *   "complete" — all tools (default, preserves current behavior)
-   * Override per-launch with PM_BRIDGE_MCP_TIER.
+   * Override per-launch with MAILPOUCH_TIER.
    */
   toolTier?: ToolTier;
   /**
@@ -403,7 +403,7 @@ export const DESTRUCTIVE_TOOLS: ReadonlySet<string> = new Set<string>([
 // burn tens of thousands of tokens before the user types anything.
 //
 // Tiering lets operators expose only the tools they actually use. Activate via
-// the PM_BRIDGE_MCP_TIER env var (core|extended|complete; default complete) or
+// the MAILPOUCH_TIER env var (core|extended|complete; default complete) or
 // the `toolTier` field in the config file.
 
 export type ToolTier = "core" | "extended" | "complete";

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import { logger, getLogFilePath } from "./utils/logger.js";
 import { isValidEmail, validateTargetFolder, requireNumericEmailId } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
 import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain } from "./config/loader.js";
+import { migrateLegacyKeychainEntries } from "./security/keychain.js";
 import type { ToolName } from "./config/schema.js";
 import { DESTRUCTIVE_TOOLS, toolsForTier, parseToolTier } from "./config/schema.js";
 
@@ -111,7 +112,7 @@ function confirmGateFallbackResponse(name: string, preview: string): {
         `${preview}\n\n` +
         `This tool is destructive. Retry the call with the exact same arguments plus ` +
         `{ "confirmed": true } — the user will see the confirmation flag in the tool call and can cancel it. ` +
-        `Set requireDestructiveConfirm: false in ~/.pm-bridge-mcp.json to disable this guard system-wide.`,
+        `Set requireDestructiveConfirm: false in ~/.mailpouch.json to disable this guard system-wide.`,
     }],
     isError: false,
     structuredContent: { success: false, confirmationRequired: true, tool: name, preview },
@@ -123,7 +124,7 @@ import { allToolDefs, allHandlers, escalationHandlers, describeRequestEscalation
 import type { ToolCallContext, ToolSharedState } from "./tools/types.js";
 
 // ─── Service Initialization ───────────────────────────────────────────────────
-// All credentials and connection settings are loaded from ~/.pm-bridge-mcp.json
+// All credentials and connection settings are loaded from ~/.mailpouch.json
 // and the OS keychain in main(). No credentials are read from environment variables
 // to prevent accidental exposure to other processes.
 
@@ -167,34 +168,70 @@ accountManager.on("active-changed", (ev: { services: { imap: SimpleIMAPService; 
 let simpleloginService = new SimpleLoginService("");
 const analyticsService = new AnalyticsService();
 
-// Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-// New wins; legacy is silently honored for one release. Remove the
-// PROTONMAIL_SCHEDULER_STORE alias in v2.2.
+// Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_*. Legacy names
+// honored through v3.0.
 function _resolveSchedulerStorePath(): string {
-  const envPath = process.env.PM_BRIDGE_MCP_SCHEDULER_STORE
+  const envPath = process.env.MAILPOUCH_SCHEDULER_STORE
+    || process.env.PM_BRIDGE_MCP_SCHEDULER_STORE
     || process.env.PROTONMAIL_SCHEDULER_STORE;
   if (envPath) return envPath;
   const home = process.env.HOME || process.env.USERPROFILE || ".";
   // Read-old/write-new: keep using the legacy file if it exists and the new
   // one doesn't, so a queue of pending scheduled emails survives the rename.
-  const preferred = `${home}/.pm-bridge-mcp-scheduled.json`;
-  const legacy = `${home}/.protonmail-mcp-scheduled.json`;
-  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  const preferred = `${home}/.mailpouch-scheduled.json`;
+  const legacyV2 = `${home}/.pm-bridge-mcp-scheduled.json`;
+  const legacyV1 = `${home}/.protonmail-mcp-scheduled.json`;
+  if (!existsSync(preferred)) {
+    if (existsSync(legacyV2)) { logger.info(`Using legacy scheduler store ${legacyV2}`, "MCPServer"); return legacyV2; }
+    if (existsSync(legacyV1)) { logger.info(`Using legacy scheduler store ${legacyV1}`, "MCPServer"); return legacyV1; }
+  }
   return preferred;
 }
 const SCHEDULER_STORE = _resolveSchedulerStorePath();
 const schedulerService = new SchedulerService(smtpService, SCHEDULER_STORE);
 
-const REMINDERS_STORE = process.env.PM_BRIDGE_MCP_REMINDERS
-  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-reminders.json`;
+/**
+ * Resolve a per-feature file path by checking env-var aliases in priority
+ * order (MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_*), then falling back
+ * through the matching on-disk defaults. Logs when a legacy path is hit so
+ * operators notice the migration.
+ */
+function _resolveHomeFile(
+  envNames: readonly [string, ...string[]],
+  basenames: readonly [string, ...string[]],
+): string {
+  for (const name of envNames) {
+    const v = process.env[name];
+    if (v) return v;
+  }
+  const home = process.env.HOME || process.env.USERPROFILE || ".";
+  const [preferredBase, ...legacyBases] = basenames;
+  const preferred = `${home}/${preferredBase}`;
+  if (!existsSync(preferred)) {
+    for (const b of legacyBases) {
+      const p = `${home}/${b}`;
+      if (existsSync(p)) { logger.info(`Using legacy path ${p}`, "MCPServer"); return p; }
+    }
+  }
+  return preferred;
+}
+
+const REMINDERS_STORE = _resolveHomeFile(
+  ["MAILPOUCH_REMINDERS", "PM_BRIDGE_MCP_REMINDERS"],
+  [".mailpouch-reminders.json", ".pm-bridge-mcp-reminders.json"],
+);
 const reminderService = new ReminderService(REMINDERS_STORE);
 
-const PASS_AUDIT_PATH = process.env.PM_BRIDGE_MCP_PASS_AUDIT
-  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-pass-audit.jsonl`;
+const PASS_AUDIT_PATH = _resolveHomeFile(
+  ["MAILPOUCH_PASS_AUDIT", "PM_BRIDGE_MCP_PASS_AUDIT"],
+  [".mailpouch-pass-audit.jsonl", ".pm-bridge-mcp-pass-audit.jsonl"],
+);
 let passService: PassService | null = null;
 
-const FTS_DB_PATH = process.env.PM_BRIDGE_MCP_FTS_DB
-  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-fts.db`;
+const FTS_DB_PATH = _resolveHomeFile(
+  ["MAILPOUCH_FTS_DB", "PM_BRIDGE_MCP_FTS_DB"],
+  [".mailpouch-fts.db", ".pm-bridge-mcp-fts.db"],
+);
 let ftsService: FtsIndexService | null = null;
 
 function getFts(): FtsIndexService {
@@ -222,10 +259,14 @@ function recordFromEmail(m: EmailMessage): FtsRecord {
 // gate is consistent whether the transport is stdio or HTTP — but stdio
 // callers fall through to the global preset (no caller context), which
 // preserves the single-user Claude Desktop default.
-const AGENT_GRANTS_PATH = process.env.PM_BRIDGE_MCP_AGENTS
-  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-agents.json`;
-const AGENT_AUDIT_PATH = process.env.PM_BRIDGE_MCP_AGENT_AUDIT
-  || `${process.env.HOME || process.env.USERPROFILE || "."}/.pm-bridge-mcp-agent-audit.jsonl`;
+const AGENT_GRANTS_PATH = _resolveHomeFile(
+  ["MAILPOUCH_AGENTS", "PM_BRIDGE_MCP_AGENTS"],
+  [".mailpouch-agents.json", ".pm-bridge-mcp-agents.json"],
+);
+const AGENT_AUDIT_PATH = _resolveHomeFile(
+  ["MAILPOUCH_AGENT_AUDIT", "PM_BRIDGE_MCP_AGENT_AUDIT"],
+  [".mailpouch-agent-audit.jsonl", ".pm-bridge-mcp-agent-audit.jsonl"],
+);
 const agentGrants = new AgentGrantStore(AGENT_GRANTS_PATH);
 const grantManager = new GrantManager(agentGrants);
 const agentAudit = new AgentAuditLog({ path: AGENT_AUDIT_PATH });
@@ -242,13 +283,13 @@ agentNotifications.subscribe((ev) => {
   // Desktop: default ON; only skip when explicitly disabled.
   if (cfg?.desktopNotificationsEnabled !== false) {
     const titleByKind: Record<string, string> = {
-      "grant-created":  "pm-bridge-mcp — agent awaiting approval",
-      "grant-approved": "pm-bridge-mcp — agent approved",
-      "grant-denied":   "pm-bridge-mcp — agent denied",
-      "grant-revoked":  "pm-bridge-mcp — agent revoked",
-      "grant-expired":  "pm-bridge-mcp — agent expired",
+      "grant-created":  "mailpouch — agent awaiting approval",
+      "grant-approved": "mailpouch — agent approved",
+      "grant-denied":   "mailpouch — agent denied",
+      "grant-revoked":  "mailpouch — agent revoked",
+      "grant-expired":  "mailpouch — agent expired",
     };
-    const title = titleByKind[ev.kind] ?? "pm-bridge-mcp";
+    const title = titleByKind[ev.kind] ?? "mailpouch";
     const body = `${ev.grant.clientName}`;
     // Fire-and-forget — notifier failures never touch the caller.
     void desktopNotifier.notify({ title, body, sound: ev.kind === "grant-created" ? "Glass" : undefined })
@@ -423,7 +464,7 @@ function truncateEmailBody(body: string, maxLength: number = 2000): string {
 // ─── MCP Server ───────────────────────────────────────────────────────────────
 
 const server = new Server(
-  { name: "pm-bridge-mcp", version: _pkgVersion },
+  { name: "mailpouch", version: _pkgVersion },
   {
     capabilities: {
       tools: { listChanged: false },
@@ -439,12 +480,14 @@ const server = new Server(
 
 /**
  * Resolve the active tool tier at the moment of the ListTools call. Order:
- *   1. PM_BRIDGE_MCP_TIER env var (per-launch override)
+ *   1. MAILPOUCH_TIER env var (per-launch override)
  *   2. config.toolTier (persisted)
  *   3. "complete" (default — preserves pre-tiering behavior)
  */
 function activeToolTier(): ReturnType<typeof parseToolTier> {
-  const envTier = process.env.PM_BRIDGE_MCP_TIER;
+  const envTier = process.env.MAILPOUCH_TIER
+    || process.env.PM_BRIDGE_MCP_TIER
+    || process.env.PROTONMAIL_MCP_TIER;
   if (envTier) return parseToolTier(envTier);
   const cfg = loadConfig();
   return parseToolTier(cfg?.toolTier);
@@ -581,7 +624,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 
   // ── Permission gate ───────────────────────────────────────────────────────
-  // Checked against ~/.pm-bridge-mcp.json (refreshed every 15 s).
+  // Checked against ~/.mailpouch.json (refreshed every 15 s).
   // If no config file exists the read-only preset is enforced — agents can
   // read and search but cannot send, move, delete, or modify email state.
   // Run `npm run settings` to open the settings UI and grant broader access.
@@ -1486,7 +1529,7 @@ function startBridgeWatchdog(): void {
         "MCPServer"
       );
       process.stderr.write(
-        `[pm-bridge-mcp] CRITICAL: Proton Bridge did not recover after ${BRIDGE_MAX_RESTARTS} restart attempts. ` +
+        `[mailpouch] CRITICAL: Proton Bridge did not recover after ${BRIDGE_MAX_RESTARTS} restart attempts. ` +
         "Start Bridge manually and restart the MCP server.\n"
       );
       if (bridgeWatchdogTimer) { clearInterval(bridgeWatchdogTimer); bridgeWatchdogTimer = null; }
@@ -1644,10 +1687,10 @@ function _buildTrayMenu(): SysTrayMenu {
   const pendingCount  = agentGrants.list({ status: "pending" }).length;
   const activeCount   = agentGrants.list({ status: "active" }).length;
   const tooltip = pendingCount > 0
-    ? `pm-bridge-mcp · ${pendingCount} agent(s) awaiting approval`
-    : "pm-bridge-mcp";
+    ? `mailpouch · ${pendingCount} agent(s) awaiting approval`
+    : "mailpouch";
   const items: MenuItem[] = [
-    { title: "pm-bridge-mcp", tooltip: "pm-bridge-mcp daemon", enabled: false, checked: false },
+    { title: "mailpouch", tooltip: "mailpouch daemon", enabled: false, checked: false },
     sep,
     { title: statusLabel, tooltip: "", enabled: false, checked: false },
     { title: emailLabel,  tooltip: "", enabled: false, checked: false },
@@ -1738,7 +1781,23 @@ async function main() {
   // Clear log file from previous run so each session starts fresh
   try { writeFileSync(getLogFilePath(), "", "utf8"); } catch { /* ignore */ }
 
-  logger.info(`Starting Proton Mail MCP Server v${_pkgVersion}`, "MCPServer");
+  logger.info(`Starting mailpouch v${_pkgVersion}`, "MCPServer");
+
+  // One-shot migration of legacy keychain service names to 'mailpouch'. Runs
+  // BEFORE any loadCredentialsFromKeychain() so the first read hits the new
+  // slot. Failures are non-fatal.
+  try {
+    const legacyResult = await migrateLegacyKeychainEntries();
+    if (legacyResult.migrated > 0) {
+      logger.info(
+        `Keychain: migrated ${legacyResult.migrated} legacy entry(ies) to 'mailpouch'` +
+        (legacyResult.conflicts > 0 ? ` (${legacyResult.conflicts} conflict(s) left in place)` : ""),
+        "MCPServer",
+      );
+    }
+  } catch (e: unknown) {
+    logger.debug("Legacy keychain migration skipped", "MCPServer", e);
+  }
 
   // Migrate plaintext credentials to OS keychain if available
   try {
@@ -1965,22 +2024,22 @@ async function main() {
         rateLimitBurst: remoteCn.remoteRateLimitBurst ?? undefined,
         agentGrants,
       });
-      logger.info(`pm-bridge-mcp started on HTTP transport at ${handle.url}${handle.issuer ? ` (OAuth issuer ${handle.issuer})` : ""}`, "MCPServer");
-      (globalThis as unknown as { __pmBridgeHttpHandle?: { close(): Promise<void> } }).__pmBridgeHttpHandle = handle;
+      logger.info(`mailpouch started on HTTP transport at ${handle.url}${handle.issuer ? ` (OAuth issuer ${handle.issuer})` : ""}`, "MCPServer");
+      (globalThis as unknown as { __mailpouchHttpHandle?: { close(): Promise<void> } }).__mailpouchHttpHandle = handle;
     } else {
       const transport = new StdioServerTransport();
       await server.connect(transport);
-      logger.info("pm-bridge-mcp started on stdio transport.", "MCPServer");
+      logger.info("mailpouch started on stdio transport.", "MCPServer");
     }
 
     // ── Daemon: start settings HTTP server + system tray ───────────────────
     // Both run alongside the MCP stdio transport. stdout is now owned by the
     // MCP protocol, so startSettingsServer is called with quiet=true.
     // Skip when running as a respawn child (stdio:ignore, no real MCP session).
-    // Honor either env name during the rename window — a child spawned by an
-    // older parent build sets PROTONMAIL_MCP_RESPAWN; a newer parent sets the
-    // PM_BRIDGE_MCP_RESPAWN form. Either one suppresses the daemon side-effects.
-    if (!process.env.PM_BRIDGE_MCP_RESPAWN && !process.env.PROTONMAIL_MCP_RESPAWN) {
+    // Honor any env name from the rename chain — children spawned by older
+    // parents may still set PROTONMAIL_MCP_RESPAWN or PM_BRIDGE_MCP_RESPAWN.
+    // Any one of them suppresses the daemon side-effects.
+    if (!process.env.MAILPOUCH_RESPAWN && !process.env.PM_BRIDGE_MCP_RESPAWN && !process.env.PROTONMAIL_MCP_RESPAWN) {
       await _startSettingsServerDaemon();
       _initTray().catch((err: unknown) => logger.warn("Tray init error", "MCPServer", err));
     }

--- a/src/notifications/desktop.ts
+++ b/src/notifications/desktop.ts
@@ -98,7 +98,7 @@ export class DesktopNotifier {
   }
 
   private async notifyLinux(n: DesktopNotification): Promise<{ ok: boolean; platform: string; reason?: string }> {
-    const args: string[] = ["--app-name=pm-bridge-mcp"];
+    const args: string[] = ["--app-name=mailpouch"];
     if (n.subtitle) {
       // notify-send doesn't have a subtitle; fold it into the body.
       args.push(n.title, `${n.subtitle}\n\n${n.body}`);
@@ -115,7 +115,7 @@ export class DesktopNotifier {
     // Inline PowerShell script uses the built-in WinRT toast API. No
     // module install required on Windows 10+; the AppID is fine as a
     // generic label since we don't care about Action Center grouping
-    // for a single pm-bridge-mcp deployment.
+    // for a single mailpouch deployment.
     const xml =
       `<toast><visual><binding template='ToastGeneric'>` +
       `<text>${n.title}</text>` +
@@ -129,7 +129,7 @@ export class DesktopNotifier {
       `$x = New-Object Windows.Data.Xml.Dom.XmlDocument;` +
       `$x.LoadXml('${escPowerShell(xml)}');` +
       `$t = [Windows.UI.Notifications.ToastNotification]::new($x);` +
-      `[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('pm-bridge-mcp').Show($t);`;
+      `[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('mailpouch').Show($t);`;
     const { code } = await this.run("powershell.exe", ["-NoProfile", "-Command", ps]);
     return code === 0 ? { ok: true, platform: "win32" } : { ok: false, platform: "win32", reason: `powershell exit ${code}` };
   }

--- a/src/notifications/webhooks.test.ts
+++ b/src/notifications/webhooks.test.ts
@@ -71,7 +71,8 @@ describe("buildPayload", () => {
   it("produces a CloudEvents 1.0 envelope", () => {
     const p = buildPayload(stubEvent("grant-created"), "cloudevents");
     expect(p.specversion).toBe("1.0");
-    expect(p.type).toBe("com.pmbridge.grant.created");
+    expect(p.type).toBe("com.mailpouch.grant.created");
+    expect(p.source).toBe("mailpouch");
     expect((p.data as Record<string, unknown>).clientId).toBe("pmc_abc");
   });
 
@@ -121,7 +122,7 @@ describe("WebhookDispatcher.deliver — SSRF guard", () => {
 });
 
 describe("WebhookDispatcher.deliver", () => {
-  it("sends a POST with the payload and sets X-PMBridge-Signature-256 when a secret is set", async () => {
+  it("sends a POST with the payload, sets X-Mailpouch-Signature-256 when a secret is set, and advertises the mailpouch UA", async () => {
     let captured: { url: string; init: RequestInit } | null = null;
     const fetcher = vi.fn(async (url: string | URL | Request, init: RequestInit = {}) => {
       captured = { url: String(url), init };
@@ -135,8 +136,12 @@ describe("WebhookDispatcher.deliver", () => {
     expect(r.ok).toBe(true);
     expect(r.attempts).toBe(1);
     expect(captured).not.toBeNull();
-    const hdr = (captured!.init.headers as Record<string, string>)["X-PMBridge-Signature-256"];
+    const hdrs = captured!.init.headers as Record<string, string>;
+    const hdr = hdrs["X-Mailpouch-Signature-256"];
     expect(hdr).toMatch(/^sha256=[a-f0-9]{64}$/);
+    // The prior pm-bridge header name must no longer appear.
+    expect(hdrs["X-PMBridge-Signature-256"]).toBeUndefined();
+    expect(hdrs["User-Agent"]).toMatch(/^mailpouch\/1 /);
     // Verify the HMAC matches.
     const expected = createHmac("sha256", "shh").update(String(captured!.init.body), "utf-8").digest("hex");
     expect(hdr).toBe(`sha256=${expected}`);
@@ -153,7 +158,7 @@ describe("WebhookDispatcher.deliver", () => {
       { id: "w1", url: "https://hooks.example.com/x" },
       stubEvent("grant-created"),
     );
-    const hdr = (captured!.init.headers as Record<string, string>)["X-PMBridge-Signature-256"];
+    const hdr = (captured!.init.headers as Record<string, string>)["X-Mailpouch-Signature-256"];
     expect(hdr).toBeUndefined();
   });
 

--- a/src/notifications/webhooks.ts
+++ b/src/notifications/webhooks.ts
@@ -15,7 +15,7 @@
  *                              discord.com/api/webhooks URLs.
  *   "raw"                    — Send the raw grant JSON.
  *
- * Signing: every delivery carries an `X-PMBridge-Signature-256` header
+ * Signing: every delivery carries an `X-Mailpouch-Signature-256` header
  * whose value is `sha256=<hex>` of HMAC(body, secret) — matches the
  * GitHub webhook convention. No signing happens when the endpoint has
  * no secret configured.
@@ -129,10 +129,10 @@ export function buildPayload(ev: GrantChangedEvent, format: WebhookFormat): Reco
     (g.conditions?.expiresAt ? ` · expires ${g.conditions.expiresAt}` : "");
 
   if (format === "slack") {
-    return { text: `*pm-bridge-mcp* — ${line}\n${detail}` };
+    return { text: `*mailpouch* — ${line}\n${detail}` };
   }
   if (format === "discord") {
-    return { content: `**pm-bridge-mcp** — ${line}\n${detail}` };
+    return { content: `**mailpouch** — ${line}\n${detail}` };
   }
   if (format === "raw") {
     return { kind: ev.kind, seq: ev.seq, grant: g };
@@ -140,9 +140,9 @@ export function buildPayload(ev: GrantChangedEvent, format: WebhookFormat): Reco
   // CloudEvents 1.0 envelope.
   return {
     specversion: "1.0",
-    id: `pmb-${randomBytes(8).toString("hex")}`,
-    source: "pm-bridge-mcp",
-    type: `com.pmbridge.${ev.kind.replace("-", ".")}`,
+    id: `mp-${randomBytes(8).toString("hex")}`,
+    source: "mailpouch",
+    type: `com.mailpouch.${ev.kind.replace("-", ".")}`,
     time: new Date().toISOString(),
     datacontenttype: "application/json",
     data: {
@@ -218,9 +218,9 @@ export class WebhookDispatcher {
     const body = JSON.stringify(payload);
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "User-Agent": "pm-bridge-mcp/1 (+https://github.com/chandshy/pm-bridge-mcp)",
+      "User-Agent": "mailpouch/1 (+https://github.com/chandshy/mailpouch)",
     };
-    if (endpoint.secret) headers["X-PMBridge-Signature-256"] = sign(body, endpoint.secret);
+    if (endpoint.secret) headers["X-Mailpouch-Signature-256"] = sign(body, endpoint.secret);
 
     let lastError = "";
     let status: number | undefined;

--- a/src/permissions/escalation.test.ts
+++ b/src/permissions/escalation.test.ts
@@ -78,49 +78,68 @@ describe('isUpgrade', () => {
 // ─── File path helpers ───────────────────────────────────────────────────────
 
 describe('getPendingFilePath / getAuditLogPath', () => {
-  it('uses the new default home-dir path when env vars are absent', () => {
+  function clearEnv() {
+    delete process.env.MAILPOUCH_PENDING;
+    delete process.env.MAILPOUCH_AUDIT;
     delete process.env.PM_BRIDGE_MCP_PENDING;
     delete process.env.PM_BRIDGE_MCP_AUDIT;
     delete process.env.PROTONMAIL_MCP_PENDING;
     delete process.env.PROTONMAIL_MCP_AUDIT;
-    // Default is the new pm-bridge-mcp path unless a legacy file exists on
-    // disk (the read-old/write-new fallback). The test runner's homedir is
+  }
+
+  it('uses the new default home-dir path when env vars are absent', () => {
+    clearEnv();
+    // Default is the new mailpouch path unless a legacy file exists on disk
+    // (the read-old/write-new fallback). The test runner's homedir is
     // unlikely to contain one, so assert the new name.
-    expect(getPendingFilePath()).toMatch(/pm-bridge-mcp\.pending\.json$/);
-    expect(getAuditLogPath()).toMatch(/pm-bridge-mcp\.audit\.jsonl$/);
+    expect(getPendingFilePath()).toMatch(/mailpouch\.pending\.json$/);
+    expect(getAuditLogPath()).toMatch(/mailpouch\.audit\.jsonl$/);
   });
 
-  it('uses new-name env var overrides when set', () => {
-    process.env.PM_BRIDGE_MCP_PENDING = '/tmp/test-pending-new.json';
-    process.env.PM_BRIDGE_MCP_AUDIT   = '/tmp/test-audit-new.jsonl';
+  it('uses new-name env var overrides (MAILPOUCH_*) when set', () => {
+    clearEnv();
+    process.env.MAILPOUCH_PENDING = '/tmp/test-pending-new.json';
+    process.env.MAILPOUCH_AUDIT   = '/tmp/test-audit-new.jsonl';
     expect(getPendingFilePath()).toBe('/tmp/test-pending-new.json');
     expect(getAuditLogPath()).toBe('/tmp/test-audit-new.jsonl');
-    delete process.env.PM_BRIDGE_MCP_PENDING;
-    delete process.env.PM_BRIDGE_MCP_AUDIT;
+    clearEnv();
   });
 
-  it('still accepts legacy PROTONMAIL_MCP_* env vars for one release', () => {
-    delete process.env.PM_BRIDGE_MCP_PENDING;
-    delete process.env.PM_BRIDGE_MCP_AUDIT;
+  it('still accepts legacy PM_BRIDGE_MCP_* env vars', () => {
+    clearEnv();
+    process.env.PM_BRIDGE_MCP_PENDING = '/tmp/test-pending-v21.json';
+    process.env.PM_BRIDGE_MCP_AUDIT   = '/tmp/test-audit-v21.jsonl';
+    expect(getPendingFilePath()).toBe('/tmp/test-pending-v21.json');
+    expect(getAuditLogPath()).toBe('/tmp/test-audit-v21.jsonl');
+    clearEnv();
+  });
+
+  it('still accepts legacy PROTONMAIL_MCP_* env vars', () => {
+    clearEnv();
     process.env.PROTONMAIL_MCP_PENDING = '/tmp/test-pending-legacy.json';
     process.env.PROTONMAIL_MCP_AUDIT   = '/tmp/test-audit-legacy.jsonl';
     expect(getPendingFilePath()).toBe('/tmp/test-pending-legacy.json');
     expect(getAuditLogPath()).toBe('/tmp/test-audit-legacy.jsonl');
-    delete process.env.PROTONMAIL_MCP_PENDING;
-    delete process.env.PROTONMAIL_MCP_AUDIT;
+    clearEnv();
   });
 
-  it('prefers the new env var over the legacy alias when both are set', () => {
-    process.env.PM_BRIDGE_MCP_PENDING  = '/tmp/new-wins-pending.json';
-    process.env.PM_BRIDGE_MCP_AUDIT    = '/tmp/new-wins-audit.jsonl';
-    process.env.PROTONMAIL_MCP_PENDING = '/tmp/legacy-loses-pending.json';
-    process.env.PROTONMAIL_MCP_AUDIT   = '/tmp/legacy-loses-audit.jsonl';
-    expect(getPendingFilePath()).toBe('/tmp/new-wins-pending.json');
-    expect(getAuditLogPath()).toBe('/tmp/new-wins-audit.jsonl');
-    delete process.env.PM_BRIDGE_MCP_PENDING;
-    delete process.env.PM_BRIDGE_MCP_AUDIT;
-    delete process.env.PROTONMAIL_MCP_PENDING;
-    delete process.env.PROTONMAIL_MCP_AUDIT;
+  it('MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_MCP_* priority chain', () => {
+    clearEnv();
+    process.env.MAILPOUCH_PENDING      = '/tmp/mp-pending.json';
+    process.env.MAILPOUCH_AUDIT        = '/tmp/mp-audit.jsonl';
+    process.env.PM_BRIDGE_MCP_PENDING  = '/tmp/v21-pending.json';
+    process.env.PM_BRIDGE_MCP_AUDIT    = '/tmp/v21-audit.jsonl';
+    process.env.PROTONMAIL_MCP_PENDING = '/tmp/v1-pending.json';
+    process.env.PROTONMAIL_MCP_AUDIT   = '/tmp/v1-audit.jsonl';
+    expect(getPendingFilePath()).toBe('/tmp/mp-pending.json');
+    expect(getAuditLogPath()).toBe('/tmp/mp-audit.jsonl');
+
+    // With MAILPOUCH_* removed, PM_BRIDGE_MCP_* takes over.
+    delete process.env.MAILPOUCH_PENDING;
+    delete process.env.MAILPOUCH_AUDIT;
+    expect(getPendingFilePath()).toBe('/tmp/v21-pending.json');
+    expect(getAuditLogPath()).toBe('/tmp/v21-audit.jsonl');
+    clearEnv();
   });
 });
 
@@ -130,8 +149,10 @@ describe('escalation workflow', () => {
   let tmpDir: string;
   let pendingPath: string;
   let auditPath: string;
-  const origPending    = process.env.PM_BRIDGE_MCP_PENDING;
-  const origAudit      = process.env.PM_BRIDGE_MCP_AUDIT;
+  const origPending    = process.env.MAILPOUCH_PENDING;
+  const origAudit      = process.env.MAILPOUCH_AUDIT;
+  const origV21Pend    = process.env.PM_BRIDGE_MCP_PENDING;
+  const origV21Aud     = process.env.PM_BRIDGE_MCP_AUDIT;
   const origLegacyPend = process.env.PROTONMAIL_MCP_PENDING;
   const origLegacyAud  = process.env.PROTONMAIL_MCP_AUDIT;
 
@@ -139,19 +160,23 @@ describe('escalation workflow', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'escalation-test-'));
     pendingPath = join(tmpDir, 'pending.json');
     auditPath   = join(tmpDir, 'audit.jsonl');
-    // Ensure a stale legacy override from another test cannot shadow the
-    // new-name path we're about to set.
+    // Ensure stale overrides from another test cannot shadow the new-name
+    // path we're about to set.
+    delete process.env.PM_BRIDGE_MCP_PENDING;
+    delete process.env.PM_BRIDGE_MCP_AUDIT;
     delete process.env.PROTONMAIL_MCP_PENDING;
     delete process.env.PROTONMAIL_MCP_AUDIT;
-    process.env.PM_BRIDGE_MCP_PENDING = pendingPath;
-    process.env.PM_BRIDGE_MCP_AUDIT   = auditPath;
+    process.env.MAILPOUCH_PENDING = pendingPath;
+    process.env.MAILPOUCH_AUDIT   = auditPath;
   });
 
   afterEach(() => {
-    if (origPending !== undefined) process.env.PM_BRIDGE_MCP_PENDING = origPending;
-    else delete process.env.PM_BRIDGE_MCP_PENDING;
-    if (origAudit !== undefined) process.env.PM_BRIDGE_MCP_AUDIT = origAudit;
-    else delete process.env.PM_BRIDGE_MCP_AUDIT;
+    if (origPending !== undefined) process.env.MAILPOUCH_PENDING = origPending;
+    else delete process.env.MAILPOUCH_PENDING;
+    if (origAudit !== undefined) process.env.MAILPOUCH_AUDIT = origAudit;
+    else delete process.env.MAILPOUCH_AUDIT;
+    if (origV21Pend !== undefined) process.env.PM_BRIDGE_MCP_PENDING = origV21Pend;
+    if (origV21Aud !== undefined)  process.env.PM_BRIDGE_MCP_AUDIT   = origV21Aud;
     if (origLegacyPend !== undefined) process.env.PROTONMAIL_MCP_PENDING = origLegacyPend;
     if (origLegacyAud !== undefined)  process.env.PROTONMAIL_MCP_AUDIT   = origLegacyAud;
     rmSync(tmpDir, { recursive: true, force: true });

--- a/src/permissions/escalation.ts
+++ b/src/permissions/escalation.ts
@@ -29,7 +29,7 @@
  *      MAX_PENDING pending at a time, preventing flooding/confusion.
  *
  *   7. DURABLE AUDIT TRAIL — all events are appended to
- *      ~/.pm-bridge-mcp.audit.jsonl immediately, before any response is
+ *      ~/.mailpouch.audit.jsonl immediately, before any response is
  *      sent.  The agent cannot erase this log via MCP tools.
  *
  *   8. UPGRADE-ONLY — downgrading a preset (reducing privilege) never
@@ -37,7 +37,7 @@
  *      Only transitions to a higher-privilege preset require approval.
  *
  * Shared state between the MCP server and the settings server is maintained
- * via a file (~/.pm-bridge-mcp.pending.json, mode 0600) rather than IPC,
+ * via a file (~/.mailpouch.pending.json, mode 0600) rather than IPC,
  * so both processes remain independent.
  *
  * Residual risk (documented):
@@ -116,31 +116,41 @@ interface PendingFile {
 // ─── File paths ────────────────────────────────────────────────────────────────
 
 export function getPendingFilePath(): string {
-  // Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-  // New wins; legacy is silently honored for one release. Remove the
-  // PROTONMAIL_MCP_PENDING alias in v2.2.
-  const envPath = process.env.PM_BRIDGE_MCP_PENDING ?? process.env.PROTONMAIL_MCP_PENDING;
+  // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_*. Legacy
+  // names honored through v3.0.
+  const envPath = process.env.MAILPOUCH_PENDING
+    ?? process.env.PM_BRIDGE_MCP_PENDING
+    ?? process.env.PROTONMAIL_MCP_PENDING;
   if (envPath) return envPath;
   // Read-old/write-new: prefer the new path, but if a stale pending record
-  // is sitting in the legacy file (and the new one doesn't exist yet), keep
+  // is sitting in a legacy file (and the new one doesn't exist yet), keep
   // honoring it so an in-flight escalation isn't dropped on the floor mid-flow.
-  const preferred = join(homedir(), ".pm-bridge-mcp.pending.json");
-  const legacy = join(homedir(), ".protonmail-mcp.pending.json");
-  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  const preferred = join(homedir(), ".mailpouch.pending.json");
+  const legacyV2 = join(homedir(), ".pm-bridge-mcp.pending.json");
+  const legacyV1 = join(homedir(), ".protonmail-mcp.pending.json");
+  if (!existsSync(preferred)) {
+    if (existsSync(legacyV2)) return legacyV2;
+    if (existsSync(legacyV1)) return legacyV1;
+  }
   return preferred;
 }
 
 export function getAuditLogPath(): string {
-  // Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-  // New wins; legacy is silently honored for one release. Remove the
-  // PROTONMAIL_MCP_AUDIT alias in v2.2.
-  const envPath = process.env.PM_BRIDGE_MCP_AUDIT ?? process.env.PROTONMAIL_MCP_AUDIT;
+  // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_*. Legacy
+  // names honored through v3.0.
+  const envPath = process.env.MAILPOUCH_AUDIT
+    ?? process.env.PM_BRIDGE_MCP_AUDIT
+    ?? process.env.PROTONMAIL_MCP_AUDIT;
   if (envPath) return envPath;
-  // Read-old/write-new: append to the legacy file when it's the only one
+  // Read-old/write-new: append to a legacy file when it's the only one
   // present so the audit trail stays continuous across the rename.
-  const preferred = join(homedir(), ".pm-bridge-mcp.audit.jsonl");
-  const legacy = join(homedir(), ".protonmail-mcp.audit.jsonl");
-  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  const preferred = join(homedir(), ".mailpouch.audit.jsonl");
+  const legacyV2 = join(homedir(), ".pm-bridge-mcp.audit.jsonl");
+  const legacyV1 = join(homedir(), ".protonmail-mcp.audit.jsonl");
+  if (!existsSync(preferred)) {
+    if (existsSync(legacyV2)) return legacyV2;
+    if (existsSync(legacyV1)) return legacyV1;
+  }
   return preferred;
 }
 

--- a/src/security/keychain.test.ts
+++ b/src/security/keychain.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { isKeychainAvailable, loadCredentials, saveCredentials, deleteCredentials, migrateFromConfig } from './keychain.js';
 import type { ServerConfig } from '../config/schema.js';
 
 // keytar is an optional dependency that won't be installed in test environments.
@@ -7,26 +6,31 @@ import type { ServerConfig } from '../config/schema.js';
 
 describe('Keychain (without keytar installed)', () => {
   it('isKeychainAvailable should return false', async () => {
+    const { isKeychainAvailable } = await import('./keychain.js');
     const available = await isKeychainAvailable();
     expect(available).toBe(false);
   });
 
   it('loadCredentials should return null', async () => {
+    const { loadCredentials } = await import('./keychain.js');
     const creds = await loadCredentials();
     expect(creds).toBeNull();
   });
 
   it('saveCredentials should return false', async () => {
+    const { saveCredentials } = await import('./keychain.js');
     const result = await saveCredentials('password', 'token');
     expect(result).toBe(false);
   });
 
   it('deleteCredentials should return false', async () => {
+    const { deleteCredentials } = await import('./keychain.js');
     const result = await deleteCredentials();
     expect(result).toBe(false);
   });
 
   it('migrateFromConfig should return false when keychain unavailable', async () => {
+    const { migrateFromConfig } = await import('./keychain.js');
     const mockConfig = {
       configVersion: 1,
       connection: {
@@ -53,6 +57,7 @@ describe('Keychain (without keytar installed)', () => {
   });
 
   it('migrateFromConfig should return false when no credentials to migrate', async () => {
+    const { migrateFromConfig } = await import('./keychain.js');
     const mockConfig = {
       configVersion: 1,
       connection: {
@@ -76,5 +81,107 @@ describe('Keychain (without keytar installed)', () => {
     const result = await migrateFromConfig(mockConfig, saveFn);
     expect(result).toBe(false);
     expect(saveFn).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Legacy keychain migration ────────────────────────────────────────────────
+//
+// These tests stub the dynamic `import("@napi-rs/keyring")` call that the
+// keychain module performs via `new Function("specifier", "return import(...)")`.
+// The stub installs a fake Entry class backed by an in-memory map keyed by
+// "<service>\0<account>" so we can assert the migration's read/write/delete
+// behavior without touching the OS keychain.
+
+type Store = Map<string, string>;
+
+function installFakeKeyring(store: Store): () => void {
+  const FakeEntry = class {
+    constructor(private service: string, private account: string) {}
+    private key(): string { return `${this.service}\u0000${this.account}`; }
+    getPassword(): string | null {
+      return store.has(this.key()) ? (store.get(this.key()) as string) : null;
+    }
+    setPassword(password: string): void { store.set(this.key(), password); }
+    deletePassword(): boolean { return store.delete(this.key()); }
+  };
+  const fakeModule = { Entry: FakeEntry };
+  const originalFn = global.Function;
+  const patchedFn = function (this: unknown, ...args: unknown[]) {
+    const src = String(args[args.length - 1] ?? "");
+    if (src.includes("import(specifier)")) {
+      return ((_specifier: string) => Promise.resolve(fakeModule)) as unknown as Function;
+    }
+    return (originalFn as unknown as new (...a: unknown[]) => Function)(...args as []);
+  };
+  patchedFn.prototype = originalFn.prototype;
+  (global as { Function: unknown }).Function = patchedFn;
+  return () => { (global as { Function: unknown }).Function = originalFn; };
+}
+
+describe('migrateLegacyKeychainEntries', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('migrates a legacy entry when no new entry exists (read, write, delete, return migrated=1)', async () => {
+    const store: Store = new Map();
+    store.set('pm-bridge-mcp\u0000bridge-password', 'secret-v2.1');
+    const restore = installFakeKeyring(store);
+    try {
+      const { migrateLegacyKeychainEntries, __resetKeyringCacheForTests } = await import('./keychain.js');
+      __resetKeyringCacheForTests();
+      const result = await migrateLegacyKeychainEntries();
+      expect(result.migrated).toBe(1);
+      expect(result.conflicts).toBe(0);
+      expect(store.get('mailpouch\u0000bridge-password')).toBe('secret-v2.1');
+      expect(store.has('pm-bridge-mcp\u0000bridge-password')).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves both entries alone when the new slot is already populated (conflict counter)', async () => {
+    const store: Store = new Map();
+    store.set('pm-bridge-mcp\u0000bridge-password', 'legacy-value');
+    store.set('mailpouch\u0000bridge-password', 'new-value');
+    const restore = installFakeKeyring(store);
+    try {
+      const { migrateLegacyKeychainEntries, __resetKeyringCacheForTests } = await import('./keychain.js');
+      __resetKeyringCacheForTests();
+      const result = await migrateLegacyKeychainEntries();
+      expect(result.migrated).toBe(0);
+      expect(result.conflicts).toBe(1);
+      // New slot untouched
+      expect(store.get('mailpouch\u0000bridge-password')).toBe('new-value');
+      // Legacy slot left in place (operator resolves)
+      expect(store.get('pm-bridge-mcp\u0000bridge-password')).toBe('legacy-value');
+    } finally {
+      restore();
+    }
+  });
+
+  it('is a noop when no legacy entries exist (migrated=0)', async () => {
+    const store: Store = new Map();
+    const restore = installFakeKeyring(store);
+    try {
+      const { migrateLegacyKeychainEntries, __resetKeyringCacheForTests } = await import('./keychain.js');
+      __resetKeyringCacheForTests();
+      const result = await migrateLegacyKeychainEntries();
+      expect(result.migrated).toBe(0);
+      expect(result.conflicts).toBe(0);
+      expect(store.size).toBe(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('is a noop when @napi-rs/keyring import fails (migrated=0)', async () => {
+    // Do not install the fake — the real dynamic import throws because the
+    // optional dep is not present in the test env.
+    const { migrateLegacyKeychainEntries, __resetKeyringCacheForTests } = await import('./keychain.js');
+    __resetKeyringCacheForTests();
+    const result = await migrateLegacyKeychainEntries();
+    expect(result.migrated).toBe(0);
+    expect(result.conflicts).toBe(0);
   });
 });

--- a/src/security/keychain.ts
+++ b/src/security/keychain.ts
@@ -12,12 +12,21 @@
  */
 
 import type { ServerConfig } from "../config/schema.js";
+import { logger } from "../utils/logger.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const SERVICE_NAME = "protonmail-mcp-server";
+const SERVICE_NAME = "mailpouch";
+/**
+ * Legacy keychain service names we migrate away from at startup. Priority
+ * order (first hit wins when both slots still exist under legacy names):
+ *   1. v2.1 rename window — `pm-bridge-mcp`
+ *   2. original — `protonmail-mcp-server`
+ */
+const LEGACY_SERVICE_NAMES = ["pm-bridge-mcp", "protonmail-mcp-server"] as const;
 const KEY_PASSWORD = "bridge-password";
 const KEY_SMTP_TOKEN = "smtp-token";
+const ACCOUNT_KEYS = [KEY_PASSWORD, KEY_SMTP_TOKEN] as const;
 
 // ─── Lazy @napi-rs/keyring loading ────────────────────────────────────────────
 
@@ -50,6 +59,15 @@ async function getKeyring(): Promise<KeyringModule | null> {
     keyringModule = null;
     return null;
   }
+}
+
+/**
+ * Test hook — reset the cached keyring module so `vi.mock` re-runs resolve
+ * with a fresh factory between cases. Production code never calls this.
+ */
+export function __resetKeyringCacheForTests(): void {
+  keyringModule = null;
+  keyringChecked = false;
 }
 
 // ─── Public API ───────────────────────────────────────────────────────────────
@@ -160,4 +178,76 @@ export async function migrateFromConfig(
   saveConfigFn(config);
 
   return true;
+}
+
+// ─── Legacy keychain migration ────────────────────────────────────────────────
+
+export interface LegacyMigrationResult {
+  /** Entries copied from a legacy service name to `mailpouch`. */
+  migrated: number;
+  /**
+   * Legacy entries left in place because the `mailpouch` slot was already
+   * populated. Surfaces when a user manually added the new name and then
+   * the migration ran; we never overwrite the authoritative slot.
+   */
+  conflicts: number;
+}
+
+/**
+ * One-shot migration of legacy keychain entries to the `mailpouch` service
+ * name. Called once at server startup, before any `loadCredentialsFromKeychain`.
+ *
+ * For each legacy service × each account-key we know about:
+ *   - read the legacy entry; if empty, skip
+ *   - if the `mailpouch` slot is empty, copy the value over and delete the
+ *     legacy entry (migration)
+ *   - if the `mailpouch` slot is already populated, leave the legacy entry
+ *     in place (conflict — operator resolves manually) and DO NOT overwrite
+ *
+ * All failures are non-fatal — a stranded credential just means the user
+ * re-enters their Bridge password via the settings UI.
+ */
+export async function migrateLegacyKeychainEntries(): Promise<LegacyMigrationResult> {
+  const result: LegacyMigrationResult = { migrated: 0, conflicts: 0 };
+  let keyring: KeyringModule | null;
+  try {
+    keyring = await getKeyring();
+  } catch {
+    return result;
+  }
+  if (!keyring) return result;
+
+  for (const legacyService of LEGACY_SERVICE_NAMES) {
+    for (const account of ACCOUNT_KEYS) {
+      try {
+        const legacyEntry = new keyring.Entry(legacyService, account);
+        const legacyValue = legacyEntry.getPassword();
+        if (!legacyValue) continue;
+
+        const newEntry = new keyring.Entry(SERVICE_NAME, account);
+        const newValue = newEntry.getPassword();
+        if (newValue) {
+          // Already populated under mailpouch — do not overwrite; leave
+          // legacy entry as-is so the operator can decide.
+          result.conflicts += 1;
+          continue;
+        }
+
+        newEntry.setPassword(legacyValue);
+        try { legacyEntry.deletePassword(); } catch { /* non-fatal */ }
+        logger.info(
+          `Keychain: migrated ${account} from '${legacyService}' to 'mailpouch'`,
+          "Keychain",
+        );
+        result.migrated += 1;
+      } catch (err) {
+        logger.debug(
+          `Keychain: migration probe failed for ${legacyService}/${account}`,
+          "Keychain",
+          err,
+        );
+      }
+    }
+  }
+  return result;
 }

--- a/src/services/connect-tls.test.ts
+++ b/src/services/connect-tls.test.ts
@@ -101,13 +101,17 @@ describe("SimpleIMAPService.connect() bridgeCertPath handling", () => {
   describe("strict mode (no allowInsecureBridge opt-in)", () => {
     // Tests in this block run with the env var temporarily cleared so that
     // the strict default (throw when no cert or cert load fails) is exercised.
-    let prevEnv: string | undefined;
+    const ENV_KEYS = ["MAILPOUCH_INSECURE_BRIDGE", "PM_BRIDGE_MCP_INSECURE_BRIDGE", "PROTONMAIL_MCP_INSECURE_BRIDGE"] as const;
+    let prev: Record<string, string | undefined> = {};
     beforeEach(() => {
-      prevEnv = process.env.PROTONMAIL_MCP_INSECURE_BRIDGE;
-      delete process.env.PROTONMAIL_MCP_INSECURE_BRIDGE;
+      prev = {};
+      for (const k of ENV_KEYS) { prev[k] = process.env[k]; delete process.env[k]; }
     });
     afterEach(() => {
-      if (prevEnv !== undefined) process.env.PROTONMAIL_MCP_INSECURE_BRIDGE = prevEnv;
+      for (const k of ENV_KEYS) {
+        if (prev[k] !== undefined) process.env[k] = prev[k];
+        else delete process.env[k];
+      }
     });
 
     it("throws when localhost and no cert path is configured", async () => {

--- a/src/services/fts-service.test.ts
+++ b/src/services/fts-service.test.ts
@@ -25,7 +25,7 @@ function sqliteAvailable(): boolean {
 const describeMaybe = sqliteAvailable() ? describe : describe.skip;
 
 function tmpDb(): string {
-  return join(tmpdir(), `pm-bridge-fts-${randomBytes(6).toString("hex")}.db`);
+  return join(tmpdir(), `mailpouch-fts-${randomBytes(6).toString("hex")}.db`);
 }
 
 function sampleRecord(overrides: Partial<Parameters<FtsIndexService["upsert"]>[0]> = {}) {

--- a/src/services/fts-service.ts
+++ b/src/services/fts-service.ts
@@ -6,7 +6,7 @@
  * FTS5 gives us BM25-ranked keyword search with snippet highlighting, which
  * is good-enough for most day-to-day "find the email about X" queries.
  *
- * `better-sqlite3` is an *optional* dependency — pm-bridge-mcp must still
+ * `better-sqlite3` is an *optional* dependency — mailpouch must still
  * load and serve mail tools when it isn't available. Call openFtsIndex() to
  * get a live instance; it throws FtsUnavailableError when the native
  * binding is missing, and callers return a structured error to the tool
@@ -221,7 +221,7 @@ export function openFtsIndex(dbPath: string): FtsIndexService {
   } catch (err) {
     throw new FtsUnavailableError(
       "FTS index requires 'better-sqlite3' (optional dependency). Install with " +
-      "`npm install better-sqlite3` in the pm-bridge-mcp directory. " +
+      "`npm install better-sqlite3` in the mailpouch directory. " +
       `Underlying error: ${(err as Error).message}`,
     );
   }

--- a/src/services/pass-service.test.ts
+++ b/src/services/pass-service.test.ts
@@ -18,7 +18,7 @@ vi.mock("child_process", () => ({
 }));
 
 function tmpPath(): string {
-  return join(tmpdir(), `pm-bridge-pass-audit-${randomBytes(6).toString("hex")}.jsonl`);
+  return join(tmpdir(), `mailpouch-pass-audit-${randomBytes(6).toString("hex")}.jsonl`);
 }
 
 type FakeChild = EventEmitter & {

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -20,7 +20,7 @@
  * - PAT is read from the config file (mode 0600) OR keychain. Never from
  *   env vars the agent can inspect.
  * - Every call is logged to an append-only audit file
- *   (~/.pm-bridge-mcp-pass-audit.jsonl, mode 0600) with timestamp + tool
+ *   (~/.mailpouch-pass-audit.jsonl, mode 0600) with timestamp + tool
  *   name + item ID (but never the secret value itself).
  * - No tool returns or logs the decrypted secret in plain text unless the
  *   user has explicitly confirmed via the elicitation gate. That's the

--- a/src/services/reminder-service.test.ts
+++ b/src/services/reminder-service.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "os";
 import { randomBytes } from "crypto";
 
 function tmpPath(): string {
-  return join(tmpdir(), `pm-bridge-reminders-${randomBytes(6).toString("hex")}.json`);
+  return join(tmpdir(), `mailpouch-reminders-${randomBytes(6).toString("hex")}.json`);
 }
 
 describe("ReminderService", () => {
@@ -129,14 +129,14 @@ describe("ReminderService", () => {
     it("cancels a reminder when an inbox message's In-Reply-To matches its Message-ID", () => {
       const svc = new ReminderService(path);
       const r = svc.add({
-        messageId: "<outbound-42@pm-bridge>",
+        messageId: "<outbound-42@mailpouch>",
         recipient: "alice@x",
         subject: "Proposal",
         sentAt: new Date(),
         afterDays: 3,
       });
       const cancelled = svc.detectRepliesAndCancel([
-        { headers: { "in-reply-to": "<outbound-42@pm-bridge>" } },
+        { headers: { "in-reply-to": "<outbound-42@mailpouch>" } },
       ]);
       expect(cancelled).toEqual([r.id]);
       expect(svc.listPending()).toHaveLength(0);
@@ -145,11 +145,11 @@ describe("ReminderService", () => {
     it("matches against References header and multi-valued tokens", () => {
       const svc = new ReminderService(path);
       svc.add({
-        messageId: "<chain-1@pm-bridge>",
+        messageId: "<chain-1@mailpouch>",
         recipient: "bob@x", subject: "chain", sentAt: new Date(), afterDays: 1,
       });
       const cancelled = svc.detectRepliesAndCancel([
-        { headers: { "References": "<other@x> <chain-1@pm-bridge> <another@x>" } },
+        { headers: { "References": "<other@x> <chain-1@mailpouch> <another@x>" } },
       ]);
       expect(cancelled).toHaveLength(1);
     });

--- a/src/services/reminder-service.ts
+++ b/src/services/reminder-service.ts
@@ -69,7 +69,7 @@ export class ReminderService {
 
   private persist(): void {
     const payload: ReminderFile = { version: 1, reminders: this.reminders };
-    const tmp = join(tmpdir(), `pm-bridge-reminders-${randomBytes(8).toString("hex")}.json.tmp`);
+    const tmp = join(tmpdir(), `mailpouch-reminders-${randomBytes(8).toString("hex")}.json.tmp`);
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { encoding: "utf-8", mode: 0o600 });
     renameSync(tmp, this.path);
   }

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -325,10 +325,10 @@ export class SimpleIMAPService {
 
       // Check if using localhost (Proton Bridge)
       const isLocalhost = host === 'localhost' || host === '127.0.0.1';
-      // Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-      // New wins; legacy is silently honored for one release. Remove the
-      // PROTONMAIL_MCP_INSECURE_BRIDGE alias in v2.2.
+      // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_MCP_*.
+      // Legacy names honored through v3.0.
       const allowInsecure = allowInsecureBridge
+        || process.env.MAILPOUCH_INSECURE_BRIDGE === '1'
         || process.env.PM_BRIDGE_MCP_INSECURE_BRIDGE === '1'
         || process.env.PROTONMAIL_MCP_INSECURE_BRIDGE === '1';
 
@@ -359,7 +359,7 @@ export class SimpleIMAPService {
               throw new Error(
                 `IMAP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
                 `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
-                `(or PM_BRIDGE_MCP_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
+                `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
                 `Underlying error: ${(err as Error).message}`
               );
             }
@@ -377,7 +377,7 @@ export class SimpleIMAPService {
             throw new Error(
               'IMAP: No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate ' +
               "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
-              'disabled for localhost), set allowInsecureBridge: true or launch with PM_BRIDGE_MCP_INSECURE_BRIDGE=1.'
+              'disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1.'
             );
           }
           logger.warn(
@@ -463,7 +463,7 @@ export class SimpleIMAPService {
       // swallow any failure — a missing ID response is not actionable.
       const idFn = (this.client as unknown as { id?: (info?: Record<string, string>) => Promise<Record<string, string>> }).id;
       if (typeof idFn !== 'function') return;
-      const info = await idFn.call(this.client, { name: 'pm-bridge-mcp' });
+      const info = await idFn.call(this.client, { name: 'mailpouch' });
       const name = String(info?.name ?? '');
       const version = String(info?.version ?? '');
       if (!version) return;

--- a/src/services/simplelogin-service.ts
+++ b/src/services/simplelogin-service.ts
@@ -9,7 +9,7 @@
  * spelling — that's how SimpleLogin designed it). API keys are scoped per
  * account and generated from the SimpleLogin dashboard.
  *
- * All requests are fire-and-forget from pm-bridge-mcp's perspective; we do
+ * All requests are fire-and-forget from mailpouch's perspective; we do
  * not persist alias state locally — the agent always reads fresh from the API.
  */
 

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -68,11 +68,11 @@ export class SMTPService {
       ? this.config.smtp.smtpToken
       : this.config.smtp.password;
 
-    // Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-    // New wins; legacy is silently honored for one release. Remove the
-    // PROTONMAIL_MCP_INSECURE_BRIDGE alias in v2.2.
+    // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_MCP_*. Legacy
+    // names honored through v3.0.
     const allowInsecure =
       this.config.smtp.allowInsecureBridge === true ||
+      process.env.MAILPOUCH_INSECURE_BRIDGE === "1" ||
       process.env.PM_BRIDGE_MCP_INSECURE_BRIDGE === "1" ||
       process.env.PROTONMAIL_MCP_INSECURE_BRIDGE === "1";
 
@@ -103,7 +103,7 @@ export class SMTPService {
             throw new Error(
               `SMTP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
               `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
-              `(or PM_BRIDGE_MCP_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
+              `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
               `Underlying error: ${(err as Error).message}`
             );
           }
@@ -122,7 +122,7 @@ export class SMTPService {
           throw new Error(
             "SMTP: No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate " +
             "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
-            "disabled for localhost), set allowInsecureBridge: true or launch with PM_BRIDGE_MCP_INSECURE_BRIDGE=1."
+            "disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1."
           );
         }
         logger.warn(
@@ -435,12 +435,12 @@ export class SMTPService {
   ): Promise<{ success: boolean; messageId?: string; error?: string }> {
     logger.debug("Sending test email", "SMTPService", { to });
 
-    const subject = "Test Email from pm-bridge-mcp";
+    const subject = "Test Email from mailpouch";
     const body =
       customMessage ||
       `
       <h2>Test Email Successful</h2>
-      <p>This is a test email from the pm-bridge-mcp server.</p>
+      <p>This is a test email from the mailpouch server.</p>
       <p><strong>Timestamp:</strong> ${new Date().toISOString()}</p>
       <p><strong>From:</strong> ${escapeHtml(this.config.smtp.username)}</p>
       <p>If you received this email, your SMTP configuration is working correctly.</p>

--- a/src/services/smtp-tls.test.ts
+++ b/src/services/smtp-tls.test.ts
@@ -47,15 +47,19 @@ function baseConfig(overrides: Partial<ProtonMailConfig["smtp"]> = {}): ProtonMa
 }
 
 describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
-  let prevEnv: string | undefined;
+  const ENV_KEYS = ["MAILPOUCH_INSECURE_BRIDGE", "PM_BRIDGE_MCP_INSECURE_BRIDGE", "PROTONMAIL_MCP_INSECURE_BRIDGE"] as const;
+  let prev: Record<string, string | undefined> = {};
 
   beforeEach(() => {
-    prevEnv = process.env.PROTONMAIL_MCP_INSECURE_BRIDGE;
-    delete process.env.PROTONMAIL_MCP_INSECURE_BRIDGE;
+    prev = {};
+    for (const k of ENV_KEYS) { prev[k] = process.env[k]; delete process.env[k]; }
   });
 
   afterEach(() => {
-    if (prevEnv !== undefined) process.env.PROTONMAIL_MCP_INSECURE_BRIDGE = prevEnv;
+    for (const k of ENV_KEYS) {
+      if (prev[k] !== undefined) process.env[k] = prev[k];
+      else delete process.env[k];
+    }
   });
 
   it("throws when localhost has credentials but no cert path and no opt-in", () => {
@@ -114,7 +118,19 @@ describe("SMTPService TLS insecure opt-in", () => {
     expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(true);
   });
 
-  it("runs in insecure mode when PROTONMAIL_MCP_INSECURE_BRIDGE=1 is set in env", () => {
+  it("runs in insecure mode when MAILPOUCH_INSECURE_BRIDGE=1 is set in env", () => {
+    const prev = process.env.MAILPOUCH_INSECURE_BRIDGE;
+    process.env.MAILPOUCH_INSECURE_BRIDGE = "1";
+    try {
+      const svc = new SMTPService(baseConfig());
+      expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(true);
+    } finally {
+      if (prev !== undefined) process.env.MAILPOUCH_INSECURE_BRIDGE = prev;
+      else delete process.env.MAILPOUCH_INSECURE_BRIDGE;
+    }
+  });
+
+  it("still honors legacy PROTONMAIL_MCP_INSECURE_BRIDGE=1 as an env alias", () => {
     const prev = process.env.PROTONMAIL_MCP_INSECURE_BRIDGE;
     process.env.PROTONMAIL_MCP_INSECURE_BRIDGE = "1";
     try {

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * pm-bridge-mcp — Settings entry point
+ * mailpouch — Settings entry point
  *
  * Auto-detects the display environment and launches the best available UI:
  *
@@ -43,7 +43,7 @@ function hasFlag(name: string): boolean  { return flagIndex(name) !== -1; }
 
 if (hasFlag("--help") || hasFlag("-h")) {
   process.stdout.write(
-    "Usage: pm-bridge-mcp-settings [options]\n\n" +
+    "Usage: mailpouch-settings [options]\n\n" +
     "Options:\n" +
     "  --port <n>    HTTP server port (default: 8765)\n" +
     "  --browser     Force browser mode\n" +
@@ -85,7 +85,7 @@ const port = portArg !== -1
     : configPort;
 
 if (isNaN(port) || port < 1 || port > 65535) {
-  process.stderr.write("Invalid port. Usage: pm-bridge-mcp-settings [--port <1-65535>]\n");
+  process.stderr.write("Invalid port. Usage: mailpouch-settings [--port <1-65535>]\n");
   process.exit(1);
 }
 
@@ -134,7 +134,7 @@ switch (mode) {
       if (!noOpen) {
         const opened = openBrowser(url);
         if (!opened) {
-          process.stdout.write(`\n  pm-bridge-mcp Settings\n`);
+          process.stdout.write(`\n  mailpouch Settings\n`);
           process.stdout.write(`  Could not auto-open browser. Open manually:\n`);
           process.stdout.write(`  ${url}\n\n`);
         }

--- a/src/settings/security.ts
+++ b/src/settings/security.ts
@@ -1,5 +1,5 @@
 /**
- * Security utilities for the pm-bridge-mcp Settings Server
+ * Security utilities for the mailpouch Settings Server
  *
  * Covers:
  *   • Per-IP rate limiting (sliding window, in-memory)
@@ -311,7 +311,7 @@ export function tryGenerateSelfSignedCert(): TlsCredentials | null {
         "-days",   "365",
         "-nodes",
         "-batch",
-        "-subj",   "/CN=pm-bridge-mcp Settings/O=Local/C=US",
+        "-subj",   "/CN=mailpouch Settings/O=Local/C=US",
       ],
       { stdio: "pipe", timeout: 30_000 },
     );

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -1,5 +1,5 @@
 /**
- * pm-bridge-mcp — Settings UI Server
+ * mailpouch — Settings UI Server
  *
  * Starts a localhost-only HTTP server that serves a browser-based
  * configuration interface.  The UI lets users:
@@ -9,7 +9,7 @@
  *   • Test connectivity
  *   • View server status and the generated Claude Desktop config snippet
  *
- * The config is persisted to ~/.pm-bridge-mcp.json (mode 0600).
+ * The config is persisted to ~/.mailpouch.json (mode 0600).
  * The MCP server reads that file every 15 s, so changes take effect
  * without a restart.
  */
@@ -132,7 +132,7 @@ function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): s
 
   // Read version + name from package.json at the project root
   let pkgVersion = "unknown";
-  let pkgName = "pm-bridge-mcp";
+  let pkgName = "mailpouch";
   try {
     const pkgPath = _pkgJsonPath;
     const pkgJson = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string; name?: string };
@@ -149,7 +149,7 @@ function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): s
     process.platform === "darwin" ? "~/Library/Application Support/protonmail/bridge-v3/cert.pem" :
                                     "~/.config/protonmail/bridge-v3/cert.pem";
   const certPlatformHint = `Default location: <code style="background:var(--surface3);padding:1px 5px;border-radius:3px;font-size:11px">${certDefaultPath}</code>`;
-  // configPath comes from process.env.PM_BRIDGE_MCP_CONFIG and is injected
+  // configPath comes from process.env.MAILPOUCH_CONFIG and is injected
   // directly into two <code> elements via template-literal interpolation.
   // A path like `/home/u/<script>alert(1)</script>.json` (set by a malicious
   // env var or via path manipulation) would produce XSS in the settings page.
@@ -168,7 +168,7 @@ function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): s
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="csrf-token" content="${csrfToken}">
-<title>pm-bridge-mcp — Settings</title>
+<title>mailpouch — Settings</title>
 <style>
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -847,7 +847,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
   <div class="logo-wrap">
     <div class="logo-icon">✉</div>
     <div>
-      <div class="header-title">pm-bridge-mcp</div>
+      <div class="header-title">mailpouch</div>
       <div class="header-subtitle">Settings</div>
     </div>
   </div>
@@ -925,7 +925,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
       <!-- ══ Step 1: Welcome ══ -->
       <div class="wiz-panel active" id="wpanel-0" role="tabpanel" aria-label="Welcome">
-        <div class="wiz-title">Welcome to pm-bridge-mcp</div>
+        <div class="wiz-title">Welcome to mailpouch</div>
         <div class="wiz-subtitle">
           Give Claude secure, permission-controlled access to your Proton Mail inbox
           via Proton Bridge. Setup takes about 3 minutes.
@@ -1263,7 +1263,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
         <div class="done-hero">
           <div class="done-check">✓</div>
           <h2>You're all set!</h2>
-          <p>pm-bridge-mcp is configured. The last step is registering it with your MCP host.</p>
+          <p>mailpouch is configured. The last step is registering it with your MCP host.</p>
         </div>
 
         <div id="done-write-section">
@@ -2427,9 +2427,9 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
     // Build snippet from wizard state
     const snippet = {
-      'pm-bridge': {
+      'mailpouch': {
         command: 'node',
-        args: [window.__distIndexPath || '/path/to/pm-bridge-mcp/dist/index.js'],
+        args: [window.__distIndexPath || '/path/to/mailpouch/dist/index.js'],
       },
     };
     document.getElementById('done-snippet').textContent = JSON.stringify(snippet, null, 2);
@@ -2894,9 +2894,9 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
   function buildClaudeSnippet(cn) {
     const snippet = {
-      'pm-bridge': {
+      'mailpouch': {
         command: 'node',
-        args: [window.__distIndexPath || '/path/to/pm-bridge-mcp/dist/index.js'],
+        args: [window.__distIndexPath || '/path/to/mailpouch/dist/index.js'],
       },
     };
     document.getElementById('claude-snippet').textContent = JSON.stringify(snippet, null, 2);
@@ -3896,7 +3896,7 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         try {
           const pkgJson = JSON.parse(readFileSync(_pkgJsonPath, "utf-8")) as { version?: string; name?: string };
           const current = pkgJson.version ?? "unknown";
-          const name    = pkgJson.name    ?? "pm-bridge-mcp";
+          const name    = pkgJson.name    ?? "mailpouch";
 
           const latest = await new Promise<string>((resolve, reject) => {
             const isWin = process.platform === "win32";
@@ -3956,7 +3956,7 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         if (!requireCsrf(req, res)) return;
         try {
           const pkgJson = JSON.parse(readFileSync(_pkgJsonPath, "utf-8")) as { name?: string };
-          const name    = pkgJson.name ?? "pm-bridge-mcp";
+          const name    = pkgJson.name ?? "mailpouch";
 
           const output = await new Promise<string>((resolve, reject) => {
             const isWin = process.platform === "win32";
@@ -4360,7 +4360,7 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           if (!existing.mcpServers || typeof existing.mcpServers !== "object") {
             existing.mcpServers = {};
           }
-          (existing.mcpServers as Record<string, unknown>)["pm-bridge"] = entry;
+          (existing.mcpServers as Record<string, unknown>)["mailpouch"] = entry;
 
           // Write atomically via temp file + rename
           const tmpPath = claudeConfigPath + ".tmp." + randomBytes(6).toString("hex");
@@ -4542,7 +4542,7 @@ export async function startSettingsServer(
 
     console.log("");
     console.log(`  ┌${"─".repeat(w + 2)}┐`);
-    line("pm-bridge-mcp — Settings UI");
+    line("mailpouch — Settings UI");
     blank();
     line(`Local:   ${localUrl}`);
 

--- a/src/settings/tui.ts
+++ b/src/settings/tui.ts
@@ -1,5 +1,5 @@
 /**
- * pm-bridge-mcp — Terminal UI
+ * mailpouch — Terminal UI
  *
  * Provides interactive configuration management when a browser is not
  * available. Detects the environment at runtime and selects the best
@@ -186,7 +186,7 @@ export function printNonInteractive(): void {
   const cfg = loadConfig();
   const path = getConfigPath();
 
-  process.stdout.write("\npm-bridge-mcp — Settings\n");
+  process.stdout.write("\nmailpouch — Settings\n");
   process.stdout.write("─".repeat(48) + "\n");
 
   if (cfg) {
@@ -201,7 +201,7 @@ export function printNonInteractive(): void {
   }
 
   process.stdout.write("\nTo configure: run in an interactive terminal, or start the browser UI:\n");
-  process.stdout.write("  npx pm-bridge-mcp-settings\n\n");
+  process.stdout.write("  npx mailpouch-settings\n\n");
 }
 
 // ─── Colour helpers (ANSI) ────────────────────────────────────────────────────
@@ -317,7 +317,7 @@ function ansiDraw(st: AnsiState): void {
   out.push(C.clrScr + C.hideCur);
 
   // Header
-  const title = "  ✉  pm-bridge-mcp — Settings";
+  const title = "  ✉  mailpouch — Settings";
   out.push(C.bgNav + C.bCyan + C.bold + title.padEnd(w) + C.reset + "\n");
 
   const cfgExists = configExists();
@@ -739,7 +739,7 @@ export async function runPlainTUI(serverPort: number, startServerFn: (port: numb
   function hr() { process.stdout.write("─".repeat(48) + "\n"); }
 
   function printHeader() {
-    process.stdout.write("\npm-bridge-mcp — Settings\n");
+    process.stdout.write("\nmailpouch — Settings\n");
     hr();
     const cfg = loadConfig();
     const path = getConfigPath();

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -9,4 +9,4 @@
  * every call site. Tests that verify the throw-on-missing-cert behavior
  * override this in their own setup.
  */
-process.env.PROTONMAIL_MCP_INSECURE_BRIDGE = "1";
+process.env.MAILPOUCH_INSECURE_BRIDGE = "1";

--- a/src/tools/bridge.ts
+++ b/src/tools/bridge.ts
@@ -81,7 +81,7 @@ export const handlers: Record<string, ToolHandler> = {
       spawn(process.execPath, process.argv.slice(1), {
         stdio: "ignore",
         detached: true,
-        env: { ...process.env, PM_BRIDGE_MCP_RESPAWN: "1" },
+        env: { ...process.env, MAILPOUCH_RESPAWN: "1" },
       }).unref();
     } catch (spawnErr: unknown) {
       logger.error("Failed to spawn replacement process during restart", "MCPServer", spawnErr);

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -36,7 +36,7 @@ async function freePort(): Promise<number> {
 }
 
 function buildServer(): McpServer {
-  const srv = new McpServer({ name: "pm-bridge-mcp-test", version: "0.0.0" }, {
+  const srv = new McpServer({ name: "mailpouch-test", version: "0.0.0" }, {
     capabilities: { tools: { listChanged: false } },
   });
   srv.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
@@ -415,7 +415,7 @@ describe("HTTP transport", () => {
       const res = await fetch(`${url}/oauth/authorize?${q.toString()}`);
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("Authorize pm-bridge-mcp");
+      expect(html).toContain("Authorize mailpouch");
       expect(html).toContain("Inky");
     });
 

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -1,5 +1,5 @@
 /**
- * HTTP transport for pm-bridge-mcp (remote / self-host mode).
+ * HTTP transport for mailpouch (remote / self-host mode).
  *
  * Spec reference: https://modelcontextprotocol.io/specification/2025-11-25
  *
@@ -244,7 +244,7 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
         const expectedResource = `${issuer}${path}`;
         if (rec.resource && rec.resource !== expectedResource) {
           res.statusCode = 401;
-          res.setHeader("WWW-Authenticate", `Bearer realm="pm-bridge-mcp", error="invalid_token", error_description="token resource does not match endpoint"`);
+          res.setHeader("WWW-Authenticate", `Bearer realm="mailpouch", error="invalid_token", error_description="token resource does not match endpoint"`);
           res.end(JSON.stringify({ error: "invalid_token" }));
           return;
         }
@@ -261,8 +261,8 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
       res.statusCode = 401;
       res.setHeader("WWW-Authenticate",
         oauthHandlers
-          ? `Bearer realm="pm-bridge-mcp", resource_metadata="${issuer}/.well-known/oauth-protected-resource"`
-          : 'Bearer realm="pm-bridge-mcp"',
+          ? `Bearer realm="mailpouch", resource_metadata="${issuer}/.well-known/oauth-protected-resource"`
+          : 'Bearer realm="mailpouch"',
       );
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "invalid_token" }));

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -1,5 +1,5 @@
 /**
- * OAuth 2.1 authorization-server HTTP handlers for pm-bridge-mcp.
+ * OAuth 2.1 authorization-server HTTP handlers for mailpouch.
  *
  * Implements the surface required by the 2025-11-25 MCP spec for an
  * authenticated remote deployment:
@@ -181,7 +181,7 @@ export class OAuthHandlers {
       authorization_servers: [this.cfg.issuer],
       scopes_supported: SCOPES,
       bearer_methods_supported: ["header"],
-      resource_name: "pm-bridge-mcp",
+      resource_name: "mailpouch",
     });
     return { handled: true };
   }
@@ -381,7 +381,7 @@ export class OAuthHandlers {
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; form-action 'self'">
-    <title>pm-bridge-mcp — authorize</title>
+    <title>mailpouch — authorize</title>
     <style>
       body { font-family: system-ui, sans-serif; background: #111; color: #eee; margin: 0; padding: 40px; }
       .card { max-width: 480px; margin: 0 auto; background: #1b1b1e; padding: 24px; border-radius: 12px; }
@@ -398,7 +398,7 @@ export class OAuthHandlers {
   </head>
   <body>
     <div class="card">
-      <h1>Authorize pm-bridge-mcp</h1>
+      <h1>Authorize mailpouch</h1>
       <p>An MCP client is requesting access to your Proton Mail via this server.</p>
       <dl>
         <dt>Client</dt><dd>${esc(ctx.clientName)} (${esc(ctx.clientId)})</dd>

--- a/src/transports/oauth-store.ts
+++ b/src/transports/oauth-store.ts
@@ -1,7 +1,7 @@
 /**
  * In-memory stores for the OAuth 2.1 authorization server.
  *
- * All state is process-local — matching pm-bridge-mcp's single-user design.
+ * All state is process-local — matching mailpouch's single-user design.
  * A restart drops outstanding auth codes (short TTL anyway) and tokens
  * (requiring clients to re-auth); registered DCR clients are re-provisioned
  * on demand because MCP hosts will call the register endpoint again.

--- a/src/tray.ts
+++ b/src/tray.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * pm-bridge-mcp — System Tray entry point
+ * mailpouch — System Tray entry point
  *
  * Starts the settings HTTP server and shows a system tray icon
  * matching the style of the Proton Bridge tray icon:
@@ -163,7 +163,7 @@ async function main(): Promise<void> {
     // systray2 not installed — start server and open browser, no tray icon
     openBrowser(settingsUrl);
     process.stdout.write(
-      `\npm-bridge-mcp Settings: ${settingsUrl}\nPress Ctrl+C to stop.\n\n`
+      `\nmailpouch Settings: ${settingsUrl}\nPress Ctrl+C to stop.\n\n`
     );
     return;
   }
@@ -176,9 +176,9 @@ async function main(): Promise<void> {
     menu: {
       icon:    ICON_B64,
       title:   "",
-      tooltip: "pm-bridge-mcp",
+      tooltip: "mailpouch",
       items: [
-        item("pm-bridge-mcp", "Proton Mail via Proton Bridge", false),
+        item("mailpouch", "Proton Mail via Proton Bridge", false),
         sep,
         item(`\u25CF Connected`,    "", false),
         item(email || "Not configured", "", false),
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
   });
 
   process.stdout.write(
-    `\npm-bridge-mcp tray icon active.\nSettings: ${settingsUrl}\nRight-click the tray icon to manage.\n\n`
+    `\nmailpouch tray icon active.\nSettings: ${settingsUrl}\nRight-click the tray icon to manage.\n\n`
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Type definitions for pm-bridge-mcp (the Proton Mail MCP server)
+ * Type definitions for mailpouch (the Proton Mail MCP server)
  */
 
 export interface SMTPConfig {
@@ -15,7 +15,7 @@ export interface SMTPConfig {
   /**
    * Explicit opt-in to accept the local Bridge connection without a pinned TLS cert.
    * Default false → the service refuses to start when localhost is used without a cert.
-   * Set true (or PM_BRIDGE_MCP_INSECURE_BRIDGE=1) to preserve the pre-2026-04 behavior.
+   * Set true (or MAILPOUCH_INSECURE_BRIDGE=1) to preserve the pre-2026-04 behavior.
    */
   allowInsecureBridge?: boolean;
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Helper utilities for pm-bridge-mcp
+ * Helper utilities for mailpouch
  */
 
 import { randomUUID } from "crypto";

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
 /**
- * Logging utility for pm-bridge-mcp
+ * Logging utility for mailpouch
  */
 
 import { appendFile, existsSync } from "fs";
@@ -18,17 +18,21 @@ import { LogEntry } from "../types/index.js";
 const SENSITIVE_KEYS = /(password|token|secret|apikey|api_key|verifier|credential|authorization|bridgecertpath|attachments|content|^body$)/i;
 
 export function getLogFilePath(): string {
-  // Accept either the new PM_BRIDGE_MCP name or the legacy PROTONMAIL name.
-  // New wins; legacy is silently honored for one release to avoid breaking
-  // existing installs. Remove the PROTONMAIL_LOG_FILE alias in v2.2.
-  const envPath = process.env.PM_BRIDGE_MCP_LOG_FILE || process.env.PROTONMAIL_LOG_FILE;
+  // Env-var priority: MAILPOUCH_* > PM_BRIDGE_MCP_* > PROTONMAIL_*. First truthy
+  // wins. Legacy names honored through v3.0.
+  const envPath = process.env.MAILPOUCH_LOG_FILE
+    || process.env.PM_BRIDGE_MCP_LOG_FILE
+    || process.env.PROTONMAIL_LOG_FILE;
   if (envPath) return envPath;
-  // Read-old/write-new: if a legacy ~/.protonmail-mcp.log exists and the new
-  // one doesn't, keep appending to the legacy file so existing tail/grep
-  // workflows don't suddenly go silent. Otherwise, write to the new path.
-  const preferred = join(homedir(), ".pm-bridge-mcp.log");
-  const legacy = join(homedir(), ".protonmail-mcp.log");
-  if (!existsSync(preferred) && existsSync(legacy)) return legacy;
+  // Read-old/write-new: if a legacy log file exists and the new one doesn't,
+  // keep appending so existing tail/grep workflows don't suddenly go silent.
+  const preferred = join(homedir(), ".mailpouch.log");
+  const legacyV2 = join(homedir(), ".pm-bridge-mcp.log");
+  const legacyV1 = join(homedir(), ".protonmail-mcp.log");
+  if (!existsSync(preferred)) {
+    if (existsSync(legacyV2)) return legacyV2;
+    if (existsSync(legacyV1)) return legacyV1;
+  }
   return preferred;
 }
 


### PR DESCRIPTION
## Summary

Renames the project from `pm-bridge-mcp` to **`mailpouch`** in a single commit, with a one-shot OS keychain migration on startup and three-tier env-var / file-path fallbacks so existing installs carry forward without user action.

## Clusters changed

| Cluster | Notes |
|---|---|
| `package.json` | `name`, `version` → `2.2.0`, `bin` (`mailpouch`, `mailpouch-settings`), `homepage`, `repository.url`, `bugs.url`, `keywords`, `description` |
| Env-var prefix | 9 variables × 3-tier chain (`MAILPOUCH_*` > `PM_BRIDGE_MCP_*` > `PROTONMAIL_MCP_*`), first match wins |
| `$HOME/*` paths | config / log / scheduler / reminders / pass-audit / fts / agents / agent-audit / pending / escalation-audit — all read-fallback, write-new |
| MCP server identity | `Server` name + Claude Desktop key `pm-bridge` → `mailpouch` |
| Webhook dispatcher | Signature header, User-Agent, CloudEvents `source` + `type` prefix |
| OS keychain | `SERVICE_NAME` → `mailpouch` + `migrateLegacyKeychainEntries()` wired into `main()` |
| CLI / UI strings | TUI banners, settings-server HTML, tray menu, help output, logger messages |
| Docs | README, CHANGELOG, CONTRIBUTING, SECURITY, README_FIRST_AI, .env.example, docs/*.md |

## Env-var alias priority

At every read site: `process.env.MAILPOUCH_X ?? process.env.PM_BRIDGE_MCP_X ?? process.env.PROTONMAIL_MCP_X` (first truthy wins). Legacy names honored through v3.0.

## File-path fallback pattern

New path preferred; read falls back through v2.1 (`~/.pm-bridge-mcp-*`) then original (`~/.protonmail-mcp-*`) if the new path is absent. Writes always target the new path. `logger.info` fires when a legacy fallback is resolved so the migration is visible to operators.

## Keychain migration

`migrateLegacyKeychainEntries()` runs once at startup (before `loadCredentialsFromKeychain`). For each account-key × each legacy service (`pm-bridge-mcp`, `protonmail-mcp-server`):
- legacy entry present + new entry empty → copy + delete legacy, log `info`
- legacy entry present + new entry already set → leave both, increment `conflicts`
- no legacy entry → noop
- `@napi-rs/keyring` import fails → noop (non-fatal)

## Breaking (downstream)

- Webhook signature header `X-PMBridge-Signature-256` → `X-Mailpouch-Signature-256`
- CloudEvents: `source` `pm-bridge-mcp` → `mailpouch`; `type` `com.pmbridge.*` → `com.mailpouch.*`
- Outbound User-Agent: `mailpouch/1 (+https://github.com/chandshy/mailpouch)`
- Binary names: `pm-bridge-mcp` → `mailpouch`, `pm-bridge-mcp-settings` → `mailpouch-settings`
- Package name: `pm-bridge-mcp` → `mailpouch` (not yet published to npm, so no `npm install` compat break)

## Tests

**Before:** 1,569 passing  
**After:** 1,580 passing (+11)

New coverage:
- 4 keychain migration scenarios (legacy→new, conflict, noop, import-fail) — fresh `vi.mock` pattern for the dynamic `@napi-rs/keyring` import
- 5 env-var priority chain tests (loader `MAILPOUCH_CONFIG` default + chain, escalation `MAILPOUCH_PENDING/AUDIT` chain)
- 2 TLS insecure-bridge env-alias tests (`MAILPOUCH_INSECURE_BRIDGE` + legacy kept)

## Judgment calls

- Introduced one helper `_resolveHomeFile(envNames, basenames)` in `src/index.ts` rather than duplicating the 3-tier pattern inline across 5 sites. No refactor beyond that.
- CI workflows already use `${{ github.repository }}` — no owner-rename breakage; they auto-track once the repo is renamed on GitHub.
- `tools/bridge.ts` restart-respawn marker changed to `MAILPOUCH_RESPAWN`; `main()` also honors legacy `PM_BRIDGE_MCP_RESPAWN` / `PROTONMAIL_MCP_RESPAWN` so a v2.1 parent respawning against a v2.2 child still suppresses the daemon side-effects.

## Test plan

- [ ] `npm test` — all 1,580 tests green
- [ ] `npm run typecheck` — clean
- [ ] Manually confirm an install with an existing `~/.pm-bridge-mcp.json` + legacy keychain entry migrates on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)