### PR TITLE
fix(perf): batched IMAP for bulk_mark_read, bulk_star, bulk_move_to_label, bulk_remove_label

### DIFF
--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1802,6 +1802,220 @@ export class SimpleIMAPService {
   }
 
   /**
+   * Bulk-toggle the \Seen flag on many emails using a single IMAP UID STORE
+   * per folder. Mirrors the bulkDeleteEmails / bulkMoveEmails pattern:
+   * group by cached folder, lock once, batch flag-set, fall back to per-UID
+   * on a batch error.
+   */
+  async bulkMarkRead(emailIds: string[], isRead: boolean = true): Promise<{ success: number; failed: number; errors: string[] }> {
+    const tags: SpanTags = { count: emailIds.length, isRead };
+    return tracer.span('imap.bulkMarkRead', tags, async () => {
+    logger.debug('Bulk marking read status', 'IMAPService', { count: emailIds.length, isRead });
+    if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
+
+    const results = { success: 0, failed: 0, errors: [] as string[] };
+    const grouped = new Map<string, string[]>();
+    for (const id of emailIds) {
+      try {
+        this.validateEmailId(id);
+        const folder = this.getCacheEntry(id)?.folder ?? 'INBOX';
+        if (!grouped.has(folder)) grouped.set(folder, []);
+        grouped.get(folder)!.push(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+
+    for (const [folder, ids] of grouped.entries()) {
+      const lock = await this.client.getMailboxLock(folder);
+      try {
+        const uidSet = ids.join(',');
+        try {
+          if (isRead) await this.client.messageFlagsAdd(uidSet, ['\\Seen'], { uid: true });
+          else        await this.client.messageFlagsRemove(uidSet, ['\\Seen'], { uid: true });
+          for (const id of ids) {
+            const c = this.getCacheEntry(id); if (c) c.isRead = isRead;
+            results.success++;
+          }
+        } catch (batchErr: unknown) {
+          logger.warn(`Batch mark-read failed for folder ${folder}, falling back to per-email`, 'IMAPService', batchErr);
+          for (const id of ids) {
+            try {
+              if (isRead) await this.client.messageFlagsAdd(id, ['\\Seen'], { uid: true });
+              else        await this.client.messageFlagsRemove(id, ['\\Seen'], { uid: true });
+              const c = this.getCacheEntry(id); if (c) c.isRead = isRead;
+              results.success++;
+            } catch (e: unknown) {
+              results.failed++;
+              results.errors.push(`Failed to mark ${id}: ${e instanceof Error ? e.message : String(e)}`);
+            }
+          }
+        }
+      } finally { lock.release(); }
+    }
+    tags.successCount = results.success; tags.failCount = results.failed;
+    logger.info(`Bulk mark-read completed: ${results.success}/${results.failed}`, 'IMAPService');
+    return results;
+    }); // end tracer.span('imap.bulkMarkRead')
+  }
+
+  /** Bulk-toggle the \Flagged (starred) flag on many emails. Same shape as bulkMarkRead. */
+  async bulkStar(emailIds: string[], isStarred: boolean = true): Promise<{ success: number; failed: number; errors: string[] }> {
+    const tags: SpanTags = { count: emailIds.length, isStarred };
+    return tracer.span('imap.bulkStar', tags, async () => {
+    logger.debug('Bulk starring', 'IMAPService', { count: emailIds.length, isStarred });
+    if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
+
+    const results = { success: 0, failed: 0, errors: [] as string[] };
+    const grouped = new Map<string, string[]>();
+    for (const id of emailIds) {
+      try {
+        this.validateEmailId(id);
+        const folder = this.getCacheEntry(id)?.folder ?? 'INBOX';
+        if (!grouped.has(folder)) grouped.set(folder, []);
+        grouped.get(folder)!.push(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+
+    for (const [folder, ids] of grouped.entries()) {
+      const lock = await this.client.getMailboxLock(folder);
+      try {
+        const uidSet = ids.join(',');
+        try {
+          if (isStarred) await this.client.messageFlagsAdd(uidSet, ['\\Flagged'], { uid: true });
+          else           await this.client.messageFlagsRemove(uidSet, ['\\Flagged'], { uid: true });
+          for (const id of ids) {
+            const c = this.getCacheEntry(id); if (c) c.isStarred = isStarred;
+            results.success++;
+          }
+        } catch (batchErr: unknown) {
+          logger.warn(`Batch star failed for folder ${folder}, falling back to per-email`, 'IMAPService', batchErr);
+          for (const id of ids) {
+            try {
+              if (isStarred) await this.client.messageFlagsAdd(id, ['\\Flagged'], { uid: true });
+              else           await this.client.messageFlagsRemove(id, ['\\Flagged'], { uid: true });
+              const c = this.getCacheEntry(id); if (c) c.isStarred = isStarred;
+              results.success++;
+            } catch (e: unknown) {
+              results.failed++;
+              results.errors.push(`Failed to star ${id}: ${e instanceof Error ? e.message : String(e)}`);
+            }
+          }
+        }
+      } finally { lock.release(); }
+    }
+    tags.successCount = results.success; tags.failCount = results.failed;
+    logger.info(`Bulk star completed: ${results.success}/${results.failed}`, 'IMAPService');
+    return results;
+    }); // end tracer.span('imap.bulkStar')
+  }
+
+  /** Copy many emails into `targetFolder` in a single IMAP UID COPY per source folder.
+   *  Used by bulk_move_to_label (the target is the Labels/<name> pseudo-folder). */
+  async bulkCopyToFolder(emailIds: string[], targetFolder: string): Promise<{ success: number; failed: number; errors: string[] }> {
+    this.validateFolderName(targetFolder);
+    const tags: SpanTags = { count: emailIds.length, targetFolder };
+    return tracer.span('imap.bulkCopyToFolder', tags, async () => {
+    logger.debug('Bulk copy to folder', 'IMAPService', { count: emailIds.length, targetFolder });
+    if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
+
+    const results = { success: 0, failed: 0, errors: [] as string[] };
+    const grouped = new Map<string, string[]>();
+    for (const id of emailIds) {
+      try {
+        this.validateEmailId(id);
+        const folder = this.getCacheEntry(id)?.folder ?? 'INBOX';
+        if (!grouped.has(folder)) grouped.set(folder, []);
+        grouped.get(folder)!.push(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+
+    for (const [folder, ids] of grouped.entries()) {
+      const lock = await this.client.getMailboxLock(folder);
+      try {
+        const uidSet = ids.join(',');
+        try {
+          await this.client.messageCopy(uidSet, targetFolder, { uid: true });
+          results.success += ids.length;
+        } catch (batchErr: unknown) {
+          logger.warn(`Batch copy failed from ${folder}→${targetFolder}, falling back to per-email`, 'IMAPService', batchErr);
+          for (const id of ids) {
+            try {
+              await this.client.messageCopy(id, targetFolder, { uid: true });
+              results.success++;
+            } catch (e: unknown) {
+              results.failed++;
+              results.errors.push(`Failed to copy ${id} to ${targetFolder}: ${e instanceof Error ? e.message : String(e)}`);
+            }
+          }
+        }
+      } finally { lock.release(); }
+    }
+    tags.successCount = results.success; tags.failCount = results.failed;
+    logger.info(`Bulk copy completed: ${results.success}/${results.failed}`, 'IMAPService');
+    return results;
+    }); // end tracer.span('imap.bulkCopyToFolder')
+  }
+
+  /** Delete many emails from a SPECIFIC folder (label removal). Unlike
+   *  bulkDeleteEmails this targets a single folder rather than the
+   *  cached/INBOX-fallback folder per UID. UIDs are folder-scoped, so the
+   *  caller must pass UIDs known to live in `folder`. */
+  async bulkDeleteFromFolder(emailIds: string[], folder: string): Promise<{ success: number; failed: number; errors: string[] }> {
+    this.validateFolderName(folder);
+    const tags: SpanTags = { count: emailIds.length, folder };
+    return tracer.span('imap.bulkDeleteFromFolder', tags, async () => {
+    logger.debug('Bulk delete from folder', 'IMAPService', { count: emailIds.length, folder });
+    if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
+
+    const results = { success: 0, failed: 0, errors: [] as string[] };
+    const validIds: string[] = [];
+    for (const id of emailIds) {
+      try {
+        this.validateEmailId(id);
+        validIds.push(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+    if (validIds.length === 0) return results;
+
+    const lock = await this.client.getMailboxLock(folder);
+    try {
+      const uidSet = validIds.join(',');
+      try {
+        await this.client.messageDelete(uidSet, { uid: true });
+        for (const id of validIds) { this.evictCacheEntry(id); results.success++; }
+      } catch (batchErr: unknown) {
+        logger.warn(`Batch delete-from-folder failed for ${folder}, falling back to per-email`, 'IMAPService', batchErr);
+        for (const id of validIds) {
+          try {
+            await this.client.messageDelete(id, { uid: true });
+            this.evictCacheEntry(id);
+            results.success++;
+          } catch (e: unknown) {
+            results.failed++;
+            results.errors.push(`Failed to delete ${id} from ${folder}: ${e instanceof Error ? e.message : String(e)}`);
+          }
+        }
+      }
+    } finally { lock.release(); }
+
+    tags.successCount = results.success; tags.failCount = results.failed;
+    logger.info(`Bulk delete-from-folder completed: ${results.success}/${results.failed}`, 'IMAPService');
+    return results;
+    }); // end tracer.span('imap.bulkDeleteFromFolder')
+  }
+
+  /**
    * Create a new folder
    */
   async createFolder(folderName: string): Promise<boolean> {

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -335,60 +335,42 @@ export const handlers: Record<string, ToolHandler> = {
   },
 
   bulk_mark_read: async (ctx) => {
-    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, safeErrorMessage } = ctx;
+    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS } = ctx;
     if (!Array.isArray(args.emailIds) || (args.emailIds as unknown[]).length === 0) {
       throw new McpError(ErrorCode.InvalidParams, "emailIds must be a non-empty array of numeric UID strings.");
     }
-    const bmrIds = args.emailIds as unknown[];
-    const bmrEmailIds: string[] = bmrIds
+    const bmrEmailIds: string[] = (args.emailIds as unknown[])
       .filter((id): id is string => typeof id === "string" && /^\d+$/.test(id))
       .slice(0, MAX_BULK_IDS);
+    if (bmrEmailIds.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "No valid numeric email IDs in the provided list.");
+    }
     if (args.isRead !== undefined && typeof args.isRead !== "boolean") {
       throw new McpError(ErrorCode.InvalidParams, "'isRead' must be a boolean when provided.");
     }
     const bmrIsRead = args.isRead !== undefined ? (args.isRead as boolean) : true;
-    const bmrTotal = bmrEmailIds.length;
-    const bmrResults = { success: 0, failed: 0, errors: [] as string[] };
-
-    for (let i = 0; i < bmrEmailIds.length; i++) {
-      try {
-        await imapService.markEmailRead(bmrEmailIds[i], bmrIsRead);
-        bmrResults.success++;
-      } catch (e: unknown) {
-        bmrResults.failed++;
-        bmrResults.errors.push(`${bmrEmailIds[i]}: ${safeErrorMessage(e)}`);
-      }
-      await sendProgress(i + 1, bmrTotal, `Marked ${i + 1} of ${bmrTotal}`);
-    }
+    const bmrResults = await imapService.bulkMarkRead(bmrEmailIds, bmrIsRead);
+    await sendProgress(bmrEmailIds.length, bmrEmailIds.length, `Marked ${bmrResults.success} of ${bmrEmailIds.length} (${bmrResults.failed} failed)`);
     return bulkOk(bmrResults);
   },
 
   bulk_star: async (ctx) => {
-    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, safeErrorMessage } = ctx;
+    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS } = ctx;
     if (!Array.isArray(args.emailIds) || (args.emailIds as unknown[]).length === 0) {
       throw new McpError(ErrorCode.InvalidParams, "emailIds must be a non-empty array of numeric UID strings.");
     }
-    const bsIds = args.emailIds as unknown[];
-    const bsEmailIds: string[] = bsIds
+    const bsEmailIds: string[] = (args.emailIds as unknown[])
       .filter((id): id is string => typeof id === "string" && /^\d+$/.test(id))
       .slice(0, MAX_BULK_IDS);
+    if (bsEmailIds.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "No valid numeric email IDs in the provided list.");
+    }
     if (args.isStarred !== undefined && typeof args.isStarred !== "boolean") {
       throw new McpError(ErrorCode.InvalidParams, "'isStarred' must be a boolean when provided.");
     }
     const bsIsStarred = args.isStarred !== undefined ? (args.isStarred as boolean) : true;
-    const bsTotal = bsEmailIds.length;
-    const bsResults = { success: 0, failed: 0, errors: [] as string[] };
-
-    for (let i = 0; i < bsEmailIds.length; i++) {
-      try {
-        await imapService.starEmail(bsEmailIds[i], bsIsStarred);
-        bsResults.success++;
-      } catch (e: unknown) {
-        bsResults.failed++;
-        bsResults.errors.push(`${bsEmailIds[i]}: ${safeErrorMessage(e)}`);
-      }
-      await sendProgress(i + 1, bsTotal, `Starred ${i + 1} of ${bsTotal}`);
-    }
+    const bsResults = await imapService.bulkStar(bsEmailIds, bsIsStarred);
+    await sendProgress(bsEmailIds.length, bsEmailIds.length, `Starred ${bsResults.success} of ${bsEmailIds.length} (${bsResults.failed} failed)`);
     return bulkOk(bsResults);
   },
 
@@ -429,14 +411,16 @@ export const handlers: Record<string, ToolHandler> = {
   },
 
   bulk_move_to_label: async (ctx) => {
-    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, safeErrorMessage, state } = ctx;
+    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, state } = ctx;
     if (!Array.isArray(args.emailIds) || (args.emailIds as unknown[]).length === 0) {
       throw new McpError(ErrorCode.InvalidParams, "emailIds must be a non-empty array of numeric UID strings.");
     }
-    const rawIds2 = args.emailIds as unknown[];
-    const emailIds2: string[] = rawIds2
+    const emailIds2: string[] = (args.emailIds as unknown[])
       .filter((id): id is string => typeof id === "string" && /^\d+$/.test(id))
       .slice(0, MAX_BULK_IDS);
+    if (emailIds2.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "No valid numeric email IDs in the provided list.");
+    }
     if (!args.label || typeof args.label !== "string") {
       throw new McpError(ErrorCode.InvalidParams, "'label' is required and must be a string.");
     }
@@ -444,20 +428,9 @@ export const handlers: Record<string, ToolHandler> = {
     const bmlValidErr = validateLabelName(rawLabel);
     if (bmlValidErr) throw new McpError(ErrorCode.InvalidParams, bmlValidErr);
     const labelFolder = `Labels/${rawLabel}`;
-    const total2 = emailIds2.length;
-    const results2 = { success: 0, failed: 0, errors: [] as string[] };
 
-    for (let i = 0; i < emailIds2.length; i++) {
-      try {
-        await imapService.copyEmailToFolder(emailIds2[i], labelFolder);
-        results2.success++;
-      } catch (e: unknown) {
-        results2.failed++;
-        results2.errors.push(`${emailIds2[i]}: ${safeErrorMessage(e)}`);
-      }
-      await sendProgress(i + 1, total2, `Labeled ${i + 1} of ${total2}`);
-    }
-
+    const results2 = await imapService.bulkCopyToFolder(emailIds2, labelFolder);
+    await sendProgress(emailIds2.length, emailIds2.length, `Labeled ${results2.success} of ${emailIds2.length} (${results2.failed} failed)`);
     state.analyticsCache = null;
     state.analyticsCacheInflight = null;
     return bulkOk(results2);
@@ -477,14 +450,16 @@ export const handlers: Record<string, ToolHandler> = {
   },
 
   bulk_remove_label: async (ctx) => {
-    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, safeErrorMessage, state } = ctx;
+    const { args, imapService, bulkOk, sendProgress, MAX_BULK_IDS, state } = ctx;
     if (!Array.isArray(args.emailIds) || (args.emailIds as unknown[]).length === 0) {
       throw new McpError(ErrorCode.InvalidParams, "emailIds must be a non-empty array of numeric UID strings.");
     }
-    const brlIds = args.emailIds as unknown[];
-    const brlEmailIds: string[] = brlIds
+    const brlEmailIds: string[] = (args.emailIds as unknown[])
       .filter((id): id is string => typeof id === "string" && /^\d+$/.test(id))
       .slice(0, MAX_BULK_IDS);
+    if (brlEmailIds.length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "No valid numeric email IDs in the provided list.");
+    }
     if (!args.label || typeof args.label !== "string") {
       throw new McpError(ErrorCode.InvalidParams, "'label' is required and must be a string.");
     }
@@ -492,20 +467,9 @@ export const handlers: Record<string, ToolHandler> = {
     const brlLabelValidErr = validateLabelName(brlLabel);
     if (brlLabelValidErr) throw new McpError(ErrorCode.InvalidParams, brlLabelValidErr);
     const brlLabelFolder = `Labels/${brlLabel}`;
-    const brlTotal = brlEmailIds.length;
-    const brlResults = { success: 0, failed: 0, errors: [] as string[] };
 
-    for (let i = 0; i < brlEmailIds.length; i++) {
-      try {
-        await imapService.deleteFromFolder(brlEmailIds[i], brlLabelFolder);
-        brlResults.success++;
-      } catch (e: unknown) {
-        brlResults.failed++;
-        brlResults.errors.push(`${brlEmailIds[i]}: ${safeErrorMessage(e)}`);
-      }
-      await sendProgress(i + 1, brlTotal, `Unlabeled ${i + 1} of ${brlTotal}`);
-    }
-
+    const brlResults = await imapService.bulkDeleteFromFolder(brlEmailIds, brlLabelFolder);
+    await sendProgress(brlEmailIds.length, brlEmailIds.length, `Unlabeled ${brlResults.success} of ${brlEmailIds.length} (${brlResults.failed} failed)`);
     state.analyticsCache = null;
     state.analyticsCacheInflight = null;
     return bulkOk(brlResults);


### PR DESCRIPTION
## Summary

Closes the same class of bug as #120 for the four bulk handlers that were left as follow-up because no batch ImapService method existed yet. After this PR, every `bulk_*` MCP tool uses a single batched IMAP command per folder rather than N sequential round-trips.

## What's new on `ImapService`

| Method | IMAP command |
|---|---|
| `bulkMarkRead(ids, isRead)` | `UID STORE +/-FLAGS (\\Seen)` |
| `bulkStar(ids, isStarred)` | `UID STORE +/-FLAGS (\\Flagged)` |
| `bulkCopyToFolder(ids, folder)` | `UID COPY` per source folder |
| `bulkDeleteFromFolder(ids, folder)` | `UID STORE +FLAGS (\\Deleted)` scoped to one folder |

All four mirror the existing `bulkDeleteEmails` / `bulkMoveEmails` shape: returns `{success, failed, errors[]}`, runs inside a tracer span, falls back to per-UID commands on batch error.

## Tool handlers rewired

- `bulk_mark_read`     → `bulkMarkRead`
- `bulk_star`          → `bulkStar`
- `bulk_move_to_label` → `bulkCopyToFolder(ids, \`Labels/${name}\`)`
- `bulk_remove_label`  → `bulkDeleteFromFolder(ids, \`Labels/${name}\`)`

Each handler also picks up the post-filter empty-input guard that PR #126 added to the other two bulk handlers.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 1606/1606 pass
- [x] `grep "for (let i = 0; i < .*emailIds"` across `src/tools/` returns no matches
- [ ] Manual: `bulk_mark_read` on 100 emails completes in <2 s instead of ~30 min
- [ ] Manual: partial failure (e.g. one UID in a different folder) still increments `failed` count and surfaces in `errors[]`

## Security checklist
- [x] No secrets, keys, or credentials committed
- [x] No new attack surface — same validation as the single-email path; UIDs still validated, folder names still passed through `validateFolderName`
- [x] Dependencies unchanged
- [x] No Docker changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)