### PR TITLE
fix(tray): deduplicate tray icon across multiple MCP processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2051,7 +2051,12 @@ async function main() {
     // Skip when running as a respawn child (stdio:ignore, no real MCP session).
     if (!process.env.MAILPOUCH_RESPAWN) {
       await _startSettingsServerDaemon();
-      _initTray().catch((err: unknown) => logger.warn("Tray init error", "MCPServer", err));
+      // Only the process that owns the settings server gets a tray.
+      // If another MCP already holds the port, _settingsExternal is true
+      // and that process already has the tray — skip to avoid duplicates.
+      if (!_settingsExternal) {
+        _initTray().catch((err: unknown) => logger.warn("Tray init error", "MCPServer", err));
+      }
     }
   } catch (error) {
     logger.error("Server startup failed", "MCPServer", error);


### PR DESCRIPTION
## Summary

Fixes 4 tray icons appearing when cowork spawns multiple mailpouch subprocesses.

Each MCP subprocess called `_initTray()` independently, creating one tray icon per process. The root cause: `_startSettingsServerDaemon()` already detects that another mailpouch instance owns the settings port and sets `_settingsExternal = true`, but `_initTray()` ignored that flag.

Fix is one guard: skip `_initTray()` when `_settingsExternal` is true. The first process to bind the settings port owns the tray; all subsequent MCP processes attach silently without spawning redundant tray icons.

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — all 1,588 tests pass
- [x] Logic: second+ MCP instances probe the settings port → find existing owner → `_settingsExternal = true` → skip tray

## Security checklist
- [x] No secrets, keys, or credentials committed
- [x] No new attack surface
- [x] Dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)