### PR TITLE
fix(security): address CodeQL and Dependabot alerts

### DIFF
--- a/.github/workflows/build-native-tray.yml
+++ b/.github/workflows/build-native-tray.yml
@@ -27,6 +27,9 @@ on:
       - '.github/workflows/build-native-tray.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # OS × Node matrix covering every platform Proton Bridge ships on:

--- a/native/tray/Cargo.toml
+++ b/native/tray/Cargo.toml
@@ -38,10 +38,9 @@ crossbeam-channel = "0.5"
 [target.'cfg(target_os = "linux")'.dependencies]
 # tray-icon needs a GTK main loop running for events to dispatch on
 # Linux. gtk crate's `init()` initializes GLib/GTK from any thread we
-# decide to host the loop on. Bring the matching glib version so we
-# have access to MainContext::default().iteration() from the loop.
-gtk  = "0.18"
-glib = "0.18"
+# decide to host the loop on. gtk 0.18 is the latest gtk3 release
+# (gtk3 is unmaintained upstream; gtk4 migration is a separate effort).
+gtk = "0.18"
 
 [build-dependencies]
 napi-build = "2"

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -89,7 +89,7 @@ const tokenMatches = constantTimeEqual;
 function extractBearer(req: IncomingMessage): string | null {
   const raw = req.headers["authorization"];
   if (!raw || typeof raw !== "string") return null;
-  const m = /^Bearer\s+(.+)\s*$/i.exec(raw);
+  const m = /^Bearer\s+(\S+)$/i.exec(raw.trimEnd());
   return m ? m[1] : null;
 }
 


### PR DESCRIPTION
## What

Fixes the open security alerts from CodeQL and Dependabot.

### Real fixes

| Alert | Fix |
|---|---|
| CodeQL #6 — ReDoS | `Bearer\s+(.+)\s*$` → `Bearer\s+(\S+)$` with `trimEnd()` — backtracking impossible |
| CodeQL #8 — CI permissions | Added `permissions: contents: read` to `ci.yml` |
| CodeQL #1 — tray CI permissions | Added `permissions: contents: read` to `build-native-tray.yml` |
| Dependabot #1 — glib vuln | Removed stale explicit `glib = "0.18"` dep from `native/tray/Cargo.toml`; the vulnerable `glib::VariantStrIter` API is never called (only `gtk::events_pending` / `gtk::main_iteration_do`). Full glib upgrade requires a gtk4 migration — dismissed with note. |

### Dismissed as false positives (via API)

| Alert | Reason |
|---|---|
| CodeQL #5 — SSRF | `tcpCheck` host is validated by `ALLOWED_HOST_RE` (localhost + RFC-1918) at every call site |
| CodeQL #4 — clear-text logging | `oauthIssuer` is public OAuth metadata, served verbatim from `/.well-known/` |
| CodeQL #3 — stack trace | Uses `.message` not `.stack`; localhost-only settings UI |
| CodeQL #7 — Rust invalid pointer | No unsafe code; `Arc<Mutex<Option<Sender>>>` is fully safe; CodeQL Rust false positive |

## Test plan
- [ ] `npm test` passes (1592 tests)
- [ ] Bearer token extraction still works with valid tokens
- [ ] CI shows green on ubuntu/macos/windows