### PR TITLE
fix(imap): finish 3.0.41 fix in sibling paths (v3.0.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.44] — 2026-05-28
+
+### Fixed
+- **`bulkMarkRead` / `bulkStar` / `bulkCopyToFolder` defaulted to INBOX on cache miss** (IMAP-003 from the 2026-05-28 audit) — the three sibling bulk methods missed by the v3.0.41 fix. When `sourceFolder` was absent and the UID wasn't cached, they silently grouped the UID under `'INBOX'`, recreating the false-success class for these three operations. They now mirror the `bulkMoveEmails` pattern: cache lookup, then `getEmailById()` discovery, then explicit failure if still not found.
+- **`findExistingUidsInLockedFolder` silently lied about UID absence on transport errors** (IMAP-006). The pre-flight FETCH used to `catch (e) { logger.warn(...); return new Set(); }`, which collapsed network/BAD/command-too-long errors into "UIDs not found" — a flat-out misrepresentation. It now rethrows; every bulk caller wraps the call in its own catch that surfaces `UID X existence check failed in folder Y: <reason>` so callers can distinguish "definitely absent" from "couldn't verify."
+- **`setFlag` was missed by the v3.0.41 fix entirely** (IMAP-008, IMAP-009). Now (a) accepts an optional `sourceFolder` parameter, locking it directly and skipping the all-folders scan; (b) runs the same pre-flight `findExistingUidsInLockedFolder` UID check as every other mutator, so silent IMAP STORE no-ops on missing UIDs surface as honest errors.
+- **`getEmailById` accepted unvalidated `folderHint`** (VALID-001). Six reading/sending tool handlers (`get_email_by_id`, `get_thread`, `extract_action_items`, `extract_meeting`, `reply_to_email`, `forward_email`) forwarded `args.folder` raw via `as string | undefined`. The service now calls `validateFolderName(folderHint)` defensively, and the tool handlers route the arg through a new `optionalFolderHint()` helper in `src/utils/helpers.ts` that produces a clean `McpError(InvalidParams, …)` before the IMAP wire. Also closes the related VALID-009 sibling at the tool layer.
+- 9 new regression tests added in `src/services/imap-operations.test.ts` covering each bullet above. Unit suite: 1631 passes. E2E Greenmail (CI mode) green.
+
 ## [3.0.43] — 2026-05-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.43-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.44-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.43",
