### PR TITLE
docs: refresh for v3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,107 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased] — 3.0.0
+
+### Security
+- **Per-account Bridge passwords now route through the OS keychain on every
+  save path** (#93). The Accounts-tab CRUD endpoints previously wrote
+  plaintext passwords into `~/.mailpouch.json`; they now store them under
+  `bridge-password:<acct-id>` / `smtp-token:<acct-id>` keychain entries
+  (same `mailpouch` service name as the legacy single-account key) and
+  scrub the on-disk JSON. Legacy installs with the suffix-less
+  `bridge-password` key continue to work via a back-compat read path.
+  The in-memory `AccountManager` is also refreshed on every save so the
+  MCP reconnects immediately — no restart needed.
+- CSRF session-expired responses carry a machine-readable `code:
+  "session_expired"` and the settings-UI JS auto-reloads the page on
+  403 instead of surfacing the cryptic raw error (#82).
+
+### Added
+- **Native system-tray binding** (`native/tray/`) via napi-rs around the
+  `tauri-apps/tray-icon` Rust crate — the same crate Tauri ships in
+  production. Renders correctly on modern GNOME, NSStatusBar, and
+  Shell_NotifyIcon; replaces the `systray2` Go binary wherever a
+  prebuilt is available. systray2 stays as a fallback on platforms
+  without a committed prebuilt yet. (#88, #89, #90, #91, #92)
+- Prebuilts for linux-x64-gnu, linux-arm64-gnu, darwin-arm64,
+  win32-x64-msvc, and win32-arm64-msvc. darwin-x64 (Intel Mac) falls
+  back to systray2 cleanly (the GNOME rendering bug doesn't affect
+  macOS). CI workflow `.github/workflows/build-native-tray.yml`
+  produces prebuilts for the full 6-target matrix on every push.
+- Brand-matching tray icon generator (`src/utils/icon.ts`): 64×64 base
+  with a `#6D4AFF` → `#9B6DFF` gradient + rounded corners, matching
+  the settings-UI `.logo-icon` CSS byte-for-byte. Windows ICO packs
+  16/32/48/64 sub-sizes for hi-DPI sharpness. (#88)
+- **Persistent tray via `mailpouch-settings`** — the standalone
+  entry point now carries its own tray icon for its lifetime. Users
+  add it to their OS autostart (systemd user unit / LaunchAgent /
+  Windows Startup folder) and get a tray that stays resident so
+  clicking "Open Settings" anytime brings the UI back. The MCP's
+  embedded tray coexists via a probe-then-reuse check (#86, #89).
+- Bridge cert auto-detect + file-picker upload in the settings UI
+  — every cert-path field on the Setup tab, first-run wizard, and
+  Accounts form gets a **Detect** button (scans `~/Downloads`,
+  `~/Documents`, `~/Desktop`, `~/`, and Bridge's per-OS in-place
+  location) and a **📁 Browse** button (native file picker → POST
+  to new `/api/upload-bridge-cert` → written to
+  `~/.mailpouch-bridge-cert.pem` at mode 0600). No manual path
+  typing required. (#83)
+- `/api/search-bridge` now falls back to `which proton-bridge /
+  protonmail-bridge / bridge` on POSIX when the hardcoded
+  candidate list misses — catches Debian/Ubuntu's
+  `/usr/bin/protonmail-bridge` and Homebrew/AUR/Flatpak installs.
+  (#83)
+
+### Changed
+- `SMTPService` constructor no longer throws when the configured
+  Bridge cert path is unreachable — the error is deferred to the
+  first `sendEmail()` / `verifyConnection()` call. Previously a
+  stale or wrong `bridgeCertPath` crashed the MCP at module load,
+  before stdio came up, leaving no way to surface a structured
+  error to the client. The new `SMTPService.initError` field
+  carries the actionable message and `get_connection_status` now
+  surfaces it in the `smtp.initError` response field. (#84)
+- `AccountManager` gains `rebuildFromRegistryAsync()` + an
+  `applyKeychainCredentials(password, smtpToken?)` method that
+  the boot path and settings-save endpoints use to push fresh
+  credentials into the per-account SMTP/IMAP services without
+  an MCP restart. Closes a regression introduced by the
+  multi-account registry rollout where keychain-stored
+  credentials were never propagated to per-account services.
+  (#87, #93)
+- Settings-UI startup now **probes the configured port for an
+  existing mailpouch instance** before retrying the bind. When a
+  standalone `mailpouch-settings` daemon is already listening, the
+  MCP logs "Reusing existing Settings UI at …" and silently shares
+  the port instead of emitting a four-retry WARN cycle. Non-
+  mailpouch listeners still get the actionable "another process is
+  using this port" warning. (#86)
+
+### Fixed
+- Six detached-spawn sites (`.unref()` without a matching
+  `.on('error', …)` listener) hardened against `ENOENT` crashes on
+  hosts missing a target binary — including the "Restart Claude
+  Desktop" tray action that previously took the settings server
+  down on Linux (no Linux build of Claude Desktop exists). (#82)
+- Platform-aware Claude-Desktop detection via `existsSync` on
+  `/Applications/Claude.app`, `%LOCALAPPDATA%\AnthropicClaude\...`,
+  etc.; returns a structured `{ok:false, error:…}` response when the
+  binary isn't installed instead of crashing. (#82)
+- `loadConfig()` preserves `settingsPort` and `credentialStorage`
+  fields across load/save round-trips. The Settings-UI port field
+  was previously reverting to `8765` after every save even though
+  the intended value had persisted to disk; the read path was
+  silently dropping top-level fields. Validation mirrors the
+  `POST /api/config` merge path (`Math.round` → `[1, 65535]` range
+  check). (#85)
+- Tray icon click routing via napi-rs `ThreadsafeFunction` — the
+  default `ErrorStrategy::CalleeHandled` invokes the JS callback
+  Node-style as `(err, value)` so our `(id) => …` handler was
+  receiving `null` as the first arg and silently no-op'ing every
+  click. Switched to `ErrorStrategy::Fatal` so the id arrives as
+  the single callback argument. (#91)
+
 ### Removed (breaking)
 - Legacy env-var aliases `PM_BRIDGE_MCP_*` and `PROTONMAIL_MCP_*` — only
   `MAILPOUCH_*` is read now. Callers still setting the old names must update.
@@ -14,10 +114,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ran v2.2.0 must rename any `~/.pm-bridge-mcp*` / `~/.protonmail-mcp*`
   files to the matching `~/.mailpouch*` name. This covers config,
   scheduler store, reminders, log file, audit log, pending escalations,
-  pass audit, FTS database, and agent grants/audit files.
+  pass audit, FTS database, and agent grants/audit files. (#80)
 - One-shot keychain migration from `protonmail-mcp-server` / `pm-bridge-mcp`
   service entries to `mailpouch`. Users on those legacy entries must
-  re-enter their Bridge password via the settings UI.
+  re-enter their Bridge password via the settings UI. (#80)
+
+### Test-count + housekeeping
+- 1,566 → 1,588 passing tests (+22 regression tests across spawn
+  hardening, cert auto-detect, SMTP deferred-init, loader round-
+  trip, CSRF session-reload, icon format, tray preconditions, and
+  per-account keychain scrubbing).
+- 2,927 lines of stale documentation removed (autonomous-cycle
+  log, point-in-time audit snapshots, pre-rename design reviews).
+  (#81)
 
 ## [2.2.0] — 2026-04-18
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,8 +103,11 @@ feat: add email filtering by date range
 ```
 src/
 ├── index.ts                    # Unified daemon: MCP server (69 tools, Resources, Prompts) + settings HTTP server + system tray
-├── settings-main.ts            # Standalone settings UI CLI entry point
-├── tray.ts                     # System tray icon (systray2)
+├── settings-main.ts            # Standalone settings-UI CLI entry point — hosts the persistent tray icon via mailpouch-settings
+├── accounts/
+│   ├── registry.ts             # Multi-account CRUD + per-account keychain routing
+│   ├── manager.ts              # Hot-swappable per-account SMTP/IMAP service pool
+│   └── types.ts                # AccountSpec + registry types
 ├── config/
 │   ├── schema.ts               # Tool list, categories, permission types
 │   └── loader.ts               # Config load/save, preset builder, keychain migration
@@ -112,14 +115,14 @@ src/
 │   ├── manager.ts              # Permission + rate-limit enforcement
 │   └── escalation.ts           # Human-gated escalation challenge system
 ├── security/
-│   ├── keychain.ts             # OS keychain integration (@napi-rs/keyring)
+│   ├── keychain.ts             # OS keychain integration (@napi-rs/keyring) — single-account + per-account helpers
 │   └── memory.ts               # Credential wipe helpers
 ├── settings/
 │   ├── security.ts             # Rate limiting, CSRF, origin validation, TLS
 │   ├── server.ts               # Browser-based settings UI (localhost:8765)
 │   └── tui.ts                  # Terminal UI for settings
 ├── services/
-│   ├── smtp-service.ts         # SMTP email sending (Nodemailer)
+│   ├── smtp-service.ts         # SMTP email sending (Nodemailer), deferred-init pattern
 │   ├── simple-imap-service.ts  # IMAP email reading (ImapFlow)
 │   ├── scheduler.ts            # Scheduled email delivery
 │   └── analytics-service.ts   # Email analytics computation
@@ -127,8 +130,17 @@ src/
 │   └── index.ts                # Shared TypeScript types
 └── utils/
     ├── helpers.ts              # ID generation, email validation, log sanitisation
+    ├── icon.ts                 # Pure-Node PNG/ICO generator for the brand-matching tray icon
+    ├── tray.ts                 # Unified tray facade — native backend → systray2 fallback
     ├── logger.ts               # Structured log store
     └── tracer.ts               # Lightweight request tracing
+
+native/
+└── tray/                       # Rust/napi-rs binding around tauri-apps/tray-icon
+    ├── src/lib.rs              # ~280-line Rust addon, threaded event loop, click tsfn
+    ├── Cargo.toml              # tray-icon + muda + napi + napi-derive
+    ├── index.js / index.d.ts   # napi-rs generated JS loader + types
+    └── index.<platform>.node   # Committed prebuilts: linux-x64-gnu, linux-arm64-gnu, darwin-arm64, win32-x64/arm64-msvc
 
 docs/
 ├── proton-bridge-imap.md

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v2.2.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue.svg)](https://www.typescriptlang.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29+-green.svg)](https://github.com/modelcontextprotocol/sdk)
-[![Tests](https://img.shields.io/badge/tests-1%2C566%20passing-brightgreen.svg)](#development)
+[![Tests](https://img.shields.io/badge/tests-1%2C588%20passing-brightgreen.svg)](#development)
 
 **Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — over stdio or remote HTTP — with human-controlled permissions.**
 
@@ -54,7 +54,7 @@ Your emails are decrypted on your own machine by Proton Bridge. This server neve
 - **5 permission presets** — read-only by default; write access requires explicit opt-in. Per-tool overrides and rate limits via the **Custom** preset.
 - **Human-gated escalation** — agents request elevated permissions, you approve via browser UI or terminal; the agent cannot approve its own requests.
 - **Browser-based settings UI** at `localhost:8765` — auto-starts with the daemon; setup wizard, live connection test, per-tool toggles, escalation approval panel, OAuth admin password.
-- **System tray icon** — always visible; toggle the settings UI on/off or quit from the tray without touching the terminal.
+- **Native system tray icon** — always visible, clickable menu opens the settings UI or quits. Rendered via a bundled Rust (napi-rs) binding around the `tauri-apps/tray-icon` crate — the same one Tauri ships in production — so the tray behaves correctly on modern GNOME (where the legacy Go-binary library shows a generic placeholder), NSStatusBar on macOS, and Shell_NotifyIcon on Windows. Prebuilts for linux-x64/arm64, darwin-arm64, win32-x64/arm64 ship inside the main package; darwin-x64 (Intel Mac) falls back to the legacy Go backend cleanly.
 - **5 MCP prompts** — triage inbox, compose reply, daily briefing, find subscriptions, thread summary.
 - **MCP Resources** — individual emails and folders addressable via `email://` and `folder://` URIs.
 - **Scheduled email delivery** — queue emails for future sending; survives server restarts. Plus `remind_if_no_reply` for outbound follow-ups gated on inbox replies.
@@ -63,7 +63,7 @@ Your emails are decrypted on your own machine by Proton Bridge. This server neve
 - **Multi-account** — configure more than one Proton / IMAP account; hot-swap the active account from the Settings UI with no server restart. Tools accept an optional `account_id` argument to route a single call to a specific account. See [`src/accounts/`](src/accounts/).
 - **Per-agent grants** — each MCP client (identified by its OAuth `client_id`) is gated by its own approvable grant, with optional folder allowlists, IP pins, per-tool rate caps, expiry, and account binding. Separate from the global preset and the escalation flow. See [`src/agents/`](src/agents/).
 - **Live notifications** — desktop toasts (no extra deps) and outbound webhooks (CloudEvents / Slack / Discord, HMAC-signed, retried) fire on grant-state changes. See [`src/notifications/`](src/notifications/).
-- **1,566 tests passing** (Vitest); zero `any` type annotations in production source.
+- **1,588 tests passing** (Vitest); zero `any` type annotations in production source.
 
 ---
 
@@ -95,6 +95,24 @@ With read-only permissions (the default), Claude can read, search, and analyse y
 | **MCP client** | Latest | Claude Desktop, Cline, or any MCP-compatible host · [claude.ai/download](https://claude.ai/download) |
 
 Supported on macOS, Windows, and Linux.
+
+### Linux runtime libraries
+
+The native tray binding dynamically links against two GTK system
+libraries that are **preinstalled on every modern desktop Linux
+distribution** (Ubuntu ≥ 18.04, Fedora ≥ 34, Mint, Pop!_OS, Arch,
+etc.). No manual install is needed on a normal desktop system —
+just a note for server / container / minimal-WM deployments:
+
+| Runtime library | Package name |
+|---|---|
+| `libgtk-3.so.0` | `libgtk-3-0` (Debian/Ubuntu) · `gtk3` (Fedora/Arch) |
+| `libayatana-appindicator3.so.1` | `libayatana-appindicator3-1` (Debian/Ubuntu) · `libayatana-appindicator-gtk3` (Fedora) |
+
+If both are missing (headless server, container, SSH-only host),
+mailpouch's tray startup logs a skip reason and continues without
+the icon — the MCP server itself runs unaffected. macOS and
+Windows ship their native equivalents as part of the OS.
 
 ### Proton Bridge ports
 
@@ -525,7 +543,7 @@ npm install
 
 npm run build          # compile TypeScript to dist/
 npm run dev            # watch mode (recompiles on save)
-npm run test           # run test suite (Vitest, 1,566 tests)
+npm run test           # run test suite (Vitest, 1,588 tests)
 npm run test:coverage  # coverage report
 npm run lint           # TypeScript type check (tsc --noEmit)
 npm run settings       # start standalone settings UI (after build)
@@ -537,7 +555,7 @@ npm run settings       # start standalone settings UI (after build)
 src/
   index.ts                    # Unified daemon: MCP server (69 tools, resources, prompts) + settings + tray
   settings-main.ts            # Standalone settings UI CLI (for headless/SSH environments)
-  tray.ts                     # System tray icon (systray2)
+  # (Tray moved to native/tray/ — napi-rs binding around tauri-apps/tray-icon)
   config/
     schema.ts                 # Tool registry, categories, tiers, destructive set, response limits
     loader.ts                 # Config load/save, preset builder, keychain migration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.x.x   | :white_check_mark: |
+| 3.x.x   | :white_check_mark: |
+| 2.x.x   | :white_check_mark: (security fixes only) |
 | 1.x.x   | :x:                |
 
 ## Reporting a Vulnerability
@@ -82,9 +83,11 @@ When using this MCP server:
 
 ### Credential Management
 - **Never commit** credentials to version control
-- Credentials are stored in `~/.mailpouch.json` (mode 0600) or your OS keychain — never in environment variables or `.env` files
+- **OS keychain is the default credential store** — Bridge passwords and SMTP tokens live under the `mailpouch` service, keyed per account (`bridge-password:<acct-id>` / `smtp-token:<acct-id>`). The single-account legacy key names (`bridge-password` / `smtp-token`, no suffix) are still honored for back-compat on pre-v3 installs.
+- `~/.mailpouch.json` (mode 0600) holds only non-secret config. The `credentialStorage: "keychain"` marker signals that secrets are keychain-backed; the `password` and `smtpToken` fields are always blanked on disk when the keychain is reachable.
+- Credentials are never read from environment variables or `.env` files
 - Use **Proton Bridge passwords**, not your main Proton Mail password
-- Rotate credentials regularly
+- Rotate credentials regularly via the settings UI — saves route straight to the keychain and the running MCP picks up the rotation without a restart
 
 ### Network Security
 - Use **localhost (127.0.0.1)** for Proton Bridge connections
@@ -123,6 +126,7 @@ Security patches will be released as:
 |------------|---------|--------------------------------|----------|----------|
 | 2026-03-17 | 2.0.0   | Security hardening (25 findings from 3 audit loops) | Various  | Resolved |
 | 2026-03-18 | 2.1.0+  | 48-cycle autonomous audit: input validation, type safety, injection prevention, CSRF, path traversal, rate limiting across all 48 tool handlers | Various  | Resolved |
+| 2026-04-20 | 3.0.0   | Per-account Bridge passwords wrote plaintext to `~/.mailpouch.json` via Accounts-tab CRUD paths (create / update / setActive / delete all funnelled through `writeRegistry` → `saveConfig` with no keychain routing). Legacy Setup-tab path was correctly encrypted. | High | Resolved via [PR #93](https://github.com/chandshy/mailpouch/pull/93) — writeRegistry now saves secrets to keychain under per-account keys, scrubs on-disk JSON, and refreshes the running AccountManager on every save |
 
 ---
 


### PR DESCRIPTION
## Summary

Pre-publish doc sweep. Every PR that landed this release cycle
(#80–#93) is now in CHANGELOG.md under \`[Unreleased]\`, grouped
Keep-a-Changelog style. README.md + CONTRIBUTING.md + SECURITY.md
are current with the native tray, multi-account keychain design,
and runtime requirements.

## Changes

**README.md**
- npm badge \`v2.2.0\` → \`v3.0.0\`, tests badge \`1,566\` → \`1,588\`
- Rewrote the "System tray icon" bullet — now describes the native
  \`tauri-tray-icon\` binding, the 5-of-6 prebuilt coverage, and
  the clean systray2 fallback on darwin-x64
- New "Linux runtime libraries" subsection documenting the
  \`libgtk-3\` + \`libayatana-appindicator3\` runtime dependency
  (preinstalled on every modern desktop Linux) and the headless-
  skip behavior
- Dropped the stale \`tray.ts\` reference from the source-layout
  block

**CHANGELOG.md** — new \`[Unreleased] — 3.0.0\` entries covering:
#82 spawn hardening + CSRF auto-reload · #83 cert auto-detect +
Browse + \`which\` fallback · #84 SMTP deferred-init · #85 loader
preserves settingsPort · #86 settings-UI probe-then-reuse · #87
AccountManager keychain propagation · #88 brand-matching icon +
systray2 chmod + headless skip · #89 persistent tray via
mailpouch-settings · #90 native napi-rs binding · #91 tsfn
ErrorStrategy::Fatal · #92 arm64-linux prebuilt · #93 per-account
keychain storage (security).

**CONTRIBUTING.md**
- Added \`native/tray/\` to the project-structure tree
- Added \`src/accounts/\` (multi-account registry + manager)
- Updated \`utils/\` tree to include \`icon.ts\` + \`tray.ts\` facade
- Dropped stale top-level \`tray.ts\` reference

**SECURITY.md**
- 3.x marked supported; 2.x in security-fixes-only mode
- Credential Management section rewritten around the per-account
  keychain design (\`bridge-password:<acct-id>\` /
  \`smtp-token:<acct-id>\`) + the back-compat fallback to the
  suffix-less legacy keys
- Audit Trail gains the 2026-04-20 v3.0.0 entry disclosing the
  plaintext-accounts-password bug and linking PR #93

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm test\` — 1,588 / 1,588 passing
- [x] \`npm publish --dry-run\` — 2.0 MB tarball, 249 files, 5
      native prebuilts included, no secrets

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] No behavior change — docs only
- [x] Dependencies unchanged
- [x] Docker changes: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)