### PR TITLE
fix: harden platform-specific spawns against unhandled async errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1285,7 +1285,18 @@ async function launchProtonBridge(): Promise<void> {
   // User-configured path takes top priority
   if (config.bridgePath && existsSync(config.bridgePath)) {
     try {
-      spawn(config.bridgePath, [], { stdio: "ignore", detached: true, shell: false }).unref();
+      // Detach + unref lets Bridge outlive us, but an ENOENT (stale path
+      // across platforms, missing perms) arrives as an async 'error' event.
+      // Without a listener Node converts it to an unhandled throw that
+      // crashes the whole MCP server — attach a no-op handler and let the
+      // reachability poll below surface the failure naturally.
+      const bridgeProc = spawn(config.bridgePath, [], {
+        stdio: "ignore", detached: true, shell: false,
+      });
+      bridgeProc.on("error", (err) => {
+        logger.warn("Proton Bridge launch process emitted error", "MCPServer", err);
+      });
+      bridgeProc.unref();
       logger.info("Proton Bridge launch command sent — waiting up to 15 s for ports to open…", "MCPServer");
       const deadline = Date.now() + 15_000;
       while (Date.now() < deadline) {
@@ -1365,7 +1376,13 @@ async function launchProtonBridge(): Promise<void> {
     }
   }
   try {
-    spawn(cmd, args, { stdio: "ignore", detached: true, shell: false }).unref();
+    // Same async-error concern as the user-configured path above: attach a
+    // listener before .unref() so a spawn failure can't crash the MCP server.
+    const bridgeProc = spawn(cmd, args, { stdio: "ignore", detached: true, shell: false });
+    bridgeProc.on("error", (err) => {
+      logger.warn("Proton Bridge launch process emitted error", "MCPServer", err);
+    });
+    bridgeProc.unref();
     logger.info("Proton Bridge launch command sent — waiting up to 15 s for ports to open…", "MCPServer");
     const deadline = Date.now() + 15_000;
     while (Date.now() < deadline) {
@@ -1754,6 +1771,30 @@ async function main() {
       config.imap.bridgeCertPath = cn.bridgeCertPath || undefined;
       config.smtp.allowInsecureBridge = cn.allowInsecureBridge ?? false;
       config.imap.allowInsecureBridge = cn.allowInsecureBridge ?? false;
+
+      // Surface a clear startup warning when bridgeCertPath is configured
+      // but unreachable on disk — common after moving config across machines
+      // (e.g. a Windows path copied to a Linux install). Connection-time
+      // errors arrive buried inside tool responses; the startup warning gets
+      // the fix in front of the operator before they hit the first failure.
+      if (cn.bridgeCertPath) {
+        const cpath = cn.bridgeCertPath;
+        if (!existsSync(cpath)) {
+          const looksWindowsOnUnix = process.platform !== "win32" && /^[A-Za-z]:[\\/]/.test(cpath);
+          const looksUnixOnWindows = process.platform === "win32" && cpath.startsWith("/");
+          const platformHint = looksWindowsOnUnix
+            ? ` — the path looks Windows-style but this host is ${process.platform}.`
+            : looksUnixOnWindows
+              ? " — the path looks POSIX-style but this host is Windows."
+              : "";
+          logger.warn(
+            `bridgeCertPath '${cpath}' does not exist on disk${platformHint} ` +
+            `Open the settings UI → Bridge TLS Certificate to re-export the cert, ` +
+            `or enable 'Allow insecure Bridge' for a loopback-only install.`,
+            "MCPServer",
+          );
+        }
+      }
       config.debug              = !!cn.debug;
       config.autoStartBridge    = !!cn.autoStartBridge;
       config.bridgePath         = cn.bridgePath || undefined;

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4186,7 +4186,17 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         }
         try {
           if (bridgeExe) {
-            spawn(bridgeExe, [], { stdio: "ignore", detached: true, shell: false }).unref();
+            // Async 'error' would crash the server without a listener, even
+            // after .unref() — existsSync above doesn't guarantee spawn.
+            const bridgeProc = spawn(bridgeExe, [], {
+              stdio: "ignore", detached: true, shell: false,
+            });
+            bridgeProc.on("error", (err) => {
+              // Best-effort log; the tcp poll below will surface the failure
+              // to the caller as `reachable: false`.
+              void err;
+            });
+            bridgeProc.unref();
           }
         } catch (e: unknown) {
           const msg = e instanceof Error ? e.message : String(e);
@@ -4738,6 +4748,43 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         try {
           const platform = process.platform;
 
+          // Detect Claude Desktop install BEFORE killing anything. There is no
+          // official Linux build, and on macOS/Windows it may just not be
+          // installed — better to bail cleanly than leave the user with a
+          // killed instance and no relaunch path.
+          let claudeLaunchCmd: string | null = null;
+          let claudeLaunchArgs: string[] = [];
+          if (platform === "darwin") {
+            const macApp = "/Applications/Claude.app";
+            if (existsSync(macApp)) {
+              claudeLaunchCmd = "open";
+              claudeLaunchArgs = ["-a", "Claude"];
+            }
+          } else if (platform === "win32") {
+            const winCandidates = [
+              nodePath.join(process.env.LOCALAPPDATA ?? "", "AnthropicClaude", "Claude.exe"),
+              nodePath.join(process.env.LOCALAPPDATA ?? "", "Programs", "Claude", "Claude.exe"),
+              nodePath.join(process.env.PROGRAMFILES ?? "", "Claude", "Claude.exe"),
+            ];
+            const found = winCandidates.find((p) => p && existsSync(p));
+            if (found) {
+              claudeLaunchCmd = "cmd";
+              claudeLaunchArgs = ["/c", "start", "", found];
+            }
+          }
+          // Linux (and any platform where detection failed) falls through with
+          // claudeLaunchCmd === null.
+
+          if (!claudeLaunchCmd) {
+            json(res, 200, {
+              ok: false,
+              error: platform === "linux"
+                ? "Claude Desktop is not distributed for Linux. Restart it manually from wherever you launched it."
+                : "Claude Desktop was not found at the standard install locations. Launch it manually.",
+            });
+            return;
+          }
+
           // Kill Claude Desktop (ignore errors — may not be running)
           await new Promise<void>((resolve) => {
             let killCmd: string;
@@ -4745,12 +4792,9 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
             if (platform === "win32") {
               killCmd = "taskkill";
               killArgs = ["/IM", "Claude.exe", "/F"];
-            } else if (platform === "darwin") {
+            } else {
               killCmd = "killall";
               killArgs = ["Claude"];
-            } else {
-              killCmd = "pkill";
-              killArgs = ["-f", "Claude"];
             }
             const killProc = spawn(killCmd, killArgs, { stdio: "ignore" });
             killProc.on("close", () => resolve());
@@ -4760,14 +4804,15 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           // Wait ~500ms before relaunching
           await new Promise<void>((resolve) => setTimeout(resolve, 500));
 
-          // Relaunch Claude Desktop (fire-and-forget)
-          if (platform === "win32") {
-            spawn("cmd", ["/c", "start", "Claude"], { stdio: "ignore", detached: true }).unref();
-          } else if (platform === "darwin") {
-            spawn("open", ["-a", "Claude"], { stdio: "ignore", detached: true }).unref();
-          } else {
-            spawn("Claude", [], { stdio: "ignore", detached: true }).unref();
-          }
+          // Relaunch Claude Desktop (fire-and-forget). Attach an async error
+          // handler: without it, an ENOENT becomes an unhandled 'error' event
+          // and crashes the settings server — we still reply 200 here because
+          // we pre-verified the binary exists.
+          const launchProc = spawn(claudeLaunchCmd, claudeLaunchArgs, {
+            stdio: "ignore", detached: true,
+          });
+          launchProc.on("error", () => { /* already verified presence; swallow */ });
+          launchProc.unref();
 
           json(res, 200, { ok: true });
         } catch (e: unknown) {

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -1837,6 +1837,31 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
   // ── CSRF ──────────────────────────────────────────────────────────────────
   const CSRF = document.querySelector('meta[name="csrf-token"]')?.content || '';
 
+  // Auto-recover from stale CSRF tokens. The server's CSRF token is minted
+  // per-process — when the daemon restarts (e.g. after install-update or a
+  // crash), any open settings tab holds a token the new process rejects with
+  // 403 { code: "session_expired" }. Without this wrapper the user sees a
+  // raw "Missing or invalid CSRF token" alert and has no idea what to do;
+  // with it, the page silently reloads and picks up the fresh token. Guarded
+  // by __mpReloading so concurrent mutations only trigger one reload.
+  (function installCsrfAutoReload() {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async function(...args) {
+      const response = await originalFetch(...args);
+      if (response.status === 403 && !window.__mpReloading) {
+        try {
+          const clone = response.clone();
+          const body = await clone.json();
+          if (body && body.code === 'session_expired') {
+            window.__mpReloading = true;
+            try { window.location.reload(); } catch (_) { /* ignore */ }
+          }
+        } catch (_) { /* not JSON — not ours */ }
+      }
+      return response;
+    };
+  })();
+
   // ── Boot ──────────────────────────────────────────────────────────────────
   window.addEventListener('DOMContentLoaded', async () => {
     buildCategoryUI();
@@ -3838,7 +3863,16 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
       provided.length === csrfToken.length &&
       timingSafeEqual(Buffer.from(provided, "utf8"), Buffer.from(csrfToken, "utf8"));
     if (valid) return true;
-    json(res, 403, { error: "Missing or invalid CSRF token. Load the settings page in a browser first." });
+    // Human-legible message. Stable `code` field drives the client-side
+    // auto-reload interceptor (see CSRF_SESSION_EXPIRED_CODE / fetch wrapper
+    // in the inline page JS) — when the server restarts, the browser's cached
+    // token goes stale and every mutation 403's; we catch that and silently
+    // reload so the user sees "page refreshed" rather than
+    // "Missing or invalid CSRF token".
+    json(res, 403, {
+      error: "Your settings session expired. Reload the page to continue.",
+      code: "session_expired",
+    });
     return false;
   }
 

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4226,9 +4226,13 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
               stdio: "ignore", detached: true, shell: false,
             });
             bridgeProc.on("error", (err) => {
-              // Best-effort log; the tcp poll below will surface the failure
-              // to the caller as `reachable: false`.
-              void err;
+              // Log at warn level so operators can diagnose launch failures
+              // from `tail ~/.mailpouch.log`. The tcp poll below will also
+              // surface this to the HTTP caller as `reachable: false`, but
+              // the specific error (ENOENT vs EACCES vs EPERM) only shows
+              // up here.
+              const msg = err instanceof Error ? err.message : String(err);
+              logger.warn(`Failed to launch Proton Bridge (${bridgeExe}): ${msg}`, "SettingsServer");
             });
             bridgeProc.unref();
           }
@@ -4795,12 +4799,21 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
               claudeLaunchArgs = ["-a", "Claude"];
             }
           } else if (platform === "win32") {
-            const winCandidates = [
-              nodePath.join(process.env.LOCALAPPDATA ?? "", "AnthropicClaude", "Claude.exe"),
-              nodePath.join(process.env.LOCALAPPDATA ?? "", "Programs", "Claude", "Claude.exe"),
-              nodePath.join(process.env.PROGRAMFILES ?? "", "Claude", "Claude.exe"),
-            ];
-            const found = winCandidates.find((p) => p && existsSync(p));
+            // Only build absolute candidates — falling back to `?? ""` would
+            // produce `AnthropicClaude\Claude.exe` (relative to cwd) if the
+            // env var is unset, which existsSync could match by accident and
+            // lead to killing Claude and then failing to relaunch.
+            const winCandidates: string[] = [];
+            const localAppData = process.env.LOCALAPPDATA;
+            const programFiles = process.env.PROGRAMFILES;
+            if (localAppData) {
+              winCandidates.push(nodePath.join(localAppData, "AnthropicClaude", "Claude.exe"));
+              winCandidates.push(nodePath.join(localAppData, "Programs", "Claude", "Claude.exe"));
+            }
+            if (programFiles) {
+              winCandidates.push(nodePath.join(programFiles, "Claude", "Claude.exe"));
+            }
+            const found = winCandidates.find((p) => existsSync(p));
             if (found) {
               claudeLaunchCmd = "cmd";
               claudeLaunchArgs = ["/c", "start", "", found];

--- a/src/tools/bridge.ts
+++ b/src/tools/bridge.ts
@@ -78,11 +78,18 @@ export const handlers: Record<string, ToolHandler> = {
     await killProtonBridge();
     state.bridgeAutoStarted = false;
     try {
-      spawn(process.execPath, process.argv.slice(1), {
+      // Attach an async 'error' handler before .unref() — otherwise an
+      // ENOENT / EACCES from the child can propagate as an unhandled event
+      // and take the current process down before gracefulShutdown runs.
+      const child = spawn(process.execPath, process.argv.slice(1), {
         stdio: "ignore",
         detached: true,
         env: { ...process.env, MAILPOUCH_RESPAWN: "1" },
-      }).unref();
+      });
+      child.on("error", (err) => {
+        logger.error("Replacement process emitted error after spawn", "MCPServer", err);
+      });
+      child.unref();
     } catch (spawnErr: unknown) {
       logger.error("Failed to spawn replacement process during restart", "MCPServer", spawnErr);
       throw new McpError(ErrorCode.InternalError, "Restart failed: could not spawn replacement process.");


### PR DESCRIPTION
## Summary

Hardens every platform-specific \`spawn()\` site in the codebase so
async child-process failures (ENOENT on missing binaries, EACCES on
perms, etc.) can't crash the MCP server or settings UI. Fixes a real
crash the user hit this session, a latent UX footgun around stale
CSRF tokens, and a handful of related correctness issues Copilot
caught during review.

## Pass 1 — Unhandled-spawn audit + fixes

Root crash: clicking **Restart Claude Desktop** on Linux spawned a
literal \`Claude\` binary that doesn't exist (no official Linux
distribution of Claude Desktop). The async ENOENT bypassed the
surrounding try/catch (try/catch sees the sync spawn call, not the
later 'error' event) and took down the settings server. Audit found
**six more detached-spawn sites with the same latent bug**.

Fixes:
- **Claude-restart endpoint** (\`settings/server.ts\`): pre-detect
  Claude Desktop via \`existsSync\` on platform-specific install
  locations; return \`200 { ok: false, error: "..." }\` with a
  platform-aware message when absent instead of killing the running
  instance and then crashing before relaunch.
- **Five more detached-spawn sites** (\`index.ts\` × 2, \`settings/
  server.ts\`, \`tools/bridge.ts\`) now attach \`.on('error')\`
  before \`.unref()\` so ENOENT can't propagate unhandled.
- **\`bridgeCertPath\` startup warning**: log a loud warning when
  the configured cert path is unreachable, with a platform-mismatch
  hint (Windows-style path on POSIX, or vice versa). Previously the
  failure only surfaced at first tool call, buried in a generic
  TLS error.

## Pass 2 — CSRF UX fix

The settings server mints a fresh CSRF token on every process start.
When the daemon restarts (install-update, crash, restart_server
tool, re-respawn), any browser tab holding the old token 403's on
the next mutation with "Missing or invalid CSRF token. Load the
settings page in a browser first." — opaque to normal users.

Fix:
- Server: rename the error to "Your settings session expired.
  Reload the page to continue." and add a stable machine-readable
  \`code: "session_expired"\` field.
- Client: wrap \`window.fetch\` at page load to intercept 403
  responses with \`code: "session_expired"\`; silently call
  \`window.location.reload()\` to pick up the fresh token. Guarded
  by \`window.__mpReloading\` so concurrent in-flight mutations
  only trigger one reload.

## Pass 3 — Copilot review fixes

- Bridge-launch \`.on('error')\` in \`/api/start-bridge\` was
  swallowing the error (\`void err\`) despite claiming to log.
  Now logs at warn level with the executable path + underlying
  message, so \`tail ~/.mailpouch.log\` surfaces specific spawn
  failure modes.
- Windows Claude-Desktop detection used \`path.join(LOCALAPPDATA
  ?? "", ...)\` which produces a *relative* path when unset —
  \`existsSync\` could match cwd accidentally, leading to "kill
  + fail to relaunch". Rebuilt the candidate list to only include
  absolute paths when the env var is actually defined.

## Audit complete list (all spawn sites, documented for future)

✓ Already correct:
- \`notifications/desktop.ts\` — has 'error' + 'close'
- \`services/pass-service.ts\` — try/catch + 'error' + typed error
- \`settings/server.ts:4261, 4321\` — npm view/install; pipe + 'error'
- \`settings/server.ts:4755\` — Claude kill; \`.on('error', resolve)\`
- \`index.ts:1407\` — Bridge kill; same pattern

Fixed here:
- \`index.ts:1288, 1368\` — Bridge launch (configured path + defaults)
- \`settings/server.ts: /api/start-bridge\` — Bridge launch via API
- \`settings/server.ts: /api/restart-claude-desktop\` — Claude relaunch
- \`tools/bridge.ts:81\` — self-respawn on \`restart_server\` tool

## Test plan

- [x] \`npm run lint\` — clean across all three commits
- [x] \`npm test\` — 1,566 / 1,566 passing (no regressions)
- [x] Reproduced original crash pre-fix (spawn \`Claude\` → process dies)
- [x] Verified post-fix: \`POST /api/restart-claude-desktop\` on
      Linux returns \`200 { ok: false, error: "Claude Desktop is
      not distributed for Linux..." }\` and server stays up

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] No new attack surface — all additions are defensive (error
      handlers, presence checks, absolute-path guards)
- [x] Dependencies unchanged
- [x] Docker changes: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)