### PR TITLE
fix(settings-ui): escape single quotes in dynamic innerHTML + copy tweak

### DIFF
--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -927,7 +927,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
       <div class="wiz-panel active" id="wpanel-0" role="tabpanel" aria-label="Welcome">
         <div class="wiz-title">Welcome to mailpouch</div>
         <div class="wiz-subtitle">
-          Give Claude secure, permission-controlled access to your Proton Mail inbox
+          Give your Agent secure, permission-controlled access to your Proton Mail inbox
           via Proton Bridge. Setup takes about 3 minutes.
         </div>
 
@@ -1889,9 +1889,9 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
     list.innerHTML = rows.map(a => {
       const active = a.id === activeId;
       const buttons =
-        (active ? '' : '<button class="btn btn-primary" onclick="activateAccount(\'' + esc(a.id) + '\')">Activate</button>') +
-        '<button class="btn btn-ghost" onclick="editAccount(\'' + esc(a.id) + '\')">Edit</button>' +
-        (!active ? '<button class="btn btn-ghost" onclick="deleteAccountConfirm(\'' + esc(a.id) + '\')">Delete</button>' : '');
+        (active ? '' : '<button class="btn btn-primary" onclick="activateAccount(\\'' + esc(a.id) + '\\')">Activate</button>') +
+        '<button class="btn btn-ghost" onclick="editAccount(\\'' + esc(a.id) + '\\')">Edit</button>' +
+        (!active ? '<button class="btn btn-ghost" onclick="deleteAccountConfirm(\\'' + esc(a.id) + '\\')">Delete</button>' : '');
       const last = a.lastCheckedAt ? ' · last check ' + new Date(a.lastCheckedAt).toLocaleString() + ' · ' + esc(a.lastCheckResult || '') : '';
       return (
         '<div class="card" style="padding:12px;border:1px solid #333;border-radius:8px;' + (active ? 'border-color:#6D4AFF' : '') + '">' +
@@ -2071,13 +2071,13 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
       const nameEsc = esc(g.clientName);
       const condArg = g.conditions ? JSON.stringify(g.conditions).replace(/'/g, "\\'") : 'null';
       const buttons = g.status === 'pending'
-        ? '<button class="btn btn-primary" onclick="approveGrant(\'' + cidEsc + '\',\'read_only\')">Approve read-only</button>' +
-          '<button class="btn btn-primary" onclick="approveGrant(\'' + cidEsc + '\',\'supervised\')">Approve supervised</button>' +
-          '<button class="btn btn-ghost"   onclick="openGrantModal(\'' + cidEsc + '\',\'' + nameEsc + '\',null)">Customize\u2026</button>' +
-          '<button class="btn btn-ghost"   onclick="denyGrant(\''    + cidEsc + '\')">Deny</button>'
+        ? '<button class="btn btn-primary" onclick="approveGrant(\\'' + cidEsc + '\\',\\'read_only\\')">Approve read-only</button>' +
+          '<button class="btn btn-primary" onclick="approveGrant(\\'' + cidEsc + '\\',\\'supervised\\')">Approve supervised</button>' +
+          '<button class="btn btn-ghost"   onclick="openGrantModal(\\'' + cidEsc + '\\',\\'' + nameEsc + '\\',null)">Customize\u2026</button>' +
+          '<button class="btn btn-ghost"   onclick="denyGrant(\\''    + cidEsc + '\\')">Deny</button>'
         : g.status === 'active'
-        ? '<button class="btn btn-ghost"   onclick="openGrantModal(\'' + cidEsc + '\',\'' + nameEsc + '\',' + condArg + ')">Extend / modify\u2026</button>' +
-          '<button class="btn btn-ghost"   onclick="revokeGrant(\''  + cidEsc + '\')">Revoke</button>'
+        ? '<button class="btn btn-ghost"   onclick="openGrantModal(\\'' + cidEsc + '\\',\\'' + nameEsc + '\\',' + condArg + ')">Extend / modify\u2026</button>' +
+          '<button class="btn btn-ghost"   onclick="revokeGrant(\\''  + cidEsc + '\\')">Revoke</button>'
         : '';
       return (
         '<div class="card" style="padding:12px;border:1px solid #333;border-radius:8px">' +


### PR DESCRIPTION
## Summary

Two fixes in one PR, both narrow:

### 1. Wizard/settings UI clicks were silent no-ops

\`buildHtml()\` returns a template literal containing an inline \`<script>\`. Inside a template literal, \`\\'\` is an escape sequence that produces \`'\`. Source code like

\`\`\`ts
'onclick="activateAccount(\\'' + esc(a.id) + '\\')"'
\`\`\`

was being shipped to the browser as

\`\`\`js
'onclick="activateAccount(\\'\\' + esc(a.id) + \\'\\')"'   // '' = empty strings
\`\`\`

which is a JavaScript syntax error. The whole inline \`<script>\` fails to parse after that line → \`wizGo\` / \`openSettingsView\` / \`showTab\` / etc. never get assigned to \`window\` → every click becomes a silent no-op. Symptom in the browser: the wizard shows on first run and nothing responds.

Fix: change \`\\'\` → \`\\\\'\` at each affected site so the template literal emits a literal \`\\'\` in the shipped JS.

Affected call sites (all inside \`refreshAccounts\` and \`refreshGrants\` innerHTML builders):
- \`activateAccount\`, \`editAccount\`, \`deleteAccountConfirm\`
- \`approveGrant\` (×2 for read_only / supervised)
- \`openGrantModal\` (×2 — pending + active)
- \`denyGrant\`, \`revokeGrant\`

### 2. Welcome-step copy

"Give Claude secure …" → "Give your Agent secure …" so the wizard reads correctly for non-Claude MCP clients.

## Verification

- \`node --check\` on the full in-browser \`<script>\` payload now parses clean (fails on main).
- Restarted the settings UI and exercised the wizard in a browser: Get Started advances, Skip wizard goes to tabs, Accounts tab Activate/Edit/Delete buttons fire.
- \`npm run build\` clean.
- **1,580 tests pass** (no behavior delta — tests don't exercise the in-browser DOM).

## Why no test added

The break was a server-rendered-string-to-browser-script pipeline issue; exercising it requires a browser DOM. The linter equivalent is \`node --check\` on the inline script — worth wiring into CI in a follow-up but out of scope here (would need to extract the script from the rendered HTML first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)