### PR TITLE
chore(deps): bump nodemailer from 8.0.5 to 8.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@modelcontextprotocol/sdk": "~1.29.0",
         "imapflow": "~1.3.1",
         "mailparser": "~3.9.8",
-        "nodemailer": "~8.0.2"
+        "nodemailer": "~8.0.7"
       },
       "bin": {
         "mailpouch": "dist/index.js",
@@ -2056,6 +2056,15 @@
         "libqp": "2.1.1"
       }
     },
+    "node_modules/imapflow/node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2550,6 +2559,15 @@
         "libqp": "2.1.1"
       }
     },
+    "node_modules/mailparser/node_modules/nodemailer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -2706,9 +2724,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@modelcontextprotocol/sdk": "~1.29.0",
     "imapflow": "~1.3.1",
     "mailparser": "~3.9.8",
-    "nodemailer": "~8.0.2"
+    "nodemailer": "~8.0.7"
   },
   "optionalDependencies": {
     "@napi-rs/keyring": "~1.2.0",


### PR DESCRIPTION
Recreates the accidentally-closed dependabot PR #107.

Bumps nodemailer from 8.0.5 to 8.0.7 (patch). No API changes — see [nodemailer releases](https://github.com/nodemailer/nodemailer/releases). All 1592 tests pass locally.