### PR TITLE
fix(update-check): resolve npm from node bin dir, not PATH

### DIFF
--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4512,13 +4512,18 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           const name    = pkgJson.name    ?? "mailpouch";
 
           const latest = await new Promise<string>((resolve, reject) => {
+            // Resolve npm from the same bin/ dir as the running node binary so
+            // this works even when PATH is stripped (e.g. Claude Desktop stdio
+            // children, VS Code extension hosts).
             const isWin = process.platform === "win32";
+            const nodeDir = nodePath.dirname(process.execPath);
+            const npmResolved = nodePath.join(nodeDir, isWin ? "npm.cmd" : "npm");
             const [viewCmd, viewArgs] = isWin
-              ? ["cmd.exe", ["/c", "npm", "view", name, "version", "--json"]]
-              : ["npm",     ["view", name, "version", "--json"]];
+              ? [npmResolved, ["view", name, "version", "--json"]]
+              : [npmResolved, ["view", name, "version", "--json"]];
             const proc = spawn(viewCmd, viewArgs, {
               stdio: ["ignore", "pipe", "pipe"],
-              shell: false,
+              shell: isWin, // cmd scripts need shell on Windows
             });
             let out = "";
             let err = "";
@@ -4573,12 +4578,14 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
 
           const output = await new Promise<string>((resolve, reject) => {
             const isWin = process.platform === "win32";
+            const nodeDir = nodePath.dirname(process.execPath);
+            const npmResolved = nodePath.join(nodeDir, isWin ? "npm.cmd" : "npm");
             const [instCmd, instArgs] = isWin
-              ? ["cmd.exe", ["/c", "npm", "install", "-g", `${name}@latest`]]
-              : ["npm",     ["install", "-g", `${name}@latest`]];
+              ? [npmResolved, ["install", "-g", `${name}@latest`]]
+              : [npmResolved, ["install", "-g", `${name}@latest`]];
             const proc  = spawn(instCmd, instArgs, {
               stdio: ["ignore", "pipe", "pipe"],
-              shell: false,
+              shell: isWin,
             });
             let out = "";
             proc.stdout?.on("data", (d: Buffer) => { out += d.toString(); });


### PR DESCRIPTION
## Summary

Fixes `Update check failed: spawn npm ENOENT` in the settings UI status panel.

Claude Desktop (and VS Code) strips `PATH` when spawning stdio MCP subprocesses. The `/api/check-update` and `/api/install-update` endpoints called `spawn("npm", ...)` which fails with ENOENT when `npm` isn't on PATH.

Fix: resolve npm from `path.dirname(process.execPath)` — npm is always installed alongside the running node binary in the same `bin/` directory. This works regardless of what PATH the parent passes.

Same pattern as the `DISPLAY` inheritance fix (#95) — GUI clients strip env vars from stdio children; resolve from known-good sources instead.

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — 1,587/1,588 pass (1 pre-existing date-boundary flap in analytics unrelated to this change)
- [x] Pre-existing failure confirmed via `git stash` — not introduced here

## Security checklist
- [x] No secrets committed
- [x] `npmResolved` is derived from `process.execPath` (trusted, controlled by the runtime) — not user input
- [x] Dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)