### PR TITLE
fix(smtp): defer cert-load errors from ctor to first send

### DIFF
--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -43,6 +43,17 @@ export class SMTPService {
   /** True when TLS certificate validation is disabled (no Bridge cert configured). */
   insecureTls = false;
   /**
+   * Actionable initialization error, or null on successful init. Populated
+   * when the configured Bridge cert path cannot be loaded AND the user has
+   * not opted into insecure mode. Construction itself NEVER throws — a
+   * synchronous throw here would kill the MCP server at module load (stdio
+   * servers have no chance to report structured errors to the client
+   * before the transport comes up), so we defer the failure to the first
+   * sendEmail() / verifyConnection() call where the error can propagate
+   * back through the MCP response. reinitialize() clears this.
+   */
+  initError: string | null = null;
+  /**
    * Tracks consecutive abuse-signal failures (SMTP 421/450/454 etc.) and
    * holds back sends during the exponential-backoff window. Surfaced via
    * getBackoffState() so get_connection_status can report throttling to
@@ -57,6 +68,11 @@ export class SMTPService {
 
   private initializeTransporter(): void {
     logger.debug("Initializing SMTP transporter", "SMTPService");
+    // Reset degraded state so reinitialize() after the user fixes config
+    // clears any prior deferred failure.
+    this.initError = null;
+    this.transporter = null;
+    this.insecureTls = false;
 
     // Check if using localhost (Proton Bridge)
     const isLocalhost =
@@ -96,12 +112,20 @@ export class SMTPService {
           logger.info(`SMTP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, "SMTPService");
         } catch (err: unknown) {
           if (!allowInsecure) {
-            throw new Error(
+            // Deferred failure: stash an actionable message, log a loud
+            // warning, return without building a transporter. sendEmail()
+            // surfaces this to the caller; the MCP server stays up.
+            this.initError =
               `SMTP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
               `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
               `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
-              `Underlying error: ${(err as Error).message}`
+              `Underlying error: ${(err as Error).message}`;
+            logger.warn(
+              `SMTP init deferred: ${this.initError} ` +
+              "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",
+              "SMTPService",
             );
+            return;
           }
           logger.warn(
             `SMTP: Failed to load Bridge cert at "${resolvedCertPath}" — running with TLS validation DISABLED (allowInsecureBridge is set). ` +
@@ -115,11 +139,17 @@ export class SMTPService {
       } else if (this.config.smtp.username) {
         // Credentials are loaded — this is a real connection attempt.
         if (!allowInsecure) {
-          throw new Error(
+          // Deferred failure — same rationale as the cert-load branch above.
+          this.initError =
             "SMTP: No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate " +
             "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
-            "disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1."
+            "disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1.";
+          logger.warn(
+            `SMTP init deferred: ${this.initError} ` +
+            "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",
+            "SMTPService",
           );
+          return;
         }
         logger.warn(
           "SMTP: No Bridge certificate configured and allowInsecureBridge is set — " +
@@ -170,6 +200,11 @@ export class SMTPService {
     return tracer.span('smtp.verifyConnection', {}, async () => {
     logger.debug("Verifying SMTP connection", "SMTPService");
 
+    // Surface deferred-init errors first — more actionable than the generic
+    // "transporter not initialized".
+    if (this.initError) {
+      throw new Error(this.initError);
+    }
     if (!this.transporter) {
       throw new Error("SMTP transporter not initialized");
     }
@@ -206,6 +241,11 @@ export class SMTPService {
       subject: options.subject,
     });
 
+    // Surface deferred-init errors first (cert missing, unreadable, etc.)
+    // — far more actionable than the generic "transporter not initialized".
+    if (this.initError) {
+      throw new Error(this.initError);
+    }
     if (!this.transporter) {
       throw new Error("SMTP transporter not initialized");
     }

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -68,6 +68,15 @@ export class SMTPService {
 
   private initializeTransporter(): void {
     logger.debug("Initializing SMTP transporter", "SMTPService");
+    // Close any existing transporter before replacing it — reinitialize()
+    // runs on every config update (AccountManager.rebuildFromRegistry, the
+    // settings UI save path, etc.) and nodemailer holds a connection pool
+    // internally. Skipping close() here would leak sockets + file
+    // descriptors on every save. Best-effort: swallow close errors so a
+    // dead transporter can't block re-init.
+    if (this.transporter) {
+      try { this.transporter.close(); } catch { /* already dead — ignore */ }
+    }
     // Reset degraded state so reinitialize() after the user fixes config
     // clears any prior deferred failure.
     this.initError = null;
