### PR TITLE
fix(tray): inherit DISPLAY from parent + migrate MCP to native backend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,10 @@ const _pkgVersion = (() => {
   } catch { return "unknown"; }
 })();
 import { homedir } from "os";
-import { createRequire as _createRequire } from "module";
 import { createConnection } from "net";
 import { spawn } from "child_process";
 import { startSettingsServer } from "./settings/server.js";
 import { openBrowser } from "./settings/tui.js";
-import type SysTrayClass from "systray2";
-import type { MenuItem, SysTrayMenu } from "systray2";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -1513,8 +1510,8 @@ function trimForAnalytics(emails: EmailMessage[]): EmailMessage[] {
 // rounded-square gradient envelope (64×64 base, multi-resolution ICO on
 // Windows). Lazy-computed at module load so tests that import index.ts for
 // non-tray reasons don't pay the raster cost when they never touch it.
-import { makeTrayIconBase64 } from "./utils/icon.js";
-const TRAY_ICON_B64 = makeTrayIconBase64();
+import { makeIconPng, makeTrayIconBytes } from "./utils/icon.js";
+import { createTray, preflightTrayBinary, trayPreconditionSkip, inheritDisplayFromParent, type TrayHandle, type TrayItem } from "./utils/tray.js";
 
 // ─── Daemon: Settings Server + Tray State ────────────────────────────────────
 
@@ -1529,8 +1526,8 @@ let _settingsUrl:     string  = "";
  * just detaches our own references.
  */
 let _settingsExternal: boolean = false;
-let _trayInstance:    InstanceType<typeof SysTrayClass> | null = null;
-const _trayRequire = _createRequire(import.meta.url);
+let _trayInstance:    TrayHandle | null = null;
+let _trayTooltip:     string = "mailpouch";
 
 /**
  * Probe whether a mailpouch settings UI is already serving on `port`.
@@ -1667,8 +1664,7 @@ async function _stopSettingsServerDaemon(): Promise<void> {
   }
 }
 
-function _buildTrayMenu(): SysTrayMenu {
-  const sep: MenuItem = { title: "<SEPARATOR>", tooltip: "", enabled: true, checked: false };
+function _buildTrayItems(): { items: TrayItem[]; tooltip: string } {
   const statusLabel   = sharedState.smtpStatus.connected ? "\u25CF Connected" : "\u25CB Disconnected";
   const emailLabel    = config.smtp.username || "Not configured";
   const pendingCount  = agentGrants.list({ status: "pending" }).length;
@@ -1676,100 +1672,96 @@ function _buildTrayMenu(): SysTrayMenu {
   const tooltip = pendingCount > 0
     ? `mailpouch · ${pendingCount} agent(s) awaiting approval`
     : "mailpouch";
-  const items: MenuItem[] = [
-    { title: "mailpouch", tooltip: "mailpouch daemon", enabled: false, checked: false },
-    sep,
-    { title: statusLabel, tooltip: "", enabled: false, checked: false },
-    { title: emailLabel,  tooltip: "", enabled: false, checked: false },
+  const items: TrayItem[] = [
+    { id: "header",  label: "mailpouch", enabled: false },
+    { id: "sep1",    label: "",          separator: true },
+    { id: "status",  label: statusLabel, enabled: false },
+    { id: "account", label: emailLabel,  enabled: false },
     ...(pendingCount > 0
-      ? [{ title: `\u26A0 ${pendingCount} agent(s) pending`, tooltip: "Open Settings → Agents to approve", enabled: false, checked: false }]
+      ? [{ id: "pending", label: `\u26A0 ${pendingCount} agent(s) pending`, enabled: false }]
       : []),
     ...(activeCount > 0
-      ? [{ title: `\u25CF ${activeCount} agent(s) active`, tooltip: "", enabled: false, checked: false }]
+      ? [{ id: "active",  label: `\u25CF ${activeCount} agent(s) active`,   enabled: false }]
       : []),
-    sep,
+    { id: "sep2",    label: "", separator: true },
     ...(_settingsEnabled && _settingsUrl
-      ? [{ title: "Open Settings", tooltip: `Open ${_settingsUrl}`, enabled: true, checked: false }]
+      ? [{ id: "open", label: "Open Settings" }]
       : []),
-    sep,
+    { id: "sep3",    label: "", separator: true },
     {
-      title:   _settingsEnabled ? "Disable Settings UI" : "Enable Settings UI",
-      tooltip: _settingsEnabled ? "Stop the settings HTTP server" : "Start the settings HTTP server",
-      enabled: true,
-      checked: false,
+      id:    _settingsEnabled ? "disable" : "enable",
+      label: _settingsEnabled ? "Disable Settings UI" : "Enable Settings UI",
     },
-    sep,
-    { title: "Quit", tooltip: "Stop the MCP daemon", enabled: true, checked: false },
+    { id: "sep4",    label: "", separator: true },
+    { id: "quit",    label: "Quit" },
   ];
-  return { icon: TRAY_ICON_B64, title: "", tooltip, items };
+  return { items, tooltip };
 }
 
-async function _rebuildTray(): Promise<void> {
+function _rebuildTray(): void {
   if (!_trayInstance) return;
   try {
-    await _trayInstance.sendAction({ type: "update-menu", menu: _buildTrayMenu() });
+    const { items, tooltip } = _buildTrayItems();
+    _trayInstance.setMenu(items);
+    if (tooltip !== _trayTooltip) {
+      _trayInstance.setTooltip(tooltip);
+      _trayTooltip = tooltip;
+    }
   } catch (err: unknown) {
     logger.debug("Tray menu update failed", "MCPServer", err);
   }
 }
 
 async function _initTray(): Promise<void> {
-  // Preflight + precondition checks live in src/utils/tray.ts so the
-  // standalone settings daemon (src/settings-main.ts) shares the exact
-  // same boot hygiene — the systray2 chmod bug and headless/arm64 skip
-  // logic are properties of the platform, not of any specific entry point.
-  const { preflightTrayBinary, trayPreconditionSkip } = await import("./utils/tray.js");
+  // Claude Desktop / VS Code strip DISPLAY from stdio-spawned children
+  // even on graphical hosts — copy it from the parent's environ before
+  // the precondition check so GTK can connect.
+  inheritDisplayFromParent();
+
   const skipReason = trayPreconditionSkip();
   if (skipReason) {
     logger.debug(`Tray: ${skipReason}`, "MCPServer");
     return;
   }
-  // Fix the mode-0644 shipping bug before systray2's native spawn.
+  // Fix the mode-0644 shipping bug before the systray2 fallback's spawn.
   preflightTrayBinary();
 
-  type SysTrayConstructor = typeof SysTrayClass;
-  let ST: SysTrayConstructor | undefined;
   try {
-    ST = (_trayRequire("systray2") as { default: SysTrayConstructor }).default;
-  } catch {
-    logger.debug("systray2 not installed — tray icon disabled", "MCPServer");
-    return;
-  }
-
-  try {
-    const tray = new ST({ menu: _buildTrayMenu(), debug: false, copyDir: true });
-
-    // Wait for the native tray binary to signal ready
-    await tray.ready();
+    const { items, tooltip } = _buildTrayItems();
+    _trayTooltip = tooltip;
+    const tray = createTray({
+      iconPng: makeIconPng(64),
+      iconLegacyOverride: process.platform === "win32" ? makeTrayIconBytes("win32") : undefined,
+      tooltip,
+      items,
+      onClick: (id) => {
+        switch (id) {
+          case "open":
+            openBrowser(_settingsUrl);
+            break;
+          case "disable":
+            _stopSettingsServerDaemon()
+              .then(() => _rebuildTray())
+              .catch((err: unknown) => logger.warn("Settings disable failed", "MCPServer", err));
+            break;
+          case "enable":
+            _startSettingsServerDaemon()
+              .then(() => _rebuildTray())
+              .catch((err: unknown) => logger.warn("Settings enable failed", "MCPServer", err));
+            break;
+          case "quit":
+            gracefulShutdown("tray-quit").catch(() => process.exit(1));
+            break;
+        }
+      },
+    });
     _trayInstance = tray;
-    logger.info("System tray icon active", "MCPServer");
+    logger.info(`System tray icon active (${tray.backend} backend)`, "MCPServer");
 
     // Keep the tray menu in sync with grant changes (new pending → badge,
-    // approved/revoked → count update). Handler is fire-and-forget; if
-    // rebuild fails we swallow to avoid crashing the daemon.
+    // approved/revoked → count update).
     agentNotifications.subscribe(() => {
-      void _rebuildTray().catch(() => { /* swallow */ });
-    });
-
-    await tray.onClick((action: { item: MenuItem }) => {
-      switch (action.item.title) {
-        case "Open Settings":
-          openBrowser(_settingsUrl);
-          break;
-        case "Disable Settings UI":
-          _stopSettingsServerDaemon()
-            .then(() => _rebuildTray())
-            .catch((err: unknown) => logger.warn("Settings disable failed", "MCPServer", err));
-          break;
-        case "Enable Settings UI":
-          _startSettingsServerDaemon()
-            .then(() => _rebuildTray())
-            .catch((err: unknown) => logger.warn("Settings enable failed", "MCPServer", err));
-          break;
-        case "Quit":
-          gracefulShutdown("tray-quit").catch(() => process.exit(1));
-          break;
-      }
+      try { _rebuildTray(); } catch { /* swallow */ }
     });
   } catch (err: unknown) {
     logger.warn("Tray icon failed to start", "MCPServer", err);
@@ -2084,7 +2076,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
     // 0. Stop settings server + tray
     await _stopSettingsServerDaemon();
     if (_trayInstance) {
-      try { _trayInstance.kill(false); } catch { /* ignore */ }
+      try { _trayInstance.destroy(); } catch { /* ignore */ }
       _trayInstance = null;
     }
 

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -33,7 +33,7 @@ import {
 } from "./settings/tui.js";
 import { startSettingsServer } from "./settings/server.js";
 import { loadConfig } from "./config/loader.js";
-import { createTray, trayPreconditionSkip, type TrayHandle } from "./utils/tray.js";
+import { createTray, trayPreconditionSkip, inheritDisplayFromParent, type TrayHandle } from "./utils/tray.js";
 import { makeIconPng, makeTrayIconBytes } from "./utils/icon.js";
 
 // ─── Parse CLI flags ──────────────────────────────────────────────────────────
@@ -141,6 +141,10 @@ function startServer(p: number): void {
 let _activeTray: TrayHandle | null = null;
 function _startTrayIcon(url: string): void {
   if (noTray) return;
+  // GUI MCP clients (Claude Desktop, VS Code) strip DISPLAY from
+  // stdio-spawned children; copy it from the parent's environ on Linux
+  // before the precondition check so GTK can connect.
+  inheritDisplayFromParent();
   const skip = trayPreconditionSkip();
   if (skip) {
     process.stderr.write(`Tray skipped: ${skip}\n`);

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -3626,10 +3626,17 @@ export interface ServerSecurityOptions {
 // minimal, copy-paste-ready summary: what this server is, how to launch
 // it, and the exact client-config JSON an agent needs.
 
+const _agentSetupPkgVersion = (() => {
+  try {
+    const dir = nodePath.dirname(fileURLToPath(import.meta.url));
+    return (JSON.parse(readFileSync(nodePath.resolve(dir, "../../package.json"), "utf-8")) as { version: string }).version;
+  } catch { return "unknown"; }
+})();
+
 function buildAgentSetupJson() {
   return {
     product: "mailpouch",
-    version: "2.2.0",
+    version: _agentSetupPkgVersion,
     summary:
       "An MCP server that exposes a user's Proton Mail inbox (via Proton Bridge) to AI agents as typed, permission-gated, audit-logged tools.",
     protocol: {

--- a/src/utils/tray.ts
+++ b/src/utils/tray.ts
@@ -20,7 +20,7 @@
  * helpers are still exported for direct callers that want to gate
  * tray init themselves.
  */
-import { existsSync, chmodSync } from "fs";
+import { existsSync, chmodSync, readFileSync } from "fs";
 import { homedir } from "os";
 import nodePath from "path";
 import { createRequire } from "module";
@@ -184,6 +184,54 @@ export function preflightTrayBinary(platform: NodeJS.Platform = process.platform
     } catch { /* non-fatal */ }
   }
   return resolvedSource;
+}
+
+/**
+ * MCPs are commonly spawned by GUI clients (Claude Desktop, VS Code)
+ * that strip `DISPLAY` / `WAYLAND_DISPLAY` from the child env, even
+ * when the user running the client is on a graphical session. Without
+ * those variables GTK can't connect to the display server and the
+ * tray precondition check bails.
+ *
+ * This reads the parent's `/proc/<ppid>/environ` on Linux and copies
+ * any missing display-related vars into `process.env` so downstream
+ * tray initialization can see them. No-op on non-Linux platforms and
+ * when the current process already has them.
+ *
+ * Mutates `process.env` on purpose — GTK reads the vars via getenv()
+ * at window-creation time, not via a copy we control. Returns true
+ * if anything was inherited.
+ */
+export function inheritDisplayFromParent(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (platform !== "linux") return false;
+  if (process.env.DISPLAY || process.env.WAYLAND_DISPLAY) return false;
+  const ppid = process.ppid;
+  if (!ppid || ppid === 1) return false;
+  try {
+    const raw = readFileSync(`/proc/${ppid}/environ`, "utf8");
+    const pairs = raw.split("\0");
+    let inherited = false;
+    for (const line of pairs) {
+      const eq = line.indexOf("=");
+      if (eq <= 0) continue;
+      const key = line.slice(0, eq);
+      const val = line.slice(eq + 1);
+      if (
+        (key === "DISPLAY" || key === "WAYLAND_DISPLAY" ||
+         key === "XDG_RUNTIME_DIR" || key === "XAUTHORITY" ||
+         key === "XDG_SESSION_TYPE" || key === "DBUS_SESSION_BUS_ADDRESS") &&
+        !process.env[key]
+      ) {
+        process.env[key] = val;
+        inherited = true;
+      }
+    }
+    return inherited;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the tray icon not appearing when mailpouch is launched by Claude Desktop (and other GUI MCP clients like VS Code). Two root causes, both fixed:

1. **Missing DISPLAY env** — GUI clients strip `DISPLAY` / `WAYLAND_DISPLAY` when spawning stdio subprocesses. The MCP tray precondition check bailed with `no display environment (DISPLAY / WAYLAND_DISPLAY unset) — tray skipped` even though the user was on a graphical session. Added `inheritDisplayFromParent()` which reads `/proc/<ppid>/environ` on Linux and copies the display vars into `process.env` before tray init runs.

2. **MCP used the broken systray2 backend** — `src/index.ts` `_initTray()` still called systray2 directly, which has the known 3-dot ellipsis rendering bug on GNOME. Migrated it to the `createTray()` facade (shared with `mailpouch-settings`), so on GNOME it now uses the native tauri-apps/tray-icon Rust binding.

Bonus: fixed a stale hardcoded `"2.2.0"` string in the `/agent-setup` JSON output — now derived from `package.json` like the MCP `serverInfo.version`.

## Test plan

- [x] `npm test` — all 1,588 tests pass
- [x] `npm run build` — clean TypeScript compile
- [x] Smoke test from interactive shell: log shows `System tray icon active (native backend)`
- [x] Reinstalled globally via `npm install -g mailpouch-3.0.0.tgz`
- [x] User confirmed: tray appears on GNOME panel after Claude Desktop restart

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] No new attack surface — reads `/proc/<ppid>/environ` which is already readable by the process owner
- [x] Dependencies unchanged
- [x] Docker changes: n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)