### PR TITLE
fix(update-check): inject node bin dir into PATH for npm spawn

### DIFF
--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4512,18 +4512,23 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           const name    = pkgJson.name    ?? "mailpouch";
 
           const latest = await new Promise<string>((resolve, reject) => {
-            // Resolve npm from the same bin/ dir as the running node binary so
-            // this works even when PATH is stripped (e.g. Claude Desktop stdio
-            // children, VS Code extension hosts).
+            // npm is a shell script (#!/usr/bin/env node) so it needs both the
+            // resolved npm path AND node on PATH. GUI MCP clients strip PATH, so
+            // we inject node's bin dir into the child's PATH explicitly.
             const isWin = process.platform === "win32";
             const nodeDir = nodePath.dirname(process.execPath);
+            const pathSep = isWin ? ";" : ":";
+            const childEnv = {
+              ...process.env,
+              PATH: process.env.PATH
+                ? `${nodeDir}${pathSep}${process.env.PATH}`
+                : nodeDir,
+            };
             const npmResolved = nodePath.join(nodeDir, isWin ? "npm.cmd" : "npm");
-            const [viewCmd, viewArgs] = isWin
-              ? [npmResolved, ["view", name, "version", "--json"]]
-              : [npmResolved, ["view", name, "version", "--json"]];
-            const proc = spawn(viewCmd, viewArgs, {
+            const proc = spawn(npmResolved, ["view", name, "version", "--json"], {
               stdio: ["ignore", "pipe", "pipe"],
-              shell: isWin, // cmd scripts need shell on Windows
+              shell: isWin,
+              env: childEnv,
             });
             let out = "";
             let err = "";
@@ -4579,13 +4584,18 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           const output = await new Promise<string>((resolve, reject) => {
             const isWin = process.platform === "win32";
             const nodeDir = nodePath.dirname(process.execPath);
+            const pathSep = isWin ? ";" : ":";
+            const childEnv = {
+              ...process.env,
+              PATH: process.env.PATH
+                ? `${nodeDir}${pathSep}${process.env.PATH}`
+                : nodeDir,
+            };
             const npmResolved = nodePath.join(nodeDir, isWin ? "npm.cmd" : "npm");
-            const [instCmd, instArgs] = isWin
-              ? [npmResolved, ["install", "-g", `${name}@latest`]]
-              : [npmResolved, ["install", "-g", `${name}@latest`]];
-            const proc  = spawn(instCmd, instArgs, {
+            const proc = spawn(npmResolved, ["install", "-g", `${name}@latest`], {
               stdio: ["ignore", "pipe", "pipe"],
               shell: isWin,
+              env: childEnv,
             });
             let out = "";
             proc.stdout?.on("data", (d: Buffer) => { out += d.toString(); });


### PR DESCRIPTION
## Summary

Fixes `Update check failed: /usr/bin/env: 'node': No such file or directory` in the settings UI.

The previous fix (#101) resolved the npm binary path from `process.execPath`, but `npm` itself is a shell script (`#!/usr/bin/env node`) that still needs `node` on `PATH`. GUI MCP clients strip PATH from stdio children, so `/usr/bin/env node` fails even when npm is found.

Fix: prepend `path.dirname(process.execPath)` to the child's `PATH` in the spawn env for both `/api/check-update` and `/api/install-update`. Node and npm are always co-located, so this guarantees npm can find its runtime regardless of what the parent passed.

## Test plan
- [x] `npm run build` — clean compile
- [x] `npm test` — all 1,588 pass

## Security checklist
- [x] No secrets committed
- [x] PATH injection is prepend-only from a trusted source (`process.execPath`)
- [x] Dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)