### PR TITLE
fix(security): full audit findings — 7 P1, 17 P2, multiple P3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,9 +2992,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/src/agents/grant-manager.ts
+++ b/src/agents/grant-manager.ts
@@ -100,10 +100,14 @@ export class GrantManager {
     const allow = grant.conditions?.folderAllowlist;
     if (!allow || allow.length === 0) return { allowed: true, effectivePreset: effective };
     const folder = extractFolderArg(ctx.args);
-    // If no folder is visible in args, skip the check — the tool might not
-    // be folder-scoped (e.g. get_email_stats), and the grant's folder
-    // allowlist is meaningful only when a folder is specified.
-    if (!folder) return { allowed: true, effectivePreset: effective };
+    if (!folder) {
+      // For folder-scoped tools, the absence of a recognized folder arg is
+      // suspicious: an attacker could tunnel folder intent through a
+      // non-standard arg name to escape the allowlist. Fail closed unless
+      // the tool is explicitly known to be folder-agnostic.
+      if (FOLDER_AGNOSTIC_TOOLS.has(ctx.tool)) return { allowed: true, effectivePreset: effective };
+      return { allowed: false, reason: `Tool '${ctx.tool}' has no recognized folder argument; the grant's folder allowlist requires a folder.` };
+    }
     const lower = folder.toLowerCase();
     if (!allow.some(a => a.toLowerCase() === lower)) {
       return { allowed: false, reason: `Folder '${folder}' is outside the grant's allowlist (${allow.join(", ")}).` };
@@ -141,6 +145,33 @@ function extractFolderArg(args: Record<string, unknown> | undefined): string | u
   }
   return undefined;
 }
+
+/** Tools that legitimately operate without a folder argument and therefore
+ *  should NOT trigger the fail-closed folder-allowlist check. Stats /
+ *  analytics / contacts roll up across all folders by design; system /
+ *  config / FTS-index management is folder-agnostic. */
+const FOLDER_AGNOSTIC_TOOLS = new Set<string>([
+  "get_email_stats", "get_email_analytics", "get_volume_trends",
+  "get_contacts", "get_correspondence_profile",
+  "list_labels", "get_folders", "sync_folders",
+  "get_connection_status", "get_unread_count", "get_email_stats",
+  "clear_cache", "get_logs", "start_bridge", "shutdown_server", "restart_server",
+  "fts_search", "fts_rebuild", "fts_status",
+  "list_scheduled_emails", "list_proton_scheduled", "cancel_scheduled_email",
+  "list_pending_reminders", "cancel_reminder", "check_reminders",
+  "remind_if_no_reply",
+  "alias_list", "alias_create_random", "alias_create_custom",
+  "alias_toggle", "alias_delete", "alias_get_activity",
+  "pass_list", "pass_search", "pass_get",
+  "extract_action_items", "extract_meeting",
+  "send_email", "send_test_email", "reply_to_email", "forward_email",
+  "save_draft", "schedule_email",
+  "request_permission_escalation", "check_escalation_status",
+  "sync_emails",
+  // Email-ID-scoped tools — folder is implied by the message UID, not by an arg.
+  "get_email_by_id", "get_thread", "mark_email_read", "star_email",
+  "delete_email", "download_attachment",
+]);
 
 /**
  * Intersect two presets — return the stricter of the two. Ordering is

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -284,14 +284,29 @@ export function loadConfig(): ServerConfig | null {
       if (sp >= 1 && sp <= 65535) preservedSettingsPort = sp;
     }
     // credentialStorage drives the settings UI's "where are my secrets
-    // kept?" badge — preserve it across load/save round-trips too; it was
-    // dropped by the same bug that hit settingsPort.
-    const preservedCredentialStorage =
+    // kept?" badge. Derive it from observed state rather than trusting the
+    // persisted value — an attacker editing the config file could otherwise
+    // set credentialStorage="keychain" while leaving plaintext passwords in
+    // the file, hiding the fact that credentials live in cleartext.
+    let preservedCredentialStorage: "keychain" | "encrypted-file" | "config" | undefined;
+    const hasEncryptedBlob =
+      CredentialEncryption.isValidEncrypted(mergedConnection.passwordEncrypted) ||
+      CredentialEncryption.isValidEncrypted(mergedConnection.smtpTokenEncrypted);
+    const hasPlaintext =
+      !!mergedConnection.password || !!mergedConnection.smtpToken;
+    if (hasEncryptedBlob) {
+      preservedCredentialStorage = "encrypted-file";
+    } else if (hasPlaintext) {
+      preservedCredentialStorage = "config";
+    } else if (
       parsed.credentialStorage === "keychain" ||
       parsed.credentialStorage === "encrypted-file" ||
       parsed.credentialStorage === "config"
-        ? parsed.credentialStorage
-        : undefined;
+    ) {
+      // No on-disk credentials at all → trust the saved hint (we expect this
+      // to be "keychain" for any installation that's gone through migration).
+      preservedCredentialStorage = parsed.credentialStorage;
+    }
 
     const result: ServerConfig = {
       configVersion: CONFIG_VERSION,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2025,13 +2025,20 @@ async function main() {
     // Claude Desktop spawns.
     const loadedCfg = loadConfig();
     const remoteCn = loadedCfg?.connection;
-    const hasBearer = !!remoteCn?.remoteBearerToken;
-    const hasOAuth  = !!remoteCn?.remoteOauthEnabled && !!remoteCn?.remoteOauthAdminPassword;
+    // Prefer keychain-stored remote secrets over the (legacy) plaintext
+    // config-file values. When both are present the keychain wins, matching
+    // the loadCredentialsFromKeychain priority chain for password/smtpToken.
+    const { loadRemoteSecrets } = await import("./security/keychain.js");
+    const remoteSecrets = await loadRemoteSecrets();
+    const effectiveBearer = remoteSecrets?.remoteBearerToken || remoteCn?.remoteBearerToken || "";
+    const effectiveAdminPassword = remoteSecrets?.remoteOauthAdminPassword || remoteCn?.remoteOauthAdminPassword || "";
+    const hasBearer = !!effectiveBearer;
+    const hasOAuth  = !!remoteCn?.remoteOauthEnabled && !!effectiveAdminPassword;
     if (remoteCn?.remoteMode) {
       if (!hasBearer && !hasOAuth) {
         logger.error(
           "remoteMode is set but no authentication is configured. " +
-          "Set remoteBearerToken OR both remoteOauthEnabled and remoteOauthAdminPassword in ~/.mailpouch.json. " +
+          "Set remoteBearerToken OR both remoteOauthEnabled and remoteOauthAdminPassword in ~/.mailpouch.json (or via keychain). " +
           "Refusing to start without auth — edit the config or remove remoteMode to use stdio.",
           "MCPServer"
         );
@@ -2043,11 +2050,11 @@ async function main() {
         host: remoteCn.remoteHost || "127.0.0.1",
         port: remoteCn.remotePort ?? 8788,
         path: remoteCn.remotePath || "/mcp",
-        bearerToken: remoteCn.remoteBearerToken || "",
+        bearerToken: effectiveBearer,
         tlsCertPath: remoteCn.remoteTlsCertPath || undefined,
         tlsKeyPath:  remoteCn.remoteTlsKeyPath  || undefined,
         oauthEnabled: !!remoteCn.remoteOauthEnabled,
-        oauthAdminPassword: remoteCn.remoteOauthAdminPassword || undefined,
+        oauthAdminPassword: effectiveAdminPassword || undefined,
         oauthIssuer: remoteCn.remoteOauthIssuer || undefined,
         rateLimitPerSecond: remoteCn.remoteRateLimitPerSecond ?? undefined,
         rateLimitBurst: remoteCn.remoteRateLimitBurst ?? undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,10 @@ let bridgeRestartAttempts = 0;
 const BRIDGE_MAX_RESTARTS = 3;
 /** Handle returned by setInterval for the bridge watchdog (null when inactive). */
 let bridgeWatchdogTimer: ReturnType<typeof setInterval> | null = null;
+/** PID of the Bridge process this server launched. Used for clean shutdown so we
+ *  never fall back to `pkill -f proton-bridge`, which would kill any unrelated
+ *  process that happens to carry "proton-bridge" in its command line. */
+let launchedBridgePid: number | null = null;
 
 // ─── Shared mutable state ────────────────────────────────────────────────────
 // Referenced by both the tool handlers (via ToolCallContext.state) and
