### PR TITLE
fix: support Proton Bridge SMTP on Node 25

### DIFF
--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -116,6 +116,11 @@ export class SMTPService {
           tlsOptions = {
             ca: [bridgeCert],
             minVersion: "TLSv1.2",
+            // Node 25 rejects an IP literal as TLS servername before
+            // checkServerIdentity can run. Bridge listens on 127.0.0.1,
+            // but using localhost here keeps SNI legal while the pinned
+            // Bridge cert remains the trust anchor for this local socket.
+            servername: "localhost",
             checkServerIdentity: () => undefined,
           };
           logger.info(`SMTP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, "SMTPService");


### PR DESCRIPTION
## Summary
- Set SMTP TLS `servername` to `localhost` when using the exported Proton Bridge certificate
- Keeps Bridge on `127.0.0.1` while avoiding Node 25 rejecting IP-literal SNI before `checkServerIdentity` can run

## Validation
- `npm run typecheck` passed locally
- OpenClaw/Mailpouch connection status verified healthy against local Proton Bridge on SMTP `127.0.0.1:1025` and IMAP `127.0.0.1:1143`

## Context
Node 25 rejects `options.servername` when it is an IP address. Proton Bridge listens locally on `127.0.0.1`; using `localhost` for SNI keeps TLS legal while the pinned Bridge cert remains the trust anchor.