+  "version": "3.0.44",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -386,7 +386,10 @@ describe("SimpleIMAPService.setFlag", () => {
       messageFlagsAdd: vi.fn().mockResolvedValue(undefined),
       messageFlagsRemove: vi.fn().mockResolvedValue(undefined),
       // fetch returns an async generator yielding a message with matching UID
-      fetch: vi.fn().mockReturnValue(asyncMessages([{ uid: 77 }])),
+      // mockImplementation (not mockReturnValue) so each fetch() call gets
+      // a fresh iterator — setFlag now calls fetch twice (folder scan +
+      // pre-flight UID existence check).
+      fetch: vi.fn().mockImplementation(() => asyncMessages([{ uid: 77 }])),
     };
     (svc as any).isConnected = true;
     (svc as any).client = client;
@@ -1728,5 +1731,136 @@ describe("UID existence pre-flight: missing UIDs count as failed, not silent suc
 
     await expect(svc.markEmailRead("999", true, "Folders/BulkTestMove"))
       .rejects.toThrow(/999 not found in folder Folders\/BulkTestMove/);
+  });
+});
+
+// ─── Batch 2 (v3.0.44): finish the v3.0.41 fix in sibling paths ──────────────
+
+describe("v3.0.44 sibling-path fixes (IMAP-003 / IMAP-006 / IMAP-008 / IMAP-009)", () => {
+  // IMAP-003: bulkMarkRead/bulkStar/bulkCopyToFolder used to default to INBOX
+  // when sourceFolder absent and cache missed. Now discover folder via
+  // getEmailById, then explicit failure if still not found.
+
+  it("bulkMarkRead without sourceFolder discovers folder via getEmailById (not INBOX default)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    // Cache MISS — must call getEmailById to discover
+    vi.spyOn(svc, "getEmailById").mockResolvedValue(makeEmail("42", "Folders/Work"));
+
+    const results = await svc.bulkMarkRead(["42"], true);
+
+    expect(results.success).toBe(1);
+    expect(client.getMailboxLock).toHaveBeenCalledWith("Folders/Work");
+    expect(client.getMailboxLock).not.toHaveBeenCalledWith("INBOX");
+  });
+
+  it("bulkMarkRead reports failed when getEmailById returns null (instead of defaulting to INBOX)", async () => {
+    const svc = new SimpleIMAPService();
+    connectSvc(svc);
+    vi.spyOn(svc, "getEmailById").mockResolvedValue(null);
+
+    const results = await svc.bulkMarkRead(["99"], true);
+
+    expect(results.success).toBe(0);
+    expect(results.failed).toBe(1);
+    expect(results.errors[0]).toMatch(/Email 99 not found in any folder/);
+  });
+
+  it("bulkStar without sourceFolder discovers folder via getEmailById", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    vi.spyOn(svc, "getEmailById").mockResolvedValue(makeEmail("7", "Labels/Priority"));
+
+    const results = await svc.bulkStar(["7"], true);
+
+    expect(results.success).toBe(1);
+    expect(client.getMailboxLock).toHaveBeenCalledWith("Labels/Priority");
+  });
+
+  it("bulkCopyToFolder without sourceFolder discovers folder via getEmailById", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    vi.spyOn(svc, "getEmailById").mockResolvedValue(makeEmail("12", "Folders/X"));
+
+    const results = await svc.bulkCopyToFolder(["12"], "Labels/Y");
+
+    expect(results.success).toBe(1);
+    expect(client.getMailboxLock).toHaveBeenCalledWith("Folders/X");
+    expect(client.messageCopy).toHaveBeenCalledWith("12", "Labels/Y", { uid: true });
+  });
+
+  // IMAP-006: findExistingUidsInLockedFolder used to catch all errors and
+  // return empty Set → all UIDs reported as "not found" (silent corruption
+  // of success/failed counters). Now rethrows; bulk callers surface a
+  // distinct "existence check failed" message.
+
+  it("bulkMarkRead surfaces 'existence check failed' on transport error (IMAP-006)", async () => {
+    const svc = new SimpleIMAPService();
+    connectSvc(svc, {
+      fetch: vi.fn().mockImplementation(() => {
+        // First call: pre-flight UID FETCH throws
+        throw new Error("connection reset");
+      }),
+    });
+
+    const results = await svc.bulkMarkRead(["1", "2"], true, "INBOX");
+
+    expect(results.success).toBe(0);
+    expect(results.failed).toBe(2);
+    for (const err of results.errors) {
+      expect(err).toMatch(/existence check failed/);
+      expect(err).toMatch(/connection reset/);
+    }
+  });
+
+  it("bulkDeleteFromFolder surfaces 'existence check failed' on transport error", async () => {
+    const svc = new SimpleIMAPService();
+    connectSvc(svc, {
+      fetch: vi.fn().mockImplementation(() => { throw new Error("BAD command line too long"); }),
+    });
+
+    const results = await svc.bulkDeleteFromFolder(["10", "11"], "Labels/Foo");
+
+    expect(results.success).toBe(0);
+    expect(results.failed).toBe(2);
+    expect(results.errors[0]).toMatch(/existence check failed.*BAD command line too long/);
+  });
+
+  // IMAP-008: setFlag now does pre-flight UID FETCH inside the lock.
+
+  it("setFlag throws when UID is not present in the resolved folder (IMAP-008)", async () => {
+    const svc = new SimpleIMAPService();
+    // Inline empty-fetch mock (fetchYielding from sister describe block isn't in scope here).
+    connectSvc(svc, {
+      fetch: vi.fn().mockImplementation(() => (async function* () { /* no UIDs */ })()),
+    });
+
+    await expect(svc.setFlag("999", "\\Answered", true, "Folders/Work"))
+      .rejects.toThrow(/999 not found in folder Folders\/Work/);
+  });
+
+  // IMAP-009: setFlag now accepts sourceFolder, locking it directly.
+
+  it("setFlag with sourceFolder locks the specified folder and skips the scan (IMAP-009)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    const getEmailByIdSpy = vi.spyOn(svc, "getEmailById");
+
+    const result = await svc.setFlag("5", "\\Flagged", true, "Folders/Priority");
+
+    expect(result).toBe(true);
+    expect(client.getMailboxLock).toHaveBeenCalledWith("Folders/Priority");
+    expect(getEmailByIdSpy).not.toHaveBeenCalled();
+    expect(client.messageFlagsAdd).toHaveBeenCalledWith("5", ["\\Flagged"], { uid: true });
+  });
+
+  // VALID-001: getEmailById rejects CRLF/control-char folder hints.
+
+  it("getEmailById rejects folderHint containing CRLF (VALID-001)", async () => {
+    const svc = new SimpleIMAPService();
+    connectSvc(svc);
+
+    await expect(svc.getEmailById("1", "INBOX\r\nLOGOUT" as string))
+      .rejects.toThrow();
   });
 });

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1786,7 +1786,19 @@ export class SimpleIMAPService {
                 if (msg.uid.toString() === emailId) { found = true; break; }
               }
               if (found) { folder = f.path; break; }