@@ -1271,8 +1275,11 @@ async function launchProtonBridge(): Promise<void> {
   if (config.bridgePath) {
     config.bridgePath = config.bridgePath.trim().replace(/^["']|["']$/g, "");
   }
-  // User-configured path takes top priority
-  if (config.bridgePath && existsSync(config.bridgePath)) {
+  // User-configured path takes top priority. Don't pre-check existsSync —
+  // that creates a TOCTOU window where an attacker with write access to the
+  // containing directory could swap the binary between check and spawn.
+  // spawn() itself will surface ENOENT via the 'error' event below.
+  if (config.bridgePath) {
     try {
       // Detach + unref lets Bridge outlive us, but an ENOENT (stale path
       // across platforms, missing perms) arrives as an async 'error' event.
@@ -1282,6 +1289,7 @@ async function launchProtonBridge(): Promise<void> {
       const bridgeProc = spawn(config.bridgePath, [], {
         stdio: "ignore", detached: true, shell: false,
       });
+      launchedBridgePid = bridgeProc.pid ?? null;
       bridgeProc.on("error", (err) => {
         logger.warn("Proton Bridge launch process emitted error", "MCPServer", err);
       });
@@ -1368,6 +1376,7 @@ async function launchProtonBridge(): Promise<void> {
     // Same async-error concern as the user-configured path above: attach a
     // listener before .unref() so a spawn failure can't crash the MCP server.
     const bridgeProc = spawn(cmd, args, { stdio: "ignore", detached: true, shell: false });
+    launchedBridgePid = bridgeProc.pid ?? null;
     bridgeProc.on("error", (err) => {
       logger.warn("Proton Bridge launch process emitted error", "MCPServer", err);
     });
@@ -1393,30 +1402,34 @@ async function launchProtonBridge(): Promise<void> {
   }
 }
 
-/** Terminate the Proton Bridge process launched by this server. */
+/** Terminate the Proton Bridge process launched by this server.
+ *
+ *  Prefer killing by PID we recorded at spawn — that's deterministic and can
+ *  never hit an unrelated process. The previous implementation used
+ *  `pkill -f proton-bridge`, which matches the full command line: any other
+ *  process whose argv happens to contain "proton-bridge" (a developer running
+ *  `vim --servername proton-bridge`, for example) would die.
+ *
+ *  If we never launched Bridge (PID is null — e.g., Bridge was already running
+ *  when we started), we do nothing. The user can stop it themselves; we should
+ *  not kill a process we didn't create. */
 async function killProtonBridge(): Promise<void> {
-  const platform = process.platform;
+  if (launchedBridgePid === null) {
+    logger.debug("Proton Bridge not launched by this server — skipping kill", "MCPServer");
+    return;
+  }
+  const pid = launchedBridgePid;
   try {
-    let killCmd: string;
-    let killArgs: string[];
-    if (platform === "win32") {
-      killCmd = "taskkill";
-      killArgs = ["/IM", "proton-bridge.exe", "/F"];
-    } else if (platform === "darwin") {
-      killCmd = "killall";
-      killArgs = ["Proton Mail Bridge"];
-    } else {
-      killCmd = "pkill";
-      killArgs = ["-f", "proton-bridge"];
-    }
-    await new Promise<void>((resolve) => {
-      const p = spawn(killCmd, killArgs, { stdio: "ignore" });
-      p.on("close", () => resolve());
-      p.on("error", () => resolve());
-    });
-    logger.info("Proton Bridge terminated", "MCPServer");
+    process.kill(pid, "SIGTERM");
+    // Give Bridge ~2 s to exit cleanly, then SIGKILL if still alive.
+    await new Promise<void>(r => setTimeout(r, 2000));
+    try { process.kill(pid, 0); } catch { launchedBridgePid = null; logger.info(`Proton Bridge (pid ${pid}) terminated`, "MCPServer"); return; }
+    try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
+    logger.info(`Proton Bridge (pid ${pid}) force-killed`, "MCPServer");
   } catch (e: unknown) {
-    logger.debug("Could not terminate Proton Bridge", "MCPServer", e);
+    logger.debug(`Could not terminate Proton Bridge (pid ${pid})`, "MCPServer", e);
+  } finally {
+    launchedBridgePid = null;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1782,7 +1782,7 @@ async function main() {
   const noSettingsUi = process.argv.includes("--no-settings-ui");
 
   // Clear log file from previous run so each session starts fresh
-  try { writeFileSync(getLogFilePath(), "", "utf8"); } catch { /* ignore */ }
+  try { writeFileSync(getLogFilePath(), "", { encoding: "utf8", mode: 0o600 }); } catch { /* ignore */ }
 
   logger.info(`Starting mailpouch v${_pkgVersion}`, "MCPServer");
 

--- a/src/notifications/desktop.test.ts
+++ b/src/notifications/desktop.test.ts
@@ -96,13 +96,20 @@ describe("DesktopNotifier", () => {
       expect(calls[0].args.join(" ")).toContain("audio silent=");
     });
 
-    it("escapes single quotes in the XML (PowerShell literal safety)", async () => {
+    it("escapes XML-special characters in title/body before embedding", async () => {
       const { runner, calls } = makeRunner();
       const n = new DesktopNotifier({ platform: "win32", runner });
-      await n.notify({ title: "don't", body: "ok" });
-      // The XML is embedded in a single-quoted PS string; internal single
-      // quotes must be doubled. Our `don't` becomes `don''t` in the output.
-      expect(calls[0].args.join(" ")).toContain("don''t");
+      await n.notify({ title: "don't", body: "5 < 6 & 7 > 6" });
+      const out = calls[0].args.join(" ");
+      // XML escapes applied first (this is the defence against XML injection
+      // / entity expansion in ToastNotificationManager parsing).
+      expect(out).toContain("don&apos;t");
+      expect(out).toContain("5 &lt; 6 &amp; 7 &gt; 6");
+      // The wrapping single-quoted PS string still doubles any literal
+      // single quotes that come from the static XML template (the
+      // `template=''ToastGeneric''` attribute), confirming escPowerShell()
+      // is still applied to the assembled string.
+      expect(out).toContain("''ToastGeneric''");
     });
   });
 

--- a/src/notifications/desktop.ts
+++ b/src/notifications/desktop.ts
@@ -37,14 +37,35 @@ export interface DesktopNotification {
   sound?: boolean | string;
 }
 
-/** Escape a string for inclusion in an AppleScript double-quoted literal. */
+/** Escape a string for inclusion in an AppleScript double-quoted literal.
+ *  AppleScript strings can carry literal newlines and other control chars
+ *  that — even when the outer quote-escape is correct — allow breaking out
+ *  of the `display notification "…" with title …` clause and injecting
+ *  e.g. a second `with title` or a `do shell script`. Strip every control
+ *  char up to ASCII 0x1F plus DEL (0x7F); they have no legitimate place in
+ *  a toast notification body. */
 function escAppleScript(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return s
+    .replace(/[\x00-\x1f\x7f]/g, " ")
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"');
 }
 
 /** PowerShell single-quoted literal: double internal single quotes. */
 function escPowerShell(s: string): string {
   return s.replace(/'/g, "''");
+}
+
+/** HTML/XML escape for content embedded in the Windows toast XML. The toast
+ *  payload is parsed as XML by ToastNotificationManager; raw `<` `>` `&`
+ *  break the parse or expand entities. */
+function escXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
 }
 
 export interface DesktopNotifierDeps {
@@ -118,9 +139,9 @@ export class DesktopNotifier {
     // for a single mailpouch deployment.
     const xml =
       `<toast><visual><binding template='ToastGeneric'>` +
-      `<text>${n.title}</text>` +
-      (n.subtitle ? `<text>${n.subtitle}</text>` : "") +
-      `<text>${n.body}</text>` +
+      `<text>${escXml(n.title)}</text>` +
+      (n.subtitle ? `<text>${escXml(n.subtitle)}</text>` : "") +
+      `<text>${escXml(n.body)}</text>` +
       `</binding></visual>` +
       (n.sound === false ? `<audio silent='true'/>` : "") +
       `</toast>`;

--- a/src/permissions/escalation.ts
+++ b/src/permissions/escalation.ts
@@ -335,13 +335,14 @@ export function requestEscalation(
   const newTools         = computeNewTools(currentPreset, targetPreset);
   const unthrottledTools = computeUnthrottledTools(currentPreset, targetPreset);
 
+  const sanitizedReason = reason.replace(/[\x00-\x1f\x7f]|\x1b\[[0-9;]*[a-zA-Z]/g, "").slice(0, 500);
   const record: EscalationRecord = {
     id,
     requestedAt:      now.toISOString(),
     expiresAt:        expiresAt.toISOString(),
     targetPreset,
     currentPreset,
-    reason:           reason.replace(/[\x00-\x1f\x7f]|\x1b\[[0-9;]*[a-zA-Z]/g, "").slice(0, 500),
+    reason:           sanitizedReason,
     status:           "pending",
     resolvedAt:       null,
     resolvedBy:       null,
@@ -358,7 +359,7 @@ export function requestEscalation(
     id,
     fromPreset: currentPreset,
     toPreset:   targetPreset,
-    reason,
+    reason:     sanitizedReason,
   });
 
   return { ok: true, id, expiresAt: expiresAt.toISOString(), newTools, unthrottledTools };

--- a/src/security/keychain.ts
+++ b/src/security/keychain.ts
@@ -18,6 +18,8 @@ import type { ServerConfig } from "../config/schema.js";
 const SERVICE_NAME = "mailpouch";
 const KEY_PASSWORD = "bridge-password";
 const KEY_SMTP_TOKEN = "smtp-token";
+const KEY_REMOTE_BEARER = "remote-bearer-token";
+const KEY_REMOTE_OAUTH_ADMIN = "remote-oauth-admin-password";
 
 /**
  * Build the keychain account key for a per-account credential. Multi-
@@ -238,23 +240,67 @@ export async function migrateFromConfig(
 ): Promise<boolean> {
   const password = config.connection.password;
   const smtpToken = config.connection.smtpToken;
+  const remoteBearer = config.connection.remoteBearerToken;
+  const remoteOauthAdmin = config.connection.remoteOauthAdminPassword;
 
-  // Nothing to migrate if credentials are already blank
-  if (!password && !smtpToken) return false;
+  // Nothing to migrate if all credentials are already blank
+  if (!password && !smtpToken && !remoteBearer && !remoteOauthAdmin) return false;
 
   // Check if keychain is available
   const available = await isKeychainAvailable();
   if (!available) return false;
 
-  // Store in keychain
-  const saved = await saveCredentials(password, smtpToken);
-  if (!saved) return false;
+  // Store bridge creds (existing flow)
+  let migrated = false;
+  if (password || smtpToken) {
+    const saved = await saveCredentials(password, smtpToken);
+    if (saved) {
+      config.connection.password = "";
+      config.connection.smtpToken = "";
+      migrated = true;
+    }
+  }
 
-  // Blank credentials in config file
-  config.connection.password = "";
-  config.connection.smtpToken = "";
-  config.credentialStorage = "keychain";
-  saveConfigFn(config);
+  // Store OAuth secrets (new) — same pattern, separate keychain entries.
+  if (remoteBearer || remoteOauthAdmin) {
+    const saved = await saveRemoteSecrets(remoteBearer ?? "", remoteOauthAdmin ?? "");
+    if (saved) {
+      config.connection.remoteBearerToken = "";
+      config.connection.remoteOauthAdminPassword = "";
+      migrated = true;
+    }
+  }
 
-  return true;
+  if (migrated) {
+    config.credentialStorage = "keychain";
+    saveConfigFn(config);
+  }
+  return migrated;
+}
+
+/** Load remoteBearerToken + remoteOauthAdminPassword from the keychain. */
+export async function loadRemoteSecrets(): Promise<{ remoteBearerToken: string; remoteOauthAdminPassword: string } | null> {
+  try {
+    const keyring = await getKeyring();
+    if (!keyring) return null;
+    const remoteBearerToken = new keyring.Entry(SERVICE_NAME, KEY_REMOTE_BEARER).getPassword() ?? "";
+    const remoteOauthAdminPassword = new keyring.Entry(SERVICE_NAME, KEY_REMOTE_OAUTH_ADMIN).getPassword() ?? "";
+    if (!remoteBearerToken && !remoteOauthAdminPassword) return null;
+    return { remoteBearerToken, remoteOauthAdminPassword };
+  } catch {
+    return null;
+  }
+}
+
+/** Save remoteBearerToken + remoteOauthAdminPassword to the keychain. */
+export async function saveRemoteSecrets(remoteBearerToken: string, remoteOauthAdminPassword: string): Promise<boolean> {
+  try {
+    const keyring = await getKeyring();
+    if (!keyring) return false;
+    if (remoteBearerToken) new keyring.Entry(SERVICE_NAME, KEY_REMOTE_BEARER).setPassword(remoteBearerToken);
+    if (remoteOauthAdminPassword) new keyring.Entry(SERVICE_NAME, KEY_REMOTE_OAUTH_ADMIN).setPassword(remoteOauthAdminPassword);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/services/bridge-tls.ts
+++ b/src/services/bridge-tls.ts
@@ -4,6 +4,19 @@
 // checkServerIdentity can run. Using "localhost" keeps SNI legal. The pinned
 // Bridge CA cert is the trust anchor; checkServerIdentity is bypassed because
 // Bridge exports certs with CN=127.0.0.1, which would not match "localhost".
+
+import { readFileSync } from "fs";
+import { createHash } from "crypto";
+import { logger } from "../utils/logger.js";
+
+/** SHA-256 hashes of pinned Bridge certs, keyed by absolute path.
+ *  The first time we read a cert we remember its hash; subsequent reads must
+ *  produce the same bytes or we refuse the connection. Closes the TOCTOU
+ *  window where an attacker with write access to the cert path could swap it
+ *  between the bridge cert export (verified by the user out-of-band) and a
+ *  later TLS connect. */
+const pinnedCertHashes = new Map<string, string>();
+
 export function buildBridgeTlsOptions(cert: Buffer): Record<string, unknown> {
   return {
     ca: [cert],
@@ -11,4 +24,29 @@ export function buildBridgeTlsOptions(cert: Buffer): Record<string, unknown> {
     servername: "localhost",
     checkServerIdentity: () => undefined,
   };
+}
+
+/** Read the Bridge CA cert at `certPath`, verifying it matches the hash we
+ *  pinned on first read. Throws if the bytes have changed since startup. */
+export function readPinnedBridgeCert(certPath: string): Buffer {
+  const buf = readFileSync(certPath);
+  const hash = createHash("sha256").update(buf).digest("hex");
+  const existing = pinnedCertHashes.get(certPath);
+  if (existing === undefined) {
+    pinnedCertHashes.set(certPath, hash);
+    return buf;
+  }
+  if (existing !== hash) {
+    logger.error(
+      `Bridge CA cert at ${certPath} changed since startup (hash ${existing.slice(0, 16)}… → ${hash.slice(0, 16)}…). Refusing connection — the pinned trust anchor must remain stable for the life of the process.`,
+      "BridgeTLS",
+    );
+    throw new Error(`Bridge cert pin violation: ${certPath} hash changed since startup`);
+  }
+  return buf;
+}
+
+/** Reset the pinned-hash table. Test-only. */
+export function _resetBridgeCertPinsForTests(): void {
+  pinnedCertHashes.clear();
 }

--- a/src/services/fts-service.ts
+++ b/src/services/fts-service.ts
@@ -14,8 +14,23 @@
  */
 
 import { createRequire } from "module";
-import { statSync } from "fs";
+import { statSync, chmodSync, existsSync } from "fs";
 import { logger } from "../utils/logger.js";
+
+/** Tighten the FTS DB to 0600. The index contains decrypted email bodies,
+ *  subjects, and senders — must be owner-readable only. better-sqlite3 opens
+ *  files with the default umask (typically 0644 on Linux), so we chmod
+ *  every primary + sidecar file after open. */
+function chmodFtsFiles(dbPath: string): void {
+  for (const suffix of ["", "-wal", "-shm", "-journal"]) {
+    const p = dbPath + suffix;
+    if (!existsSync(p)) continue;
+    try {
+      const st = statSync(p);
+      if ((st.mode & 0o077) !== 0) chmodSync(p, 0o600);
+    } catch { /* best-effort */ }
+  }
+}
 
 const require = createRequire(import.meta.url);
 
@@ -227,6 +242,7 @@ export function openFtsIndex(dbPath: string): FtsIndexService {
   const Database = require("better-sqlite3") as unknown as DatabaseConstructor;
   try {
     const db = new Database(dbPath);
+    chmodFtsFiles(dbPath);
     return new FtsIndexService(db, dbPath);
   } catch (err) {
     throw new FtsUnavailableError(

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -27,8 +27,9 @@
  *   caller's responsibility — this service exposes the raw CLI output.
  */
 
-import { spawn } from "child_process";
-import { appendFileSync } from "fs";
+import { spawn, spawnSync } from "child_process";
+import { appendFileSync, existsSync, statSync } from "fs";
+import { isAbsolute, sep } from "path";
 import { logger } from "../utils/logger.js";
 
 export interface PassItemSummary {
@@ -52,6 +53,46 @@ export interface PassItemDetail extends PassItemSummary {
 const DEFAULT_CLI_PATH = "pass-cli";
 const DEFAULT_TIMEOUT_MS = 15_000;
 
+/** Directory prefixes considered trusted when resolving pass-cli via PATH. */
+const TRUSTED_PREFIXES = [
+  "/usr/bin/",
+  "/usr/local/bin/",
+  "/opt/",
+  "/bin/",
+  // Homebrew on macOS Apple Silicon
+  "/opt/homebrew/bin/",
+];
+
+/**
+ * Resolve `cliPath` to an absolute, validated executable path. If the
+ * configured value contains a path separator we trust it as-is (the operator
+ * picked a specific binary). Otherwise we look it up via the shell `which`
+ * command and verify the result lives under one of TRUSTED_PREFIXES so that
+ * a directory in PATH writable by the agent (e.g. `~/.local/bin`) cannot
+ * shadow the real binary.
+ */
+function resolveCliPath(configured: string): string {
+  if (configured.includes(sep) || isAbsolute(configured)) return configured;
+  try {
+    const r = spawnSync("which", [configured], { encoding: "utf-8" });
+    if (r.status !== 0) return configured;
+    const resolved = (r.stdout ?? "").trim();
+    if (!resolved || !existsSync(resolved)) return configured;
+    const trusted = TRUSTED_PREFIXES.some(p => resolved.startsWith(p));
+    if (!trusted) {
+      logger.warn(
+        `Pass: refusing to use '${resolved}' — not in a trusted PATH prefix (${TRUSTED_PREFIXES.join(", ")}). ` +
+        `Set passCliPath in config to override.`,
+        "PassService",
+      );
+      return configured; // let ENOENT surface naturally
+    }
+    return resolved;
+  } catch {
+    return configured;
+  }
+}
+
 /** Thrown when `pass-cli` is not installed or the invocation times out. */
 export class PassCliUnavailableError extends Error {
   constructor(message: string) {
@@ -67,7 +108,7 @@ export class PassService {
 
   constructor(args: { personalAccessToken: string; cliPath?: string; auditLogPath: string }) {
     this.pat = args.personalAccessToken;
-    this.cliPath = args.cliPath ?? DEFAULT_CLI_PATH;
+    this.cliPath = resolveCliPath(args.cliPath ?? DEFAULT_CLI_PATH);
     this.auditPath = args.auditLogPath;
   }
 
@@ -90,10 +131,21 @@ export class PassService {
       let child: ReturnType<typeof spawn>;
       try {
         // The PAT is passed via env, matching pass-cli's documented flow.
-        // A child env keeps it out of parent process.env visibility.
+        // Restrict the child env to a minimal allowlist — passing
+        // ...process.env would hand a malicious or compromised pass-cli
+        // every credential the parent holds (OAuth admin password,
+        // SimpleLogin keys in tests, etc.).
         child = spawn(this.cliPath, ["--json", ...args], {
           stdio: ["ignore", "pipe", "pipe"],
-          env: { ...process.env, PROTON_PASS_PAT: this.pat },
+          env: {
+            PATH: process.env.PATH ?? "",
+            HOME: process.env.HOME ?? "",
+            PROTON_PASS_PAT: this.pat,
+            // Locale/charset hints — pass-cli emits JSON; without these
+            // some libcs default to ASCII and mangle non-ASCII content.
+            LANG: process.env.LANG ?? "C.UTF-8",
+            LC_ALL: process.env.LC_ALL ?? "",
+          },
         });
       } catch (err: unknown) {
         reject(new PassCliUnavailableError(

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -10,7 +10,7 @@ import { simpleParser } from 'mailparser';
 import nodemailer, { type SendMailOptions } from 'nodemailer';
 import { EmailMessage, EmailFolder, SearchEmailOptions, SaveDraftOptions } from '../types/index.js';
 import { logger } from '../utils/logger.js';
-import { buildBridgeTlsOptions } from './bridge-tls.js';
+import { buildBridgeTlsOptions, readPinnedBridgeCert } from './bridge-tls.js';
 import { tracer, type SpanTags } from '../utils/tracer.js';
 import { BRIDGE_MIN_VERSION } from '../config/schema.js';
 
@@ -368,7 +368,7 @@ export class SimpleIMAPService {
             }
           } catch { /* stat failed — let readFileSync produce the real error below */ }
           try {
-            const bridgeCert = readFileSync(resolvedCertPath);
+            const bridgeCert = readPinnedBridgeCert(resolvedCertPath);
             tlsOptions = buildBridgeTlsOptions(bridgeCert);
             logger.info(`IMAP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, 'IMAPService');
           } catch (err) {
@@ -1942,7 +1942,7 @@ export class SimpleIMAPService {
         try {
           let certPath = cfg.bridgeCertPath;
           try { if (statSync(certPath).isDirectory()) certPath = pathJoin(certPath, 'cert.pem'); } catch {}
-          const cert = readFileSync(certPath);
+          const cert = readPinnedBridgeCert(certPath);
           tlsOptions = buildBridgeTlsOptions(cert);
         } catch {
           tlsOptions = { rejectUnauthorized: false, minVersion: 'TLSv1.2' };

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -8,7 +8,7 @@ import { readFileSync, statSync } from "fs";
 import { join as pathJoin } from "path";
 import { ProtonMailConfig, SendEmailOptions } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import { buildBridgeTlsOptions } from "./bridge-tls.js";
+import { buildBridgeTlsOptions, readPinnedBridgeCert } from "./bridge-tls.js";
 import { parseEmails, isValidEmail } from "../utils/helpers.js";
 import { tracer } from "../utils/tracer.js";
 import { BackoffTracker, isTransientAbuseError } from "../utils/backoff.js";
@@ -113,7 +113,7 @@ export class SMTPService {
         } catch { /* stat failed — let readFileSync produce the real error below */ }
         // Load the exported Bridge certificate — proper trust without disabling validation
         try {
-          const bridgeCert = readFileSync(resolvedCertPath);
+          const bridgeCert = readPinnedBridgeCert(resolvedCertPath);
           tlsOptions = buildBridgeTlsOptions(bridgeCert);
           logger.info(`SMTP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, "SMTPService");
         } catch (err: unknown) {

--- a/src/settings/security.test.ts
+++ b/src/settings/security.test.ts
@@ -340,14 +340,16 @@ describe('hasValidAccessToken', () => {
     expect(hasValidAccessToken(req, makeURL(), token)).toBe(false);
   });
 
-  it('returns true when ?token= query param matches', () => {
+  it('returns false even when ?token= query param matches (header-only mode)', () => {
+    // Query-string tokens are no longer accepted — they leak into browser
+    // history, referer headers, and proxy logs. Header is the only path.
     const token = generateAccessToken();
     const req = mockReqWithHeaders({});
     const url = makeURL(`?token=${token.value}`);
-    expect(hasValidAccessToken(req, url, token)).toBe(true);
+    expect(hasValidAccessToken(req, url, token)).toBe(false);
   });
 
-  it('returns false when ?token= query param is wrong', () => {
+  it('returns false when ?token= query param is wrong (header-only mode)', () => {
     const token = generateAccessToken();
     const req = mockReqWithHeaders({});
     const url = makeURL('?token=badtoken');

--- a/src/settings/security.ts
+++ b/src/settings/security.ts
@@ -87,13 +87,22 @@ export class RateLimiter {
     times.push(now);
 
     // Enforce the per-instance key cap before inserting a brand-new key.
-    // Run eviction first to clear stale buckets, then check the cap.
+    // Run eviction first to clear stale buckets, then evict LRU rather than
+    // insertion-order: an attacker rotating fake keys faster than the
+    // window's eviction sweep would otherwise force out long-lived legitimate
+    // clients (DoS-of-DoS).
     if (!this.buckets.has(key)) {
       if (this.buckets.size >= MAX_RATE_LIMIT_BUCKETS) {
         this.evict();
       }
       if (this.buckets.size >= MAX_RATE_LIMIT_BUCKETS) {
-        const oldestKey = this.buckets.keys().next().value;
+        // Find the bucket whose most-recent activity is oldest.
+        let oldestKey: string | undefined;
+        let oldestT = Infinity;
+        for (const [k, ts] of this.buckets) {
+          const last = ts.length === 0 ? 0 : ts[ts.length - 1];
+          if (last < oldestT) { oldestT = last; oldestKey = k; }
+        }
         if (oldestKey !== undefined) this.buckets.delete(oldestKey);
       }
     }
@@ -215,6 +224,14 @@ export function isValidOrigin(
     const RFC1918_RE =
       /^https?:\/\/(?:192\.168\.\d{1,3}|10\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3})\.\d{1,3}(?::\d+)?(?:\/|$)/;
     if (RFC1918_RE.test(header)) return true;
+    // IPv6 equivalents of RFC-1918: ULA (fc00::/7 → fc00:– / fd00:–) and
+    // link-local (fe80::/10). Origin/referer URLs bracket the IPv6 address.
+    // We don't try to validate the full IPv6 grammar — just the leading
+    // prefix bytes, which is enough to admit private-range traffic without
+    // letting public IPv6 origins through.
+    const IPV6_PRIVATE_RE =
+      /^https?:\/\/\[(?:f[cd][0-9a-f]{2}:|fe[89ab][0-9a-f]:)[0-9a-f:]*\](?::\d+)?(?:\/|$)/i;
+    if (IPV6_PRIVATE_RE.test(header)) return true;
   }
 
   // Use exact match (for Origin headers, which carry no path) or require a
@@ -250,31 +267,24 @@ export function generateAccessToken(): AccessToken {
  * Check whether an incoming request carries the valid access token.
  * Uses `timingSafeEqual` to prevent timing-based enumeration.
  *
- * Checks (in order):
- *   1. `X-Access-Token` header   — preferred (not in URL logs)
- *   2. `?token=` query parameter — for direct mobile URL access
+ * Only the `X-Access-Token` header is accepted. Query-string tokens leak
+ * into browser history, referer headers to outbound links, proxy access
+ * logs, and devtools network tab; not worth the marginal UX benefit.
  */
 export function hasValidAccessToken(
   req:   http.IncomingMessage,
-  url:   URL,
+  _url:  URL,
   token: AccessToken,
 ): boolean {
   const expected = Buffer.from(token.value, "utf-8");
-
-  const tryCompare = (candidate: string | undefined): boolean => {
-    if (!candidate) return false;
-    if (candidate.length !== token.value.length) return false;
-    try {
-      return timingSafeEqual(Buffer.from(candidate, "utf-8"), expected);
-    } catch {
-      return false;
-    }
-  };
-
-  return (
-    tryCompare(req.headers["x-access-token"] as string | undefined) ||
-    tryCompare(url.searchParams.get("token") ?? undefined)
-  );
+  const candidate = req.headers["x-access-token"] as string | undefined;
+  if (!candidate) return false;
+  if (candidate.length !== token.value.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(candidate, "utf-8"), expected);
+  } catch {
+    return false;
+  }
 }
 
 // ─── TLS certificate generation ───────────────────────────────────────────────

--- a/src/settings/security.ts
+++ b/src/settings/security.ts
@@ -15,7 +15,7 @@
 
 import http from "http";
 import { spawnSync } from "child_process";
-import { mkdtempSync, readFileSync, existsSync } from "fs";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "fs";
 import { tmpdir, networkInterfaces } from "os";
 import { join } from "path";
 import { randomBytes, createHash, timingSafeEqual } from "crypto";
@@ -296,8 +296,9 @@ export interface TlsCredentials {
  * The resulting credentials are suitable for `https.createServer()`.
  */
 export function tryGenerateSelfSignedCert(): TlsCredentials | null {
+  let dir: string | null = null;
   try {
-    const dir      = mkdtempSync(join(tmpdir(), "protonmcp-tls-"));
+    dir            = mkdtempSync(join(tmpdir(), "protonmcp-tls-"));
     const keyFile  = join(dir, "key.pem");
     const certFile = join(dir, "cert.pem");
 
@@ -335,6 +336,13 @@ export function tryGenerateSelfSignedCert(): TlsCredentials | null {
     return { key, cert, fingerprint };
   } catch {
     return null;
+  } finally {
+    // The cert + private key only ever needed to be read once — they're now
+    // in-memory buffers. Wipe the on-disk copy immediately so a crash or
+    // forensic capture of /tmp doesn't surface the private key.
+    if (dir) {
+      try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
   }
 }
 

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -134,7 +134,7 @@ const _pkgJsonPath = nodePath.resolve(_moduleDir, "../../package.json");
 
 // ─── Embedded HTML UI ─────────────────────────────────────────────────────────
 
-function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): string {
+function buildHtml(configPath: string, csrfToken: string, runningPort = 8765, cspNonce = ""): string {
   const toolsJson = JSON.stringify(ALL_TOOLS);
   const categoriesJson = JSON.stringify(TOOL_CATEGORIES);
   const distIndexPath = JSON.stringify(nodePath.resolve(_moduleDir, "../index.js"));
@@ -192,7 +192,7 @@ function buildHtml(configPath: string, csrfToken: string, runningPort = 8765): s
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="csrf-token" content="${csrfToken}">
 <title>mailpouch — Settings</title>
-<style>
+<style nonce="${cspNonce}">
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
@@ -1885,7 +1885,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
 
 <div id="toast" role="status" aria-live="polite"></div>
 
-<script>
+<script nonce="${cspNonce}">
 (function() {
   // ── Constants ─────────────────────────────────────────────────────────────
   const ALL_TOOLS  = ${toolsJson};
@@ -3682,7 +3682,7 @@ button.btn:disabled { opacity: .4; cursor: not-allowed; }
     </div>
   </div>
 </div>
-<script>
+<script nonce="${cspNonce}">
 (function() {
   let currentClientId = null;
   document.addEventListener('change', (e) => {
@@ -4177,7 +4177,7 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
       // Vary: Origin so caches do not serve the wrong ACAO value to other origins.
       res.setHeader("Vary", "Origin");
     }
-    res.setHeader("Strict-Transport-Security",    "max-age=31536000");
+    res.setHeader("Strict-Transport-Security",    "max-age=31536000; includeSubDomains; preload");
 
     // ── CORS preflight ──────────────────────────────────────────────────────
     if (method === "OPTIONS") {
@@ -4192,7 +4192,7 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
     // devices on the network cannot read config or approve escalations.
     if (lan && accessToken && path !== "/") {
       if (!hasValidAccessToken(req, url, accessToken)) {
-        json(res, 401, { error: "Access denied. Include the X-Access-Token header or ?token= query param." });
+        json(res, 401, { error: "Access denied. Include the X-Access-Token header." });
         return;
       }
     }
@@ -4206,10 +4206,15 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
     try {
       // ── Serve UI ────────────────────────────────────────────────────────
       if (method === "GET" && path === "/") {
-        const html = buildHtml(configPath, csrfToken, port);
+        // Per-response CSP nonce. Lets us drop 'unsafe-inline' for script
+        // and style: only the three inline blocks we ship can execute,
+        // because they carry the matching nonce attribute. Stops stored XSS
+        // from any future bug that reflects config into the page.
+        const cspNonce = randomBytes(16).toString("base64");
+        const html = buildHtml(configPath, csrfToken, port, cspNonce);
         res.writeHead(200, {
           "Content-Type":             "text/html; charset=utf-8",
-          "Content-Security-Policy":  "default-src 'self'; style-src 'unsafe-inline'; script-src 'unsafe-inline'",
+          "Content-Security-Policy":  `default-src 'self'; style-src 'nonce-${cspNonce}'; script-src 'nonce-${cspNonce}'`,
           "X-Content-Type-Options":   "nosniff",
           "X-Frame-Options":          "DENY",
           "Referrer-Policy":          "no-referrer",
@@ -4379,11 +4384,23 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         if (body.permissions && typeof body.permissions === "object") {
           const p = body.permissions as Record<string, unknown>;
           const validPresets = new Set<string>(PERMISSION_PRESETS as unknown as string[]);
+          // Filter incoming tool keys against ALL_TOOLS so an unknown name
+          // (typo, or a key for a tool that doesn't ship yet) is dropped
+          // instead of silently entering the persisted config. Matches the
+          // pattern config/loader.ts applies on load.
+          const knownTools = new Set<string>(ALL_TOOLS as unknown as string[]);
+          const incomingTools = typeof p.tools === "object" && p.tools !== null
+            ? p.tools as Record<string, unknown>
+            : {};
+          const filteredTools: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(incomingTools)) {
+            if (knownTools.has(k)) filteredTools[k] = v;
+          }
           current.permissions = {
             preset: typeof p.preset === "string" && validPresets.has(p.preset)
               ? (p.preset as PermissionPreset)
               : current.permissions.preset,
-            tools:  { ...current.permissions.tools, ...(typeof p.tools === "object" && p.tools !== null ? p.tools as Record<string, boolean> : {}) },
+            tools:  { ...current.permissions.tools, ...filteredTools as Record<string, boolean> },
           };
         }
 

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4303,6 +4303,30 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
           if (c.simpleloginBaseUrl !== undefined && !validUrl(c.simpleloginBaseUrl)) {
             json(res, 400, { error: "Invalid simpleloginBaseUrl: must be an http:// or https:// URL, or empty." }); return;
           }
+          // For binary paths (bridgePath / passCliPath): if a non-empty value
+          // is provided, normalise + require it points to an existing regular
+          // file. We deliberately do NOT enforce a directory allowlist (the
+          // operator may have a custom build location), but we refuse strings
+          // that don't resolve to a real file — silently saving garbage paths
+          // makes later spawn() failures opaque to the user.
+          const validBinaryPath = (raw: string): string | null => {
+            const cleaned = raw.trim().replace(/^["']|["']$/g, "");
+            if (cleaned === "") return ""; // explicit clear
+            const resolved = nodePath.resolve(cleaned);
+            if (!existsSync(resolved)) return null;
+            try { if (!statSync(resolved).isFile()) return null; } catch { return null; }
+            return resolved;
+          };
+          if (typeof c.bridgePath === "string" && c.bridgePath.trim() !== "") {
+            const v = validBinaryPath(c.bridgePath);
+            if (v === null) { json(res, 400, { error: "Invalid bridgePath: not an existing regular file." }); return; }
+            c.bridgePath = v;
+          }
+          if (typeof c.passCliPath === "string" && c.passCliPath.trim() !== "") {
+            const v = validBinaryPath(c.passCliPath);
+            if (v === null) { json(res, 400, { error: "Invalid passCliPath: not an existing regular file." }); return; }
+            c.passCliPath = v;
+          }
 
           current.connection = {
             ...current.connection,

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -4939,10 +4939,11 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         res.setHeader("Connection", "keep-alive");
         res.setHeader("X-Accel-Buffering", "no"); // disable proxy buffering
         res.write(`: connected\n\n`);
+        const stripNL = (s: unknown) => String(s).replace(/[\r\n]/g, "");
         const unsub = agentNotifications.subscribe((ev) => {
           try {
-            res.write(`event: ${ev.kind}\n`);
-            res.write(`id: ${ev.seq}\n`);
+            res.write(`event: ${stripNL(ev.kind)}\n`);
+            res.write(`id: ${stripNL(ev.seq)}\n`);
             res.write(`data: ${JSON.stringify(ev.grant)}\n\n`);
           } catch { /* client disconnected mid-write */ }
         });

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -36,6 +36,7 @@ import { OAuthStore } from "./oauth-store.js";
 import { OAuthHandlers } from "./oauth-handlers.js";
 import { TokenBucketLimiter } from "./rate-limit.js";
 import type { AgentGrantStore } from "../agents/grant-store.js";
+import { notifications } from "../agents/notifications.js";
 import { runWithCaller } from "../agents/caller-context.js";
 
 export interface HttpTransportOptions {
@@ -179,6 +180,15 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
   const derivedIssuer = `${scheme}://${host}:${opts.port}`;
   const issuer = opts.oauthIssuer ?? derivedIssuer;
   const oauthStore = new OAuthStore();
+  // Invalidate outstanding access tokens immediately when a grant transitions
+  // out of "active". Without this, a revoked agent's existing token stayed
+  // valid up to OAUTH_ACCESS_TOKEN_TTL_MS (24 h).
+  const unsubGrantChanges = notifications.subscribe((ev) => {
+    if (ev.kind === "grant-revoked" || ev.kind === "grant-denied" || ev.kind === "grant-expired") {
+      const n = oauthStore.revokeTokensForClient(ev.grant.clientId);
+      if (n > 0) logger.info(`Revoked ${n} OAuth token(s) for client ${ev.grant.clientId} after ${ev.kind}`, "HTTPTransport");
+    }
+  });
   const oauthHandlers = opts.oauthEnabled && opts.oauthAdminPassword
     ? new OAuthHandlers(
         oauthStore,
@@ -232,6 +242,7 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
     }
 
     const token = extractBearer(req);
+    const caller = clientIp(req);
     let tokenKey: string | null = null;
     let ok = false;
     let callerClientId = "bearer:static";
@@ -249,6 +260,16 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
         if (rec.resource && rec.resource !== expectedResource) {
           res.statusCode = 401;
           res.setHeader("WWW-Authenticate", `Bearer realm="mailpouch", error="invalid_token", error_description="token resource does not match endpoint"`);
+          res.end(JSON.stringify({ error: "invalid_token" }));
+          return;
+        }
+        // IP pinning at the token layer: if the token recorded its issuing
+        // IP, the request must come from the same IP. Closes the "issue from
+        // loopback, replay from remote" vector even when no per-agent grant
+        // has ipPins set.
+        if (rec.issuedFromIp && rec.issuedFromIp !== caller) {
+          res.statusCode = 401;
+          res.setHeader("WWW-Authenticate", `Bearer realm="mailpouch", error="invalid_token", error_description="token issued for a different client IP"`);
           res.end(JSON.stringify({ error: "invalid_token" }));
           return;
         }
@@ -330,6 +351,7 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
     issuer: oauthHandlers ? issuer : undefined,
     close: async () => {
       clearInterval(sweep);
+      unsubGrantChanges();
       try { await transport.close(); } catch { /* best effort */ }
       await new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -132,11 +132,15 @@ async function readJsonBody(req: IncomingMessage, maxBytes = 1_048_576): Promise
  */
 export function clientIp(req: IncomingMessage): string {
   const direct = req.socket.remoteAddress ?? "0.0.0.0";
+  // Only the exact loopback addresses qualify — earlier code accepted any
+  // 127.x.x.x or any ::ffff:127.x.x.x form, which on dual-stack/containerized
+  // setups let an attacker reaching the host from a non-loopback IPv6 address
+  // spoof X-Forwarded-For. Reject any IPv4-mapped-loopback variant other than
+  // ::ffff:127.0.0.1.
   const isLoopback =
     direct === "127.0.0.1" ||
     direct === "::1" ||
-    direct === "::ffff:127.0.0.1" ||
-    direct.startsWith("127.");
+    direct === "::ffff:127.0.0.1";
   if (!isLoopback) return direct;
   const h = req.headers["x-forwarded-for"];
   const raw = Array.isArray(h) ? h[0] : h;

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -343,6 +343,7 @@ export class OAuthHandlers {
       clientId: auth.clientId,
       scopes: auth.scopes,
       resource: auth.resource ?? resource,
+      issuedFromIp: clientIp(req),
     });
 
     json(res, 200, {

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -13,8 +13,11 @@
  *   POST /oauth/revoke                            — token revocation
  *
  * The "consent page" is a single minimal HTML form that asks the user to
- * paste the admin password (the same value as remoteBearerToken — the
- * intent is to prove physical presence, not to model a full user base).
+ * paste the admin password — a value distinct from remoteBearerToken,
+ * configured separately as remoteOauthAdminPassword. The intent is to
+ * prove physical presence, not to model a full user base. Do NOT reuse
+ * the bearer token here: a single shared secret across both auth modes
+ * means compromise of one path compromises both.
  *
  * Rate-limited through the shared TokenBucketLimiter (per client IP).
  */
@@ -242,6 +245,7 @@ export class OAuthHandlers {
       return { handled: true };
     }
     if (method !== "S256") { error(res, 400, "invalid_request", "PKCE S256 is required."); return { handled: true }; }
+    if (state.length > 500) { error(res, 400, "invalid_request", "state parameter exceeds 500 chars."); return { handled: true }; }
     if (!codeChallenge || codeChallenge.length < 43) { error(res, 400, "invalid_request", "code_challenge missing or too short."); return { handled: true }; }
 
     const html = this.consentPage({
@@ -279,6 +283,7 @@ export class OAuthHandlers {
     if (!client) { error(res, 400, "invalid_client", "Unknown client_id."); return { handled: true }; }
     const redirectUri = body.redirect_uri ?? "";
     if (!client.redirect_uris.includes(redirectUri)) { error(res, 400, "invalid_redirect_uri"); return { handled: true }; }
+    if (body.state && body.state.length > 500) { error(res, 400, "invalid_request", "state parameter exceeds 500 chars."); return { handled: true }; }
 
     const rec = this.store.issueAuthCode({
       clientId: client.client_id,

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -246,7 +246,13 @@ export class OAuthHandlers {
     }
     if (method !== "S256") { error(res, 400, "invalid_request", "PKCE S256 is required."); return { handled: true }; }
     if (state.length > 500) { error(res, 400, "invalid_request", "state parameter exceeds 500 chars."); return { handled: true }; }
-    if (!codeChallenge || codeChallenge.length < 43) { error(res, 400, "invalid_request", "code_challenge missing or too short."); return { handled: true }; }
+    // RFC 7636 §4.2: code_challenge is base64url(SHA256(verifier)), which is
+    // exactly 43 chars of URL-safe alphabet. Reject anything longer or with
+    // non-base64url characters.
+    if (!codeChallenge || !/^[A-Za-z0-9_\-.~]{43,128}$/.test(codeChallenge)) {
+      error(res, 400, "invalid_request", "code_challenge must be 43–128 chars of base64url alphabet.");
+      return { handled: true };
+    }
 
     const html = this.consentPage({
       clientId,
@@ -327,11 +333,24 @@ export class OAuthHandlers {
     const redirectUri = body.redirect_uri ?? "";
     const resource = body.resource || undefined;
 
+    // Validate verifier shape per RFC 7636 §4.1 before hashing — rejects
+    // 1-char verifiers and other malformed input that would otherwise
+    // produce a valid SHA256 against a precomputed challenge.
+    if (!/^[A-Za-z0-9_\-.~]{43,128}$/.test(verifier)) {
+      error(res, 400, "invalid_grant", "Invalid authorization code.");
+      return { handled: true };
+    }
     const auth = this.store.consumeAuthCode(code);
-    if (!auth) { error(res, 400, "invalid_grant", "Unknown or expired authorization code."); return { handled: true }; }
-    if (auth.clientId !== clientId) { error(res, 400, "invalid_grant", "client_id does not match the issued code."); return { handled: true }; }
-    if (auth.redirectUri !== redirectUri) { error(res, 400, "invalid_grant", "redirect_uri does not match the issued code."); return { handled: true }; }
-    if (!verifyPkceS256(verifier, auth.codeChallenge)) { error(res, 400, "invalid_grant", "PKCE verification failed."); return { handled: true }; }
+    // Collapse all code-validation failures into a single opaque error so an
+    // attacker can't distinguish "unknown code" from "wrong client" from
+    // "wrong redirect_uri" from "PKCE failed" via error-string enumeration.
+    if (!auth
+      || auth.clientId !== clientId
+      || auth.redirectUri !== redirectUri
+      || !verifyPkceS256(verifier, auth.codeChallenge)) {
+      error(res, 400, "invalid_grant", "Invalid authorization code.");
+      return { handled: true };
+    }
     // Resource Indicators (RFC 8707): if the request included `resource`, it
     // must match the one from authorize; if neither set one, we accept it.
     if (resource && auth.resource && resource !== auth.resource) {

--- a/src/transports/oauth-store.ts
+++ b/src/transports/oauth-store.ts
@@ -49,6 +49,11 @@ export interface IssuedToken {
   resource?: string;
   /** ms since epoch. */
   expiresAt: number;
+  /** Client IP at issuance. When set, verifyToken() rejects requests from a
+   *  different IP — closes the "issue from loopback, replay from a non-pinned
+   *  remote" gap that bypassed per-agent ipPins on the MCP endpoint. Optional
+   *  for backwards compatibility with tokens issued before this field existed. */
+  issuedFromIp?: string;
 }
 
 export const OAUTH_CODE_TTL_MS = 60_000;                // RFC 6749 §4.1.2: MAX 10 min; we go short
@@ -71,11 +76,29 @@ export class OAuthStore {
   private clients = new Map<string, RegisteredClient>();
   private codes = new Map<string, PendingAuth>();
   private tokens = new Map<string, IssuedToken>();
+  /** Reverse index clientId → tokens, so revoking a grant can invalidate all
+   *  outstanding access tokens for that client immediately rather than waiting
+   *  for the 24 h TTL to expire. Kept consistent with `tokens` via the
+   *  issueToken / revokeToken / evict / sweep paths. */
+  private tokensByClient = new Map<string, Set<string>>();
 
   /** Drop the oldest entry from a Map (relies on Map's insertion-order iteration). */
   private evictOldest<K, V>(m: Map<K, V>): void {
     const first = m.keys().next();
     if (!first.done) m.delete(first.value);
+  }
+
+  private indexToken(rec: IssuedToken): void {
+    let set = this.tokensByClient.get(rec.clientId);
+    if (!set) { set = new Set(); this.tokensByClient.set(rec.clientId, set); }
+    set.add(rec.token);
+  }
+
+  private unindexToken(token: string, clientId: string): void {
+    const set = this.tokensByClient.get(clientId);
+    if (!set) return;
+    set.delete(token);
+    if (set.size === 0) this.tokensByClient.delete(clientId);
   }
 
   registerClient(client: Omit<RegisteredClient, "client_id" | "client_id_issued_at">): RegisteredClient {
@@ -113,7 +136,7 @@ export class OAuthStore {
     return rec;
   }
 
-  issueToken(args: { clientId: string; scopes: string[]; resource?: string }): IssuedToken {
+  issueToken(args: { clientId: string; scopes: string[]; resource?: string; issuedFromIp?: string }): IssuedToken {
     const token = randomBytes(32).toString("base64url");
     const rec: IssuedToken = {
       token,
@@ -121,9 +144,18 @@ export class OAuthStore {
       scopes: args.scopes,
       resource: args.resource,
       expiresAt: Date.now() + OAUTH_ACCESS_TOKEN_TTL_MS,
+      issuedFromIp: args.issuedFromIp,
     };
-    if (this.tokens.size >= OAUTH_MAX_TOKENS) this.evictOldest(this.tokens);
+    if (this.tokens.size >= OAUTH_MAX_TOKENS) {
+      const first = this.tokens.keys().next();
+      if (!first.done) {
+        const old = this.tokens.get(first.value);
+        this.tokens.delete(first.value);
+        if (old) this.unindexToken(first.value, old.clientId);
+      }
+    }
     this.tokens.set(token, rec);
+    this.indexToken(rec);
     return rec;
   }
 
@@ -132,13 +164,32 @@ export class OAuthStore {
     if (!rec) return null;
     if (Date.now() > rec.expiresAt) {
       this.tokens.delete(token);
+      this.unindexToken(token, rec.clientId);
       return null;
     }
     return rec;
   }
 
   revokeToken(token: string): boolean {
-    return this.tokens.delete(token);
+    const rec = this.tokens.get(token);
+    const removed = this.tokens.delete(token);
+    if (removed && rec) this.unindexToken(token, rec.clientId);
+    return removed;
+  }
+
+  /** Drop every outstanding access token for `clientId`. Returns the number
+   *  of tokens revoked. Called when a per-agent grant is denied / revoked /
+   *  expires so that ongoing requests holding the token can't continue past
+   *  the policy change. */
+  revokeTokensForClient(clientId: string): number {
+    const set = this.tokensByClient.get(clientId);
+    if (!set || set.size === 0) return 0;
+    let n = 0;
+    for (const token of set) {
+      if (this.tokens.delete(token)) n++;
+    }
+    this.tokensByClient.delete(clientId);
+    return n;
   }
 
   /**
@@ -157,6 +208,7 @@ export class OAuthStore {
     for (const [k, v] of this.tokens) {
       if (now > v.expiresAt) {
         this.tokens.delete(k);
+        this.unindexToken(k, v.clientId);
         tokens++;
       }
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,10 +2,17 @@
  * Logging utility for mailpouch
  */
 
-import { appendFile } from "fs";
+import { appendFile, statSync, chmodSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { LogEntry } from "../types/index.js";
+
+function statSyncSafe(p: string): import("fs").Stats | null {
+  try { return statSync(p); } catch { return null; }
+}
+function chmodSyncSafe(p: string, m: number): void {
+  try { chmodSync(p, m); } catch { /* ignore */ }
+}
 
 /**
  * Keys whose values must be redacted before being stored in log entries.
@@ -36,14 +43,19 @@ export class Logger {
   /**
    * Recursively sanitize data before storing in log entries.
    * Redacts sensitive keys and truncates long strings.
+   *
+   * Cap recursion at SANITIZE_MAX_DEPTH so adversary-supplied JSON nested
+   * thousands of levels deep can't blow the stack or burn the CPU during
+   * sanitisation.
    */
-  private sanitizeData(data: unknown, seen?: WeakSet<object>): unknown {
+  private sanitizeData(data: unknown, seen?: WeakSet<object>, depth = 0): unknown {
     if (data === null || data === undefined) return data;
     if (typeof data === "string") {
       const truncated = data.length > 200 ? data.substring(0, 200) + "…" : data;
       return truncated.replace(/[\x00-\x1f\x7f]/g, " ");
     }
     if (typeof data !== "object") return data;
+    if (depth > 100) return "[depth-limit]";
 
     // Prevent infinite recursion on circular references (e.g. socket/TLS error objects)
     const tracker = seen ?? new WeakSet();
@@ -51,11 +63,11 @@ export class Logger {
     tracker.add(data as object);
 
     if (Array.isArray(data)) {
-      return data.map((item) => this.sanitizeData(item, tracker));
+      return data.map((item) => this.sanitizeData(item, tracker, depth + 1));
     }
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-      result[key] = SENSITIVE_KEYS.test(key) ? "[redacted]" : this.sanitizeData(value, tracker);
+      result[key] = SENSITIVE_KEYS.test(key) ? "[redacted]" : this.sanitizeData(value, tracker, depth + 1);
     }
     return result;
   }
@@ -123,7 +135,17 @@ export class Logger {
     const shouldWriteFile = this.fileLogging &&
       (level !== "debug" || this.debugFileLogging);
     if (shouldWriteFile) {
-      appendFile(getLogFilePath(), JSON.stringify(entry) + "\n", "utf8", () => {
+      // Explicit mode 0o600 so debug entries (which may carry email-like
+      // context, even after redaction) are owner-readable only.
+      // appendFile creates the file if missing; otherwise the mode is
+      // ignored, so we also chmodSync if the file already exists with
+      // looser permissions (e.g. upgraded from an older mailpouch).
+      const path = getLogFilePath();
+      try {
+        const st = statSyncSafe(path);
+        if (st && (st.mode & 0o077) !== 0) chmodSyncSafe(path, 0o600);
+      } catch { /* ignore */ }
+      appendFile(path, JSON.stringify(entry) + "\n", { encoding: "utf8", mode: 0o600 }, () => {
         /* best-effort — never crash the server over a log write */
       });
     }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -15,7 +15,7 @@ import { LogEntry } from "../types/index.js";
  * want on disk"; the second is "email body-like fields" that might carry
  * user content we don't need in a debug log.
  */
-const SENSITIVE_KEYS = /(password|token|secret|apikey|api_key|verifier|credential|authorization|bridgecertpath|attachments|content|^body$)/i;
+const SENSITIVE_KEYS = /(password|token|secret|apikey|api_key|verifier|credential|authorization|cookie|oauth|bridgecertpath|attachments|content|^body$)/i;
 
 export function getLogFilePath(): string {
   const envPath = process.env.MAILPOUCH_LOG_FILE;


### PR DESCRIPTION
## Summary

Comprehensive security hardening sweep from the full-codebase audit. Five logical commits, all P1s and most P2/P3 findings.

**Excluded from this PR** (tracked separately):
- P2.1 — host-derived encryption key (needs versioned blob migration; separate work)
- P3.4, P3.7, P3.10, P3.11, P3.14, P3.16, P3.17 — informational or unfixable

## Commits

### C1 — one-line wins
- `npm audit fix` → qs 6.15.0 → 6.15.2 (GHSA-q8mj-m7cp-5q26 DoS)
- Logger regex now redacts `cookie` / `oauth` field families (P2.16)
- `clientIp()` rejects all IPv6 loopback variants except `::ffff:127.0.0.1` — closes XFF spoof on dual-stack hosts (P1.2)
- Escalation audit appends sanitized reason instead of raw input — closes JSONL log injection (P3.6)
- OAuth `state` param length-capped at 500 chars (P3.8)
- Removed "same value as remoteBearerToken" comment from OAuth consent page (P3.13)
- SSE event/id fields strip newlines (P2.11)

### C2 — subprocess hardening
- `pass-cli` env restricted to allowlist (`PATH`/`HOME`/`PROTON_PASS_PAT`/`LANG`/`LC_ALL`) — a compromised CLI binary no longer inherits every parent secret (P1.1)
- `pass-cli` bare name resolved via `which` and validated against trusted PATH prefixes — refuses agent-writable `~/.local/bin` shadows (P2.7)
- Bridge process: track `launchedBridgePid` on spawn; `killProtonBridge()` kills by PID. Drops `pkill -f proton-bridge` which matched the full command line (P1.3)
- Dropped `existsSync(config.bridgePath)` pre-check before spawn — closes TOCTOU window (P1.4)
- `bridgePath` / `passCliPath` POST validation: resolve, must exist, must be a regular file (P2.6)
- `escAppleScript()` strips ASCII control chars 0x00–0x1F + 0x7F (P1.6)
- New `escXml()` HTML-escapes Windows toast XML body content (P1.7)
- `tryGenerateSelfSignedCert()` `rmSync`s the temp directory in `finally{}` — no lingering private key on crash (P2.8)
- New `readPinnedBridgeCert()` hashes the cert on first read and refuses connections if it changes (P2.9)

### C3 — credential lifecycle
- New keychain entries for `remoteBearerToken` + `remoteOauthAdminPassword`; auto-migrated via `migrateFromConfig()` (P2.2)
- `OAuthStore` reverse-index `clientId → tokens`; `revokeTokensForClient()` invalidates outstanding tokens immediately on grant transition (P2.3)
- `IssuedToken` records `issuedFromIp`; `verifyToken()` rejects mismatched-IP requests independent of per-agent ipPins (P1.5)
- `credentialStorage` derived from observed state (presence of `*Encrypted` blobs / plaintext creds) — can't be forged in the config file (P3.12)

### C4 — settings server hardening
- Per-response CSP nonces — dropped `'unsafe-inline'` from `script-src` and `style-src` (P2.10)
- Access token: header-only (`X-Access-Token`), query-string path removed (P2.12)
- HSTS upgraded to `max-age=31536000; includeSubDomains; preload` (P3.15)
- Log file, FTS DB + WAL/SHM/journal siblings enforce mode `0o600` (P3.1, P3.2, P3.3)
- Tool-permissions merge filters against `ALL_TOOLS` (P2.5)
- LAN origin admits IPv6 ULA + link-local (P2.13)
- Grant manager folder-allowlist now fail-closed for folder-scoped tools (P3.19)
- Rate-limit bucket eviction switched to LRU by last-activity — blocks rotate-fake-keys DoS-of-DoS (P2.4)
- `sanitizeData()` recursion capped at depth 100 (P3.5)

### C5 — OAuth polish
- PKCE `code_challenge` enforced 43–128 chars of base64url alphabet (P3.9)
- PKCE `code_verifier` enforced same constraint before SHA256 (P2.15)
- All code-validation failures collapsed to a single opaque `invalid_grant` — no enumeration (P2.14)

## Test plan
- [x] `npm run build` — clean (TS only)
- [x] `npm test` — 1604/1604 pass
- [x] `npm audit` — 0 vulnerabilities
- [ ] Manual: token revocation invalidates outstanding access tokens
- [ ] Manual: settings UI loads (nonce-based CSP, no `'unsafe-inline'`)
- [ ] Manual: settings access via `?token=` returns 401
- [ ] Manual: `/etc/passwd` / `javascript:` URLs rejected on simpleloginBaseUrl
- [ ] Manual: `~/.mailpouch-fts.db` and `~/.mailpouch.log` confirm `0600`

## Security checklist
- [x] No secrets, keys, or credentials committed
- [x] No new attack surface — this PR closes existing ones
- [x] Dependencies — `qs` bumped via npm audit fix; no other dep changes
- [x] No Docker changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)