@@ -111,6 +120,10 @@ export class SMTPService {
           };
           logger.info(`SMTP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, "SMTPService");
         } catch (err: unknown) {
+          // Robust message extraction: if a non-Error is thrown (string,
+          // object, etc.), (err as Error).message yields undefined and the
+          // diagnostic reads "Underlying error: undefined".
+          const errMsg = err instanceof Error ? err.message : String(err);
           if (!allowInsecure) {
             // Deferred failure: stash an actionable message, log a loud
             // warning, return without building a transporter. sendEmail()
@@ -119,7 +132,7 @@ export class SMTPService {
               `SMTP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
               `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
               `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
-              `Underlying error: ${(err as Error).message}`;
+              `Underlying error: ${errMsg}`;
             logger.warn(
               `SMTP init deferred: ${this.initError} ` +
               "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",

--- a/src/services/smtp-tls.test.ts
+++ b/src/services/smtp-tls.test.ts
@@ -59,20 +59,46 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
     else delete process.env.MAILPOUCH_INSECURE_BRIDGE;
   });
 
-  it("throws when localhost has credentials but no cert path and no opt-in", () => {
-    expect(() => new SMTPService(baseConfig())).toThrow(/No Bridge certificate configured/);
+  it("defers error to sendEmail when localhost has credentials but no cert path and no opt-in", async () => {
+    // Construction MUST NOT throw — a synchronous throw kills the MCP
+    // server at module load (stdio has no way to report structured errors
+    // before the transport comes up). Instead the service records initError
+    // and the first sendEmail() call surfaces the same actionable message.
+    const svc = new SMTPService(baseConfig());
+    expect(svc.initError).toMatch(/No Bridge certificate configured/);
+    await expect(svc.sendEmail({ to: "x@example.com", subject: "s", body: "b" }))
+      .rejects.toThrow(/No Bridge certificate configured/);
   });
 
-  it("throws when cert path is configured but the file cannot be loaded", async () => {
+  it("defers error to sendEmail when cert path is configured but the file cannot be loaded", async () => {
     const fs = await import("fs");
     (fs.statSync as ReturnType<typeof vi.fn>).mockReturnValue({ isDirectory: () => false });
     (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
       throw new Error("ENOENT");
     });
 
-    expect(() => new SMTPService(baseConfig({ bridgeCertPath: "/bad/cert.pem" }))).toThrow(
-      /could not be loaded and allowInsecureBridge is not set/
-    );
+    const svc = new SMTPService(baseConfig({ bridgeCertPath: "/bad/cert.pem" }));
+    expect(svc.initError).toMatch(/could not be loaded and allowInsecureBridge is not set/);
+    await expect(svc.sendEmail({ to: "x@example.com", subject: "s", body: "b" }))
+      .rejects.toThrow(/could not be loaded and allowInsecureBridge is not set/);
+  });
+
+  it("reinitialize() clears initError once the cert path is fixed", async () => {
+    const fs = await import("fs");
+    (fs.statSync as ReturnType<typeof vi.fn>).mockReturnValue({ isDirectory: () => false });
+    (fs.readFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const cfg = baseConfig({ bridgeCertPath: "/bad/cert.pem" });
+    const svc = new SMTPService(cfg);
+    expect(svc.initError).not.toBeNull();
+
+    // User fixes the config → reinitialize picks up the new state.
+    (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from("CERT"));
+    cfg.smtp.bridgeCertPath = "/good/cert.pem";
+    svc.reinitialize();
+    expect(svc.initError).toBeNull();
+    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(false);
   });
 
   it("pre-config constructor (no username yet) does not throw even without cert", () => {

--- a/src/services/smtp-tls.test.ts
+++ b/src/services/smtp-tls.test.ts
@@ -98,7 +98,7 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
     cfg.smtp.bridgeCertPath = "/good/cert.pem";
     svc.reinitialize();
     expect(svc.initError).toBeNull();
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(false);
+    expect(svc.insecureTls).toBe(false);
   });
 
   it("pre-config constructor (no username yet) does not throw even without cert", () => {
@@ -113,7 +113,7 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
     (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from("CERT"));
 
     const svc = new SMTPService(baseConfig({ bridgeCertPath: "/ok/cert.pem" }));
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(false);
+    expect(svc.insecureTls).toBe(false);
   });
 
   it("resolves cert.pem inside a directory when bridgeCertPath points to a folder", async () => {
@@ -122,7 +122,7 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
     (fs.readFileSync as ReturnType<typeof vi.fn>).mockReturnValue(Buffer.from("CERT"));
 
     const svc = new SMTPService(baseConfig({ bridgeCertPath: "/bridge/data" }));
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(false);
+    expect(svc.insecureTls).toBe(false);
     expect((fs.readFileSync as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
       expect.stringContaining("cert.pem")
     );
@@ -131,14 +131,14 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
   it("uses full TLS validation (no cert wrangling) for non-localhost SMTP hosts", () => {
     const svc = new SMTPService(baseConfig({ host: "smtp.protonmail.ch", port: 587, smtpToken: "tok" }));
     // Non-localhost never enters the bridge-cert branch; insecureTls must stay false.
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(false);
+    expect(svc.insecureTls).toBe(false);
   });
 });
 
 describe("SMTPService TLS insecure opt-in", () => {
   it("runs in insecure mode when allowInsecureBridge is set in config", () => {
     const svc = new SMTPService(baseConfig({ allowInsecureBridge: true }));
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(true);
+    expect(svc.insecureTls).toBe(true);
   });
 
   it("runs in insecure mode when MAILPOUCH_INSECURE_BRIDGE=1 is set in env", () => {
@@ -146,7 +146,7 @@ describe("SMTPService TLS insecure opt-in", () => {
     process.env.MAILPOUCH_INSECURE_BRIDGE = "1";
     try {
       const svc = new SMTPService(baseConfig());
-      expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(true);
+      expect(svc.insecureTls).toBe(true);
     } finally {
       if (prev !== undefined) process.env.MAILPOUCH_INSECURE_BRIDGE = prev;
       else delete process.env.MAILPOUCH_INSECURE_BRIDGE;
@@ -161,6 +161,6 @@ describe("SMTPService TLS insecure opt-in", () => {
     });
 
     const svc = new SMTPService(baseConfig({ bridgeCertPath: "/bad/cert.pem", allowInsecureBridge: true }));
-    expect((svc as unknown as { insecureTls: boolean }).insecureTls).toBe(true);
+    expect(svc.insecureTls).toBe(true);
   });
 });

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -45,6 +45,7 @@ export const defs: ToolDef[] = [
                 remainingMs: { type: "number", description: "Milliseconds remaining on the current backoff window" },
               },
             },
+            initError: { type: "string", description: "Deferred SMTP initialization error (e.g. unreadable bridgeCertPath). When present, sends will fail with this message until config is fixed and reinitialize() runs." },
             error: { type: "string", description: "Last SMTP error message, if any" },
           },
         },
@@ -149,6 +150,7 @@ export const handlers: Record<string, ToolHandler> = {
           failureCount: smtpService.backoff.failureCount,
           remainingMs: smtpBackoffMs,
         },
+        ...(smtpService.initError ? { initError: smtpService.initError } : {}),
         ...(state.smtpStatus.error ? { error: state.smtpStatus.error } : {}),
       },
       imap: {
@@ -167,7 +169,10 @@ export const handlers: Record<string, ToolHandler> = {
     const backoffWarning = smtpService.backoff.isBlocked()
       ? `\n\u26a0 SMTP is in abuse-signal backoff (${smtpService.backoff.failureCount} consecutive throttle responses, ${smtpBackoffMs} ms remaining). Wait or have the user trigger a manual retry.`
       : "";
-    return ok(status, JSON.stringify(status) + insecureTlsWarning + backoffWarning);
+    const initErrorWarning = smtpService.initError
+      ? `\n\u26a0 SMTP is not ready: ${smtpService.initError}`
+      : "";
+    return ok(status, JSON.stringify(status) + insecureTlsWarning + backoffWarning + initErrorWarning);
   },
 
   sync_emails: async (ctx) => {


### PR DESCRIPTION
## Summary

**SMTPService constructor used to throw synchronously** when the
Bridge cert path was unreadable and allowInsecureBridge was false.
For an stdio MCP server this is catastrophic — the throw happens at
module load (inside AccountManager's \`rebuildFromRegistry\`), before
the MCP transport comes up. There's no way to surface a structured
error to the client; the MCP silently fails to register.

Reproduced this session on a Linux install that carried a stale
Windows cert path (\`C:\\Users\\Charlie\\Desktop\\Certs\`) in its
persistent config. User got only Claude Code's generic
"Failed to connect"; no diagnostic beyond that.

## Pass 1 — Deferred init

Construction now **never throws**. On unreadable cert + strict TLS:
- \`initError: string | null\` stashes the actionable message
- loud \`WARN\` log emitted
- transporter left \`null\`; caller sees the error on first
  \`sendEmail()\` / \`verifyConnection()\`

\`reinitialize()\` clears \`initError\` + rebuilds in one shot so the
settings UI save path recovers without a server restart.

\`get_connection_status\` surfaces \`smtp.initError\` (nullable) + a
human-readable warning line → agents see "SMTP is not ready:
<reason>" without probing with a send.

## Pass 2 — Copilot review fixes

1. **Transporter leak**: \`initializeTransporter()\` was nulling
   \`this.transporter\` without \`close()\`-ing first. Since
   \`reinitialize()\` runs on every config update and nodemailer
   holds a connection pool, skipping close() leaked sockets +
   FDs on every save. Close best-effort (try/catch) before
   nulling.

2. **Fragile error message**: the cert-load catch used
   \`(err as Error).message\`, which yields \`undefined\` for
   non-Error throwables ("Underlying error: undefined").
   Switched to
   \`err instanceof Error ? err.message : String(err)\`.

3. **Test style**: dropped
   \`(svc as unknown as { insecureTls: boolean })\` across seven
   assertions — \`insecureTls\` is public, direct access is
   cleaner.

## End-to-end validation on Linux

Forced the stale Windows path on the running install:

\`\`\`
WARN [SMTPService] SMTP init deferred: Bridge cert at "C:\\Users\\…" could not be loaded …
INFO [MCPServer] Starting mailpouch v2.2.0
WARN [MCPServer] bridgeCertPath '…' does not exist on disk — the path looks Windows-style but this host is linux.
WARN [MCPServer] SMTP connection failed — sending features limited
→ claude mcp list → mailpouch ✓ Connected
\`\`\`

Pre-fix, the same config crashed the MCP at module load.

## Test plan

- [x] \`npm run lint\` — clean across all three commits
- [x] \`npm test\` — **1,567 / 1,567 passing** (+1 new: reinit
      clears initError)
- [x] Live reproduction: stale cert path → MCP stays up, error
      surfaces via \`get_connection_status\`
- [x] Valid cert path still works (no regression)

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] **Secure default stays strict** — bad cert paths surface
      loud errors instead of silently degrading to insecure
- [x] Transporter socket leak closed
- [x] Dependencies unchanged
- [x] Docker changes: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)