-            } catch { /* not in this folder */ } finally {
+            } catch (scanErr: unknown) {
+              // We can't reliably distinguish "UID not present in this folder"
+              // from a transport error here — imapflow surfaces both as throws
+              // depending on the server. Log at warn level so silent transport
+              // failures aren't invisible, then continue to the next folder.
+              // Callers that need certainty should pass `sourceFolder` and
+              // bypass this scan entirely.
+              logger.warn(
+                `setFlag folder-scan: fetch on ${f.path} for UID ${emailId} threw — ` +
+                `treating as "not in this folder": ${scanErr instanceof Error ? scanErr.message : String(scanErr)}`,
+                'IMAPService'
+              );
+            } finally {
               lock.release();
             }
           }

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -294,22 +294,20 @@ export class SimpleIMAPService {
    * the folder. UIDs not returned by the server are absent from the folder —
    * mutations against them would be silent no-ops, so callers should treat
    * them as failed rather than reporting false success.
+   *
+   * Throws on transport errors (network reset, BAD response, command-too-long).
+   * Bulk callers must distinguish "UID not in folder" from "I couldn't even
+   * check" — collapsing both into `failed` lies to the caller and recreates
+   * the v3.0.41 false-success pattern (IMAP-006 from the 2026-05-28 audit).
    */
   private async findExistingUidsInLockedFolder(uids: string[]): Promise<Set<string>> {
     const found = new Set<string>();
     if (!this.client || uids.length === 0) return found;
     const uidSet = uids.join(',');
-    try {
-      for await (const msg of this.client.fetch(uidSet, { uid: true }, { uid: true })) {
-        if (msg && typeof msg.uid === 'number') {
-          found.add(msg.uid.toString());
-        }
+    for await (const msg of this.client.fetch(uidSet, { uid: true }, { uid: true })) {
+      if (msg && typeof msg.uid === 'number') {
+        found.add(msg.uid.toString());
       }
-    } catch (e: unknown) {
-      logger.warn(
-        `UID existence check failed: ${e instanceof Error ? e.message : String(e)}`,
-        'IMAPService'
-      );
     }
     return found;
   }
@@ -826,6 +824,11 @@ export class SimpleIMAPService {
    */
   async getEmailById(emailId: string, folderHint?: string): Promise<EmailMessage | null> {
     this.validateEmailId(emailId);
+    // VALID-001 from the 2026-05-28 audit: callers (six tool handlers)
+    // forward args.folder raw via `as string | undefined`. Validate here so
+    // a CRLF/path-traversal/quote-injected folder name can't reach
+    // getMailboxLock.
+    if (folderHint !== undefined) this.validateFolderName(folderHint);
     const tags: SpanTags = { emailId };
     return tracer.span('imap.getEmailById', tags, async () => {
     logger.debug('Fetching email by ID', 'IMAPService', { emailId, folderHint });
@@ -1747,12 +1750,18 @@ export class SimpleIMAPService {
    * @param emailId Numeric UID string of the email
    * @param flag The IMAP flag to set/clear (e.g. '\\Answered', '$Forwarded')
    * @param set true to add the flag, false to remove it (default: true)
-   * @returns true on success, false/throws on failure
+   * @param sourceFolder Folder containing the UID. Strongly recommended
+   *   whenever the UID came from a folder other than INBOX — IMAP UIDs are
+   *   folder-scoped, and without this the all-folders scan can pick a
+   *   colliding UID in the wrong mailbox (IMAP-009 from the 2026-05-28 audit).
+   * @returns true on success. Throws if the UID does not exist in the
+   *   resolved source folder (IMAP-008 from the 2026-05-28 audit).
    */
-  async setFlag(emailId: string, flag: string, set: boolean = true): Promise<boolean> {
+  async setFlag(emailId: string, flag: string, set: boolean = true, sourceFolder?: string): Promise<boolean> {
     this.validateEmailId(emailId);
-    return tracer.span('imap.setFlag', { emailId, flag, set }, async () => {
-    logger.debug('Setting flag on email', 'IMAPService', { emailId, flag, set });
+    if (sourceFolder !== undefined) this.validateFolderName(sourceFolder);
+    return tracer.span('imap.setFlag', { emailId, flag, set, sourceFolder }, async () => {
+    logger.debug('Setting flag on email', 'IMAPService', { emailId, flag, set, sourceFolder });
 
     if (!this.client || !this.isConnected) {
       logger.warn('IMAP not connected', 'IMAPService');
@@ -1760,23 +1769,26 @@ export class SimpleIMAPService {
     }
 
     try {
-      // Find folder from cache first, then scan
       let folder: string | undefined;
-      const cached = this.findCacheEntryByUid(emailId);
-      if (cached) {
-        folder = cached.folder;
+      if (sourceFolder) {
+        folder = sourceFolder;
       } else {
-        const folders = await this.getFolders();
-        for (const f of folders) {
-          const lock = await this.client.getMailboxLock(f.path);
-          try {
-            let found = false;
-            for await (const msg of this.client.fetch(emailId, { uid: true }, { uid: true })) {
-              if (msg.uid.toString() === emailId) { found = true; break; }
+        const cached = this.findCacheEntryByUid(emailId);
+        if (cached) {
+          folder = cached.folder;
+        } else {
+          const folders = await this.getFolders();
+          for (const f of folders) {
+            const lock = await this.client.getMailboxLock(f.path);
+            try {
+              let found = false;
+              for await (const msg of this.client.fetch(emailId, { uid: true }, { uid: true })) {
+                if (msg.uid.toString() === emailId) { found = true; break; }
+              }
+              if (found) { folder = f.path; break; }
+            } catch { /* not in this folder */ } finally {
+              lock.release();
             }
-            if (found) { folder = f.path; break; }
-          } catch { /* not in this folder */ } finally {
-            lock.release();
           }
         }
       }
@@ -1787,12 +1799,16 @@ export class SimpleIMAPService {
 
       const lock = await this.client.getMailboxLock(folder);
       try {
+        const existing = await this.findExistingUidsInLockedFolder([emailId]);
+        if (!existing.has(emailId)) {
+          throw new Error(`Email ${emailId} not found in folder ${folder}`);
+        }
         if (set) {
           await this.client.messageFlagsAdd(emailId, [flag], { uid: true });
         } else {
           await this.client.messageFlagsRemove(emailId, [flag], { uid: true });
         }
-        logger.info(`Flag ${flag} ${set ? 'set' : 'cleared'} on email ${emailId}`, 'IMAPService');
+        logger.info(`Flag ${flag} ${set ? 'set' : 'cleared'} on email ${emailId} in ${folder}`, 'IMAPService');
         return true;
       } finally {
         lock.release();
@@ -1877,7 +1893,21 @@ export class SimpleIMAPService {
     for (const [folder, ids] of emailsByFolder.entries()) {
       const lock = await this.client.getMailboxLock(folder);
       try {
-        const existing = await this.findExistingUidsInLockedFolder(ids);
+        let existing: Set<string>;
+        try {
+          existing = await this.findExistingUidsInLockedFolder(ids);
+        } catch (e: unknown) {
+          // IMAP-006: transport error during pre-flight. Surface the real
+          // failure mode rather than collapsing into "UIDs not found" — the
+          // caller needs to distinguish "definitely absent" from "couldn't
+          // verify" so a retry is meaningful.
+          const msg = e instanceof Error ? e.message : String(e);
+          for (const id of ids) {
+            results.failed++;
+            results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+          }
+          continue;
+        }
         const present: string[] = [];
         for (const id of ids) {
           if (existing.has(id)) {
@@ -2037,7 +2067,21 @@ export class SimpleIMAPService {
     for (const [folder, ids] of emailsByFolder2.entries()) {
       const lock = await this.client.getMailboxLock(folder);
       try {
-        const existing = await this.findExistingUidsInLockedFolder(ids);
+        let existing: Set<string>;
+        try {
+          existing = await this.findExistingUidsInLockedFolder(ids);
+        } catch (e: unknown) {
+          // IMAP-006: transport error during pre-flight. Surface the real
+          // failure mode rather than collapsing into "UIDs not found" — the
+          // caller needs to distinguish "definitely absent" from "couldn't
+          // verify" so a retry is meaningful.
+          const msg = e instanceof Error ? e.message : String(e);
+          for (const id of ids) {
+            results.failed++;
+            results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+          }
+          continue;
+        }
         const present: string[] = [];
         for (const id of ids) {
           if (existing.has(id)) {
@@ -2110,12 +2154,27 @@ export class SimpleIMAPService {
       }
       if (validIds.length > 0) grouped.set(sourceFolder, validIds);
     } else {
+      // No explicit sourceFolder — discover per UID. IMAP-003 from the
+      // 2026-05-28 audit: this used to fall back to 'INBOX' on cache miss,
+      // recreating the v3.0.41 false-success class. Now mirrors the
+      // bulkMoveEmails pattern: cache lookup, then full discovery via
+      // getEmailById, then explicit failure if still not found.
       for (const id of emailIds) {
         try {
           this.validateEmailId(id);
           const cached = this.findCacheEntryByUid(id);
-          const folder = cached?.folder ?? 'INBOX';
-          if (!cached) logger.warn(`bulkMarkRead: UID ${id} not in cache, assuming INBOX`, 'IMAPService');
+          let folder: string;
+          if (cached) {
+            folder = cached.folder;
+          } else {
+            const discovered = await this.getEmailById(id);
+            if (!discovered) {
+              results.failed++;
+              results.errors.push(`Email ${id} not found in any folder`);
+              continue;
+            }
+            folder = discovered.folder;
+          }
           if (!grouped.has(folder)) grouped.set(folder, []);
           grouped.get(folder)!.push(id);
         } catch (e: unknown) {
@@ -2128,7 +2187,21 @@ export class SimpleIMAPService {
     for (const [folder, ids] of grouped.entries()) {
       const lock = await this.client.getMailboxLock(folder);
       try {
-        const existing = await this.findExistingUidsInLockedFolder(ids);
+        let existing: Set<string>;
+        try {
+          existing = await this.findExistingUidsInLockedFolder(ids);
+        } catch (e: unknown) {
+          // IMAP-006: transport error during pre-flight. Surface the real
+          // failure mode rather than collapsing into "UIDs not found" — the
+          // caller needs to distinguish "definitely absent" from "couldn't
+          // verify" so a retry is meaningful.
+          const msg = e instanceof Error ? e.message : String(e);
+          for (const id of ids) {
+            results.failed++;
+            results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+          }
+          continue;
+        }
         const present: string[] = [];
         for (const id of ids) {
           if (existing.has(id)) {
@@ -2193,12 +2266,23 @@ export class SimpleIMAPService {
       }
       if (validIds.length > 0) grouped.set(sourceFolder, validIds);
     } else {
+      // No sourceFolder — discover per UID (IMAP-003 from 2026-05-28 audit).
       for (const id of emailIds) {
         try {
           this.validateEmailId(id);
           const cached = this.findCacheEntryByUid(id);
-          const folder = cached?.folder ?? 'INBOX';
-          if (!cached) logger.warn(`bulkStar: UID ${id} not in cache, assuming INBOX`, 'IMAPService');
+          let folder: string;
+          if (cached) {
+            folder = cached.folder;
+          } else {
+            const discovered = await this.getEmailById(id);
+            if (!discovered) {
+              results.failed++;
+              results.errors.push(`Email ${id} not found in any folder`);
+              continue;
+            }
+            folder = discovered.folder;
+          }
           if (!grouped.has(folder)) grouped.set(folder, []);
           grouped.get(folder)!.push(id);
         } catch (e: unknown) {
@@ -2211,7 +2295,21 @@ export class SimpleIMAPService {
     for (const [folder, ids] of grouped.entries()) {
       const lock = await this.client.getMailboxLock(folder);
       try {
-        const existing = await this.findExistingUidsInLockedFolder(ids);
+        let existing: Set<string>;
+        try {
+          existing = await this.findExistingUidsInLockedFolder(ids);
+        } catch (e: unknown) {
+          // IMAP-006: transport error during pre-flight. Surface the real
+          // failure mode rather than collapsing into "UIDs not found" — the
+          // caller needs to distinguish "definitely absent" from "couldn't
+          // verify" so a retry is meaningful.
+          const msg = e instanceof Error ? e.message : String(e);
+          for (const id of ids) {
+            results.failed++;
+            results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+          }
+          continue;
+        }
         const present: string[] = [];
         for (const id of ids) {
           if (existing.has(id)) {
@@ -2278,12 +2376,23 @@ export class SimpleIMAPService {
       }
       if (validIds.length > 0) grouped.set(sourceFolder, validIds);
     } else {
+      // No sourceFolder — discover per UID (IMAP-003 from 2026-05-28 audit).
       for (const id of emailIds) {
         try {
           this.validateEmailId(id);
           const cached = this.findCacheEntryByUid(id);
-          const folder = cached?.folder ?? 'INBOX';
-          if (!cached) logger.warn(`bulkCopyToFolder: UID ${id} not in cache, assuming INBOX`, 'IMAPService');
+          let folder: string;
+          if (cached) {
+            folder = cached.folder;
+          } else {
+            const discovered = await this.getEmailById(id);
+            if (!discovered) {
+              results.failed++;
+              results.errors.push(`Email ${id} not found in any folder`);
+              continue;
+            }
+            folder = discovered.folder;
+          }
           if (!grouped.has(folder)) grouped.set(folder, []);
           grouped.get(folder)!.push(id);
         } catch (e: unknown) {
@@ -2296,7 +2405,21 @@ export class SimpleIMAPService {
     for (const [folder, ids] of grouped.entries()) {
       const lock = await this.client.getMailboxLock(folder);
       try {
-        const existing = await this.findExistingUidsInLockedFolder(ids);
+        let existing: Set<string>;
+        try {
+          existing = await this.findExistingUidsInLockedFolder(ids);
+        } catch (e: unknown) {
+          // IMAP-006: transport error during pre-flight. Surface the real
+          // failure mode rather than collapsing into "UIDs not found" — the
+          // caller needs to distinguish "definitely absent" from "couldn't
+          // verify" so a retry is meaningful.
+          const msg = e instanceof Error ? e.message : String(e);
+          for (const id of ids) {
+            results.failed++;
+            results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+          }
+          continue;
+        }
         const present: string[] = [];
         for (const id of ids) {
           if (existing.has(id)) {
@@ -2358,7 +2481,20 @@ export class SimpleIMAPService {
 
     const lock = await this.client.getMailboxLock(folder);
     try {
-      const existing = await this.findExistingUidsInLockedFolder(validIds);
+      let existing: Set<string>;
+      try {
+        existing = await this.findExistingUidsInLockedFolder(validIds);
+      } catch (e: unknown) {
+        // IMAP-006: transport error during pre-flight. Don't lie that the
+        // UIDs are absent — bubble up so the caller knows the check failed.
+        const msg = e instanceof Error ? e.message : String(e);
+        for (const id of validIds) {
+          results.failed++;
+          results.errors.push(`UID ${id} existence check failed in folder ${folder}: ${msg}`);
+        }
+        tags.successCount = results.success; tags.failCount = results.failed;
+        return results;
+      }
       const present: string[] = [];
       for (const id of validIds) {
         if (existing.has(id)) {

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -18,6 +18,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import {
   isValidEmail,
+  optionalFolderHint,
   requireNumericEmailId,
   validateLabelName,
   validateTargetFolder,
@@ -516,7 +517,7 @@ export const handlers: Record<string, ToolHandler> = {
   get_email_by_id: async (ctx) => {
     const { args, imapService, ok, limits } = ctx;
     const rawEmailId = requireNumericEmailId(args.emailId);
-    const folderHint = args.folder as string | undefined;
+    const folderHint = optionalFolderHint(args.folder);
     const email = await imapService.getEmailById(rawEmailId, folderHint);
     if (!email) {
       return { content: [{ type: "text" as const, text: "Email not found" }], isError: true };
@@ -719,7 +720,7 @@ export const handlers: Record<string, ToolHandler> = {
   get_thread: async (ctx) => {
     const { args, imapService, ok } = ctx;
     const threadEmailId = requireNumericEmailId(args.email_id, "email_id");
-    const threadFolderHint = args.folder as string | undefined;
+    const threadFolderHint = optionalFolderHint(args.folder);
     const maxMsgs = typeof args.max_messages === "number"
       ? Math.min(Math.max(1, args.max_messages), 200)
       : 50;
@@ -835,7 +836,7 @@ export const handlers: Record<string, ToolHandler> = {
   extract_action_items: async (ctx) => {
     const { args, imapService, ok } = ctx;
     const aiEmailId = requireNumericEmailId(args.email_id, "email_id");
-    const email = await imapService.getEmailById(aiEmailId, args.folder as string | undefined);
+    const email = await imapService.getEmailById(aiEmailId, optionalFolderHint(args.folder));
     if (!email) {
       return { content: [{ type: "text" as const, text: "Email not found" }], isError: true };
     }
@@ -846,7 +847,7 @@ export const handlers: Record<string, ToolHandler> = {
   extract_meeting: async (ctx) => {
     const { args, imapService, ok } = ctx;
     const emEmailId = requireNumericEmailId(args.email_id, "email_id");
-    const email = await imapService.getEmailById(emEmailId, args.folder as string | undefined);
+    const email = await imapService.getEmailById(emEmailId, optionalFolderHint(args.folder));
     if (!email) {
       return { content: [{ type: "text" as const, text: "Email not found" }], isError: true };
     }

--- a/src/tools/sending.ts
+++ b/src/tools/sending.ts
@@ -7,7 +7,7 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { isValidEmail, validateAttachments, requireNumericEmailId } from "../utils/helpers.js";
+import { isValidEmail, optionalFolderHint, validateAttachments, requireNumericEmailId } from "../utils/helpers.js";
 import type { EmailAttachment } from "../types/index.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
@@ -179,7 +179,7 @@ export const handlers: Record<string, ToolHandler> = {
     if (args.replyAll !== undefined && typeof args.replyAll !== "boolean") {
       throw new McpError(ErrorCode.InvalidParams, "'replyAll' must be a boolean when provided.");
     }
-    const original = await imapService.getEmailById(emailId, args.folder as string | undefined);
+    const original = await imapService.getEmailById(emailId, optionalFolderHint(args.folder));
     if (!original) {
       return { content: [{ type: "text" as const, text: "Original email not found" }], isError: true };
     }
@@ -228,7 +228,7 @@ export const handlers: Record<string, ToolHandler> = {
     if (!args.to || typeof args.to !== "string" || !(args.to as string).trim()) {
       throw new McpError(ErrorCode.InvalidParams, "'to' must be a non-empty string with at least one recipient address.");
     }
-    const fwdOriginal = await imapService.getEmailById(fwdId, args.folder as string | undefined);
+    const fwdOriginal = await imapService.getEmailById(fwdId, optionalFolderHint(args.folder));
     if (!fwdOriginal) {
       return { content: [{ type: "text" as const, text: "Original email not found" }], isError: true };
     }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -280,6 +280,28 @@ export function requireNumericEmailId(raw: unknown, fieldName: string = "emailId
 }
 
 /**
+ * Validate an optional `folder` argument that flows from a tool handler into
+ * `imapService.getEmailById` (or similar service methods that take a folder
+ * hint). Returns the validated folder string when present; returns undefined
+ * for `undefined`/`null`/empty-string; throws `McpError(InvalidParams, …)`
+ * for non-strings or invalid IMAP paths (CRLF / control chars / `..`).
+ *
+ * Closes VALID-001 / VALID-009 from the 2026-05-28 audit — the by-id reading
+ * tools (`get_email_by_id`, `get_thread`, `extract_action_items`,
+ * `extract_meeting`, `reply_to_email`, `forward_email`) were forwarding
+ * `args.folder` raw via `as string | undefined` casts.
+ */
+export function optionalFolderHint(raw: unknown, fieldName: string = "folder"): string | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (typeof raw !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, `'${fieldName}' must be a string when provided.`);
+  }
+  const err = validateTargetFolder(raw);
+  if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid ${fieldName}: ${err}`);
+  return raw;
+}
+
+/**
  * Validate the shape of an `attachments` argument before passing it to a service.
  *
  * Each element must be a plain object with:

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -292,13 +292,24 @@ export function requireNumericEmailId(raw: unknown, fieldName: string = "emailId
  * `args.folder` raw via `as string | undefined` casts.
  */
 export function optionalFolderHint(raw: unknown, fieldName: string = "folder"): string | undefined {
-  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (raw === undefined || raw === null) return undefined;
   if (typeof raw !== "string") {
     throw new McpError(ErrorCode.InvalidParams, `'${fieldName}' must be a string when provided.`);
   }
-  const err = validateTargetFolder(raw);
-  if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid ${fieldName}: ${err}`);
-  return raw;
+  // Trim and treat whitespace-only as "not provided" — otherwise '   ' passes
+  // `validateTargetFolder()` and reaches `getEmailById()` only to be rejected
+  // with a generic Error("Folder name must not be empty") from the service
+  // layer, defeating the McpError(InvalidParams) shape the gate gives.
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  const err = validateTargetFolder(trimmed);
+  if (err) {
+    // Rewrite the validator's `targetFolder ...` prefix so the error reads
+    // as the caller's own field name, not the helper's internal vocabulary.
+    const cleaned = err.replace(/^targetFolder\s+/, "").replace(/^targetFolder/, "");
+    throw new McpError(ErrorCode.InvalidParams, `Invalid ${fieldName}: ${cleaned}`);
+  }
+  return trimmed;
 }
 
 /**


### PR DESCRIPTION
## Summary

Batch 2 of the audit fix-pass. Closes 3 High findings (plus 3 Medium ride-alongs) from the [2026-05-28 audit](docs/audit-2026-05-28.md). The v3.0.41 fix was uniform on most mutators; this PR catches the four sibling paths that were missed.

### Findings closed

| ID | Severity | Bug | Fix |
|---|---|---|---|
| [IMAP-003](docs/audit-2026-05-28.md#imap-003--bulkmarkread--bulkstar--bulkcopytofolder-silently-default-to-inbox-on-cache-miss) | **High** | `bulkMarkRead`/`bulkStar`/`bulkCopyToFolder` silently grouped UIDs under `'INBOX'` on cache miss when `sourceFolder` was absent | Mirror `bulkMoveEmails`: cache lookup → `getEmailById()` discovery → explicit failure if still not found |
| [IMAP-006](docs/audit-2026-05-28.md#imap-006--uid-fetch-preflight-inside-lock-pretends-a-server-error-means-all-uids-missing) | **High** | `findExistingUidsInLockedFolder` `catch(e){return new Set()}` collapsed every transport error into "UIDs not found" | Rethrow; every bulk caller wraps in its own catch surfacing `UID X existence check failed in folder Y: <reason>` |
| [VALID-001](docs/audit-2026-05-28.md#valid-001--getemailbyid-and-callers-never-validate-folderhint) | **High** | `getEmailById` and 6 tool handlers forwarded `args.folder` raw via `as string | undefined` — CRLF/control-char folder hints reached `getMailboxLock` | Service calls `validateFolderName(folderHint)`; tool layer routes through new `optionalFolderHint()` helper |
| [IMAP-008](docs/audit-2026-05-28.md#imap-008--setflag-lacks-findexistinguidsinlockedfolder-preflight--silent-no-op-restored-for-cache-hit-paths) | Medium ride-along | `setFlag` lacked pre-flight UID FETCH | Now runs `findExistingUidsInLockedFolder` before the flag op |
| [IMAP-009](docs/audit-2026-05-28.md#imap-009--setflag-does-not-accept-sourcefolder-so-the-cross-folder-uid-hint-plumbing-is-incomplete) | Medium ride-along | `setFlag` didn't accept `sourceFolder` | Added optional `sourceFolder` parameter |
| [VALID-009](docs/audit-2026-05-28.md#valid-009--tools-that-call-getemailbyid_-argsfolder-skip-validatetargetfolder-even-when-sibling-tools-enforce-it) | Medium ride-along | Tool-layer sibling — the by-id handlers skipped `validateTargetFolder` on `folder` | All six handlers now call `optionalFolderHint()` |

## Test plan

- [x] 9 new regression tests added in `src/services/imap-operations.test.ts` covering each finding above
- [x] One pre-existing setFlag test updated from `mockReturnValue` (consumed-once iterator) to `mockImplementation` — needed because `setFlag` now calls `fetch` twice (folder scan + pre-flight check). This was the kind of latent mock fragility the audit's TEST batch flagged
- [x] `npm test` → 1631 passes (up from 1622)
- [x] `npx tsc --noEmit` → clean
- [x] `PRESHIP_NO_BRIDGE=1 npm run preship` → green in ~4 min
- [x] preship gate now hard-fails on HIGH/CRITICAL (v3.0.43 effect) — confirms the gate has bite

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] CRLF / path traversal in `folderHint` is now rejected at both tool and service layers
- [x] Dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)