### PR TITLE
fix(parsers): FTS query guard, analytics time/median correctness, iCal + HTML parsing (v3.0.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.54] — 2026-05-29
+
+### Fixed
+Parser/analytics correctness batch from the 2026-05-28 audit (DATA-PARSERS findings PARSE-001/003/004/005/006/007/010/011/012/013/015/016/017/018/019). Scope: `fts-service.ts`, `analytics-service.ts`, `content-parser.ts`.
+
+- **`fts_search` no longer throws on malformed FTS5 query syntax** (PARSE-001). `search()` passed the raw user query straight into `MATCH ?`; a stray `"`, `(`, or column-filter garbage raised an uncaught `SqliteError: fts5: syntax error` to the MCP client. (SQL injection was already impossible — the operand is a bound parameter.) Added a `runMatch()` wrapper around every `.all()` call site that catches FTS5 query-DSL syntax errors and returns a clean empty result; any other error is re-thrown unchanged.
+- **`FtsIndexService.rebuild()` clears and repopulates the index atomically** (PARSE-003). The previous flow (`clear()` then `upsertMany()`) committed the `DELETE` immediately, so a throw mid-repopulate left the index empty until the user noticed and re-triggered a rebuild. New `rebuild(records)` wraps the delete + bulk upsert in a single `db.transaction`, rolling back to the prior index on any failure. (The `fts_rebuild` tool handler in `src/tools/reading.ts` should be switched from `clear()`+`upsertMany()` to `rebuild()` — owned by the tools batch.)
+- **Contact cap no longer drops the user's own most-frequent recipients** (PARSE-004). `processContacts()` enforced the 10,000-contact cap in insertion order, iterating inbox before sent — so a flood of one-off inbox senders (newsletters, bounces) could exhaust the cap and silently drop every sent-to recipient. Sent recipients are now processed first, guaranteeing high-value contacts claim their map slots.
+- **Analytics now uses a single host-local time basis** (PARSE-005/006). `volumeTrends` previously bucketed by UTC ISO date while `peakActivityHours` used host-local `getHours()`, so two charts from the same dataset disagreed and evening mail drifted up to a day. Volume-trend day buckets now use host-local calendar dates (`localDateKey()`), matching peak-hours. Day buckets are seeded by walking back N *calendar* days via local y/m/d construction so a DST transition can't collapse or skip a day. No timezone library introduced.
+- **`responseTimeStats.median` is the conventional median** (PARSE-007). For even-length arrays it now returns the mean of the two middle values (`[1,2,3,4] → 2.5`) instead of the upper-middle element (`3`).
+- **`responseTimeStats` matches replies across angle-bracket variation** (PARSE-016). The Message-ID → date lookup now normalizes both the stored header and `inReplyTo` by stripping surrounding `<>`/whitespace, so a mailparser-style `<abc@x.com>` matches a bare `abc@x.com`; previously the lookup missed every reply and the whole block returned `null`.
+- **Undefined attachment sizes no longer poison storage stats** (PARSE-015). `att.size` (runtime `number | undefined`) is now added as `att.size ?? 0` in both `getEmailStats` and `calculateAttachmentStats`, preventing a single missing size from turning `storageUsedMB`/`totalSizeMB` into `NaN`.
+- **`inferOrganization` handles government domains correctly** (PARSE-017). `'gov'` was listed in both the TLD and compound-SLD branches; the duplicate left `cdc.gov` mis-cased and made the compound branch unreachable for it. Acronym TLDs (`edu`/`gov`/`mil`) now upper-case the whole label (`cdc.gov → CDC`), and `gov` in the compound branch only fires for real compounds like `gov.uk` (`hmrc.gov.uk → Hmrc`).
+- **iCal `DTSTART;TZID=...` zone is preserved** (PARSE-010). `splitProperty` now returns the property's parameter map; `parseIcs` persists the TZID on a new optional `Meeting.startTzid` field. The `start` value itself stays the raw RFC 5545 date-time string.
+- **iCal `BEGIN:VEVENT` lines with parameters are recognized** (PARSE-011). Legacy producers emit `BEGIN:VEVENT;X-MICROSOFT-CDO-BUSYSTATUS=BUSY`; the strict-equality block-start check silently produced `null`. Block boundaries are now matched on the parsed property name/value (and `END:VEVENT;…` is tolerated).
+- **iCal `unfoldLines` trims leading whitespace on the first line** (PARSE-012). A leading space/tab on the very first line is not a fold continuation (nothing to fold onto); it is now stripped so `splitProperty` doesn't read a property name of `" SUMMARY"` and drop the field.
+- **`extractActionItems` enforces its body cap in bytes** (PARSE-013). The 100 KB cap checked UTF-8 byte length but truncated with a character-count `.slice()`, letting ~4× the bytes through for multibyte bodies. Truncation now slices a `Buffer` and decodes back.
+- **`extractActionItems` dedup is punctuation-insensitive** (PARSE-018). The dedup key now also strips trailing `[.,;:!?]` so `Fix bug.` and `Fix bug!` collapse to one item.
+- **`extractActionItems` recognizes more bullet markers** (PARSE-019). `BULLET_RE` now matches `‣ ▪ ◦ ◾ ○ ▶ →` and the em-dash `—` used as a dash bullet in Mac/Office plaintext.
+
+### Notes
+- PARSE-002 was resolved in v3.0.48; PARSE-014 is owned by the IMAP batch (lives in `simple-imap-service.ts`).
+- PARSE-008/009 (`stripHtml` entity-decode order and HTML-comment stripping) also live in `simple-imap-service.ts` and are deferred to the IMAP batch — see audit annotations.
+
 ## [3.0.53] — 2026-05-29
 
 ### Fixed — tool-surface input hygiene (numeric + cast validation)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.53-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.54-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -1381,6 +1381,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `search()` passes `opts.query` straight into `MATCH ?` with no escaping and no try/catch. better-sqlite3 throws `SqliteError: fts5: syntax error near "..."` on any FTS5 syntax violation. SQL injection proper is blocked (parameter is bound), but FTS5 syntax is its own DSL.
 - Repro hypothesis: Call `fts_search` with `query: '"hello'` → unhandled SqliteError surfaces to MCP client.
 - Suggested next step: Wrap `searchAll.all/searchFolder.all` in try/catch returning `{ hits: [], queryError: msg }`, or sanitize via a "double-quote if not a valid expression" fallback.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Added a `runMatch()` wrapper in `fts-service.ts` around all three `.all()` call sites; it catches FTS5 query-DSL syntax errors and returns a clean empty result, re-throwing anything else. Fix is service-side only (the tool handler still receives an array).
 
 #### PARSE-003 — `fts_rebuild` clears the index before checking it can repopulate
 - Location: `src/tools/reading.ts:803-819`, `src/services/fts-service.ts:175-184`
@@ -1390,6 +1391,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `fts.clear()` (line 812) is executed via `db.exec`, not part of the upsertMany transaction. If the map throws or better-sqlite3 raises mid-transaction, the clear has already committed. User sees an empty index until they discover and re-trigger rebuild.
 - Repro hypothesis: Inject a malformed `EmailMessage` with `body` of type `Buffer` instead of string → `stripHtml` throws on `.replace`, leaving the index wiped.
 - Suggested next step: Wrap clear+upsertMany in a single `db.transaction`.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Added `FtsIndexService.rebuild(records)` that runs the `DELETE` + bulk upsert inside one `db.transaction`, rolling back to the prior index on any throw. The `fts_rebuild` tool handler in `src/tools/reading.ts` (not in this batch's ownership) should be switched from `clear()`+`upsertMany()` to `rebuild()` — flagged to the tools batch.
 
 #### PARSE-004 — `processContacts()` silently drops every new contact past the 10 000-cap including the largest senders
 - Location: `src/services/analytics-service.ts:124-146, 148-164`
@@ -1399,6 +1401,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The cap is enforced in INSERTION ORDER. The inbox is iterated first, then sent. If inbox contains 10 000 unique senders (newsletters, automated bounces), every `to` address in `sentEmails` is silently dropped — even the user's own most-frequent recipients.
 - Repro hypothesis: Load 10 001 inbox emails from distinct senders; then load 100 sent emails to high-value contacts. `getContacts(sortBy: 'sent')` returns an empty result.
 - Suggested next step: Either raise the cap, evict the lowest-interaction contact on insert pressure, or process sent first / interleave folders.
+> **Resolved in v3.0.54 — parser/analytics hardening.** `processContacts()` now processes sent recipients before inbox senders, so the user's own most-frequent contacts claim their map slots before a flood of one-off inbox senders can exhaust the cap.
 
 #### PARSE-005 — `calculateVolumeTrends` buckets by UTC ISO date; user-facing days drift by up to 24h
 - Location: `src/services/analytics-service.ts:352-381`
@@ -1408,6 +1411,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Both the bucket keys and the per-email key use `toISOString().split('T')[0]` — i.e., UTC date. An email received at 9 PM ET on Monday gets bucketed as Tuesday UTC. The "Mon" bar in volume-trends UI under-counts evening mail by up to ~5 hours of traffic per day.
 - Repro hypothesis: Send a test email at 22:00 ET; observe it land in the next-day bucket.
 - Suggested next step: Accept a `timezone` option (default to host TZ), or compute date strings in local time.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Volume-trend day buckets now use host-local calendar dates via a `localDateKey()` helper, the SAME basis as `peakActivityHours` (host-local `getHours()`). Buckets are seeded by walking back N calendar days with local y/m/d construction so DST can't collapse/skip a day. No TZ library introduced. See PARSE-006 for the unified-basis decision.
 
 #### PARSE-010 — iCal `DTSTART;TZID=...:` parameter dropped on the floor
 - Location: `src/services/content-parser.ts:174-182, 252-256`
@@ -1417,6 +1421,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `splitProperty` discards everything between the property name and the colon. For `DTSTART;TZID=America/New_York:20260601T140000`, only `20260601T140000` reaches the `Meeting` object as `start`. The parsed `start` is a naïve "2026-06-01 14:00" with no zone.
 - Repro hypothesis: Parse a calendar invite with `DTSTART;TZID=America/Los_Angeles:20260601T090000` — `extract_meeting` returns `start: "20260601T090000"`.
 - Suggested next step: Have `splitProperty` also return the parameters dict, persist `start_tzid` on the Meeting.
+> **Resolved in v3.0.54 — parser/analytics hardening.** `splitProperty` now returns a `params` map (keys upper-cased, values case-preserved for zone names); `parseIcs` persists `DTSTART`'s `TZID` on a new optional `Meeting.startTzid`. The `start` value remains the raw RFC 5545 date-time string.
 
 #### PARSE-014 — `downloadAttachment` re-fetches the full RFC 2822 source then base64-encodes the whole attachment in memory
 - Location: `src/services/simple-imap-service.ts:1222-1280`, `1287-1334`
@@ -1435,6 +1440,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: If `email.headers['message-id']` is stored as `<abc@x.com>` (mailparser default) but `sent.inReplyTo` is normalized to `abc@x.com` (or vice-versa), the lookup misses every reply → `responseTimeStats` is always `null` even when there's clearly data.
 - Suggested next step: Strip `<>` on both sides before keying.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Added `normalizeMessageId()` (trim + strip surrounding `<>`); both the stored Message-ID and `inReplyTo` are keyed through it, so `<abc@x.com>` matches `abc@x.com`.
 
 #### PARSE-006 — `calculatePeakActivityHours` uses local-host `getHours()` while volume trends use UTC
 - Location: `src/services/analytics-service.ts:383-396`
@@ -1443,6 +1449,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Within the same `EmailAnalytics` object, `volumeTrends` is bucketed in UTC but `peakActivityHours` uses `email.date.getHours()` which returns the host's local hour. Two charts derived from the same dataset disagree.
 - Suggested next step: Pick one timezone discipline; document it.
+> **Resolved in v3.0.54 — parser/analytics hardening.** TIME-BASIS DECISION: host-local time for BOTH charts. Peak-activity-hours is inherently a human-experience metric ("when in my day do I get mail") and only reads correctly in local time; `volumeTrends` was changed to match (PARSE-005). The shared basis is documented in a TIME BASIS comment on `calculateVolumeTrends` and a one-liner on `calculatePeakActivityHours`. No TZ library.
 
 #### PARSE-007 — `responseTimeStats.median` picks the upper-middle element for even-length arrays (off-by-one)
 - Location: `src/services/analytics-service.ts:336-346`
@@ -1451,6 +1458,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `const median = responseTimes[Math.floor(responseTimes.length / 2)]`. For an even-length sorted array `[1, 2, 3, 4]`, returns `3`, not the conventional `(2+3)/2 = 2.5`.
 - Suggested next step: `n % 2 ? rt[(n-1)/2] : (rt[n/2 - 1] + rt[n/2]) / 2`.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Applied the suggested even/odd median; `[1,2,3,4]` now yields `2.5`.
 
 #### PARSE-008 — `stripHtml` unescapes entities AFTER tag-strip
 - Location: `src/services/simple-imap-service.ts:61-75`
@@ -1460,6 +1468,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: An attacker who supplies HTML like `&lt;script&gt;alert(1)&lt;/script&gt;` (encoded text content) emerges as literal `<script>alert(1)</script>` in the FTS body and the bodyPreview. If any downstream consumer treats those fields as HTML, you have stored XSS.
 - Repro hypothesis: Inject an email whose plaintext body literally contains `&lt;script&gt;evil()&lt;/script&gt;`; observe FTS body now contains raw `<script>...</script>`.
 - Suggested next step: Decode entities FIRST, then strip tags (the standard order); handle numeric entities for parity.
+> **Deferred — owned by the IMAP batch (v3.0.54 parser batch).** `stripHtml` lives in `src/services/simple-imap-service.ts`, which the parser/analytics batch must not touch. Flagged to the IMAP batch for the entity-decode-order fix.
 
 #### PARSE-009 — `stripHtml` ignores HTML comments
 - Location: `src/services/simple-imap-service.ts:61-75`
@@ -1468,6 +1477,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: HTML comments are `<!-- ... -->`; the regex consumes `<!--` and `-->`, but leaves any HTML inside the comment visible as tag-stripped prose. `<!-- secret: pw123 -->` becomes `  -- secret: pw123 --` in the FTS body.
 - Suggested next step: Add `.replace(/<!--[\s\S]*?-->/g, ' ')` as the first pass.
+> **Deferred — owned by the IMAP batch (v3.0.54 parser batch).** `stripHtml` lives in `src/services/simple-imap-service.ts`, outside this batch's ownership. Flagged to the IMAP batch for the comment-stripping pass.
 
 #### PARSE-011 — iCal parser ignores `BEGIN:VEVENT` lines with parameters
 - Location: `src/services/content-parser.ts:220-232`
@@ -1476,6 +1486,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: The block-start check is strict equality `upper === "BEGIN:VEVENT"`. Some legacy producers emit `BEGIN:VEVENT;X-MICROSOFT-CDO-BUSYSTATUS=BUSY` — parser silently produces `null`.
 - Suggested next step: Compare on `upper.startsWith("BEGIN:VEVENT")` and use the parameter-aware `splitProperty`.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Block boundaries are now matched on the parsed property name/value via `splitProperty` (`BEGIN` name + `VEVENT` value), and `END:VEVENT;…` is tolerated, so a `BEGIN:VEVENT;X-…=BUSY` line is recognized.
 
 #### PARSE-012 — `unfoldLines` first-line leading-whitespace handling
 - Location: `src/services/content-parser.ts:154-168`
@@ -1484,6 +1495,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: When the *first* line of input starts with a space, the `if (folded.length > 0)` branch is skipped and the line is pushed verbatim including the leading space, then later `splitProperty` will treat ` SUMMARY:foo` as having name ` SUMMARY` (uppercased to ` SUMMARY`, not `SUMMARY`), so SUMMARY is dropped.
 - Suggested next step: Trim leading whitespace on the first line.
+> **Resolved in v3.0.54 — parser/analytics hardening.** `unfoldLines` now strips leading space/tab on the first line (a leading-whitespace first line is not a fold continuation — nothing to fold onto), so `splitProperty` reads `SUMMARY`, not `" SUMMARY"`.
 
 #### PARSE-013 — `MAX_BODY_BYTES` cap uses `body.slice(0, MAX_BODY_BYTES)` measured in chars after byte-length check
 - Location: `src/services/content-parser.ts:80-90`
@@ -1492,6 +1504,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: The guard says "Byte length on UTF-8" but then truncates with `.slice(0, MAX_BODY_BYTES)` which is a *character* count. For a body of multibyte chars, the slice keeps up to ~400 KB of actual bytes.
 - Suggested next step: Slice on a Buffer and decode back, or use `Buffer.byteLength` to walk to the right char-index.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Truncation now slices a UTF-8 `Buffer` (`Buffer.from(body).subarray(0, MAX_BODY_BYTES).toString("utf-8")`) so the cap is honest in bytes for multibyte bodies.
 
 #### PARSE-015 — `extractAttachmentMeta`'s `att.size` is `number | undefined` but added unguarded
 - Location: `src/services/analytics-service.ts:235-243, 398-412`
@@ -1500,6 +1513,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: `totalBytes += att.size;` — if `att.size` is ever `undefined`, the addition yields `NaN` and propagates through `bytesToMB(NaN)`, surfacing as `null`/`NaN` in `EmailStats.storageUsedMB`.
 - Suggested next step: `totalBytes += att.size ?? 0;`.
+> **Resolved in v3.0.54 — parser/analytics hardening.** Applied `att.size ?? 0` at both addition sites (`getEmailStats`, `calculateAttachmentStats`). Note: the `EmailAttachment.size` type is declared `number` (non-optional), but mailparser can produce attachments without a size at runtime, so the guard is defensive against that type-contract violation.
 
 #### PARSE-017 — `inferOrganization` `'gov'` listed in both TLD and compound-SLD lists
 - Location: `src/services/analytics-service.ts:38-61`
@@ -1508,6 +1522,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: `cdc.gov` returns "Cdc" without proper capitalization; `gov.uk` (root-only) returns "Gov".
 - Suggested next step: Guard the compound branch with `parts.length >= 3` strictly; uppercase known acronym TLDs (edu/gov/mil).
+> **Resolved in v3.0.54 — parser/analytics hardening.** Acronym TLDs (`edu`/`gov`/`mil`) now upper-case the whole label (`cdc.gov → CDC`); `gov` in the compound-SLD branch only fires for real compounds (`gov.uk → Hmrc`-style, requires `parts.length >= 3`), with the root-TLD case handled by the TLD branch above.
 
 #### PARSE-018 — `extractActionItems` dedup key punctuation-sensitive
 - Location: `src/services/content-parser.ts:122-124`
@@ -1516,6 +1531,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `const key = text.toLowerCase().replace(/\s+/g, " ").trim();` — case- and whitespace-tolerant but punctuation-sensitive. `- Fix bug.\n- Fix bug!` produces two action items.
 - Suggested next step: Also strip trailing `[.,;:!?]+` on the dedup key.
+> **Resolved in v3.0.54 — parser/analytics hardening.** The dedup key now also strips a trailing `[.,;:!?]+` run, so `Fix bug.` / `Fix bug!` / `Fix bug` collapse to one item.
 
 #### PARSE-019 — `BULLET_RE` doesn't recognize `→`, `▪`, `‣`, or em-dash bullets
 - Location: `src/services/content-parser.ts:57`
@@ -1524,6 +1540,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: `BULLET_RE = /^\s*(?:[-*•]|\d+[.)]|\[[ xX]\])\s+/`. Mac-formatted plaintext often uses `‣`, `▪`, em-dash `—`. Lines starting with those fall through to the "no bullet" branch.
 - Suggested next step: Add `‣▪◦◾○▶→—` to the character class.
+> **Resolved in v3.0.54 — parser/analytics hardening.** `BULLET_RE` now includes `‣ ▪ ◦ ◾ ○ ▶ →` and the em-dash `—` in its leading-marker character class.
 
 #### PARSE-020 — `extractEmailAddress` regex `/<([^>]+)>/` accepts the first angle-bracket pair anywhere
 - Location: `src/utils/helpers.ts:124-127`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.51",
+  "version": "3.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.51",
+      "version": "3.0.54",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.53",
+  "version": "3.0.54",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/analytics-service.test.ts
+++ b/src/services/analytics-service.test.ts
@@ -742,4 +742,108 @@ describe('AnalyticsService', () => {
       expect(Array.isArray(result.topSenders)).toBe(true);
     });
   });
+
+  // ─── audit-2026-05-28 parser/analytics hardening (v3.0.54) ─────────────────
+
+  function inboxMsg(over: Partial<EmailMessage>): EmailMessage {
+    return {
+      id: Math.random().toString(36).slice(2),
+      from: 'x@example.com', to: ['me@proton.me'], subject: 's', body: 'b',
+      isHtml: false, date: new Date('2024-01-15T10:00:00Z'), folder: 'INBOX',
+      isRead: true, isStarred: false, hasAttachment: false, ...over,
+    };
+  }
+  function sentMsg(over: Partial<EmailMessage>): EmailMessage {
+    return inboxMsg({ folder: 'Sent', from: 'me@proton.me', ...over });
+  }
+
+  describe('PARSE-007 — median of even-length response-time arrays', () => {
+    it('returns the mean of the two middle values, not the upper-middle', () => {
+      // Construct 4 replies with response times of 1h, 2h, 3h, 4h.
+      const base = new Date('2024-03-01T00:00:00Z').getTime();
+      const inbox: EmailMessage[] = [];
+      const sent: EmailMessage[] = [];
+      [1, 2, 3, 4].forEach((h, i) => {
+        const mid = `<orig-${i}@x.com>`;
+        inbox.push(inboxMsg({ date: new Date(base), headers: { 'message-id': mid } }));
+        sent.push(sentMsg({ date: new Date(base + h * 3600_000), inReplyTo: mid }));
+      });
+      const svc = new AnalyticsService();
+      svc.updateEmails(inbox, sent);
+      const rt = svc.getEmailAnalytics().responseTimeStats;
+      expect(rt).not.toBeNull();
+      // median of [1,2,3,4] = 2.5, not 3
+      expect(rt!.median).toBe(2.5);
+    });
+  });
+
+  describe('PARSE-016 — Message-ID angle-bracket normalization', () => {
+    it('matches a bracketed stored Message-ID against a bare inReplyTo', () => {
+      const orig = new Date('2024-03-01T00:00:00Z');
+      const inbox = [inboxMsg({ date: orig, headers: { 'message-id': '<abc@x.com>' } })];
+      const sent = [sentMsg({ date: new Date(orig.getTime() + 3600_000), inReplyTo: 'abc@x.com' })];
+      const svc = new AnalyticsService();
+      svc.updateEmails(inbox, sent);
+      const rt = svc.getEmailAnalytics().responseTimeStats;
+      expect(rt).not.toBeNull();
+      expect(rt!.sampleSize).toBe(1);
+    });
+  });
+
+  describe('PARSE-015 — undefined attachment size does not produce NaN', () => {
+    it('treats a missing att.size as 0 in storage stats', () => {
+      const msg = inboxMsg({
+        hasAttachment: true,
+        attachments: [{ filename: 'a.pdf', contentType: 'application/pdf', size: undefined as unknown as number }],
+      });
+      const svc = new AnalyticsService();
+      svc.updateEmails([msg]);
+      expect(Number.isNaN(svc.getEmailStats().storageUsedMB)).toBe(false);
+      expect(Number.isNaN(svc.getEmailAnalytics().attachmentStats.totalSizeMB)).toBe(false);
+    });
+  });
+
+  describe('PARSE-004 — sent recipients survive the contact cap', () => {
+    it('keeps high-value sent recipients even when inbox would exhaust the cap', () => {
+      // Smaller cap proxy: 10 005 distinct inbox senders + a few sent recipients.
+      const inbox = Array.from({ length: 10_005 }, (_, i) =>
+        inboxMsg({ from: `news-${i}@bulk.example.com` }));
+      const sent = [sentMsg({ to: ['vip@partner.com'] })];
+      const svc = new AnalyticsService();
+      svc.updateEmails(inbox, sent);
+      const recipients = svc.getContacts(50, 'sent');
+      expect(recipients.some(c => c.email === 'vip@partner.com')).toBe(true);
+    });
+  });
+
+  describe('PARSE-005/006 — volume trends bucket by local day', () => {
+    it('buckets an email by its host-local calendar date', () => {
+      // Use a recent local 21:00 timestamp so it falls inside the window.
+      // 21:00 local on a day where UTC would roll it to the next date for any
+      // negative-offset zone — the bucket must follow the LOCAL day.
+      const now = new Date();
+      const d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 2, 21, 0, 0);
+      const svc = new AnalyticsService();
+      svc.updateEmails([inboxMsg({ date: d })]);
+      const trends = svc.getVolumeTrends(30);
+      const localKey = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      const bucket = trends.find(t => t.date === localKey);
+      expect(bucket?.received).toBe(1);
+    });
+  });
+
+  describe('PARSE-017 — inferOrganization gov handling', () => {
+    it('upper-cases acronym TLDs (cdc.gov → CDC) and title-cases gov.uk compound', () => {
+      const svc = new AnalyticsService();
+      svc.updateEmails([
+        inboxMsg({ from: 'alerts@cdc.gov' }),
+        inboxMsg({ from: 'info@hmrc.gov.uk' }),
+      ]);
+      const contacts = svc.getContacts(50, 'received');
+      const cdc = contacts.find(c => c.email === 'alerts@cdc.gov');
+      const hmrc = contacts.find(c => c.email === 'info@hmrc.gov.uk');
+      expect(cdc?.organization).toBe('CDC');
+      expect(hmrc?.organization).toBe('Hmrc');
+    });
+  });
 });

--- a/src/services/analytics-service.ts
+++ b/src/services/analytics-service.ts
@@ -26,6 +26,29 @@ function emailDomain(email: string): string {
 }
 
 /**
+ * Canonicalize a Message-ID / In-Reply-To header for cross-folder matching:
+ * trim whitespace and strip a single pair of surrounding angle brackets so the
+ * mailparser-style `<id@host>` form matches a bare `id@host`. Returns "" for
+ * nullish input.
+ */
+function normalizeMessageId(raw: string | undefined): string {
+  if (!raw) return '';
+  return raw.trim().replace(/^<+/, '').replace(/>+$/, '').trim();
+}
+
+/**
+ * Local-time YYYY-MM-DD key for a Date. Uses host-local accessors (not UTC) so
+ * volume-trend day buckets line up with the user's lived calendar day. See the
+ * TIME BASIS note on calculateVolumeTrends (PARSE-005/006, audit-2026-05-28).
+ */
+function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/**
  * Infer a human-readable organisation name from a domain.
  * Returns undefined for known personal providers (gmail, yahoo, etc.)
  * and for addresses without a recognisable company segment.
@@ -43,12 +66,20 @@ function inferOrganization(domain: string): string | undefined {
   const tld  = parts[parts.length - 1];
   const sld  = parts[parts.length - 2];
 
-  // Academic / government TLDs — org is the label just before the TLD
+  // Academic / government TLDs — org is the label just before the TLD.
+  // Known acronym TLDs upper-case the whole label (mit.edu → "MIT", cdc.gov →
+  // "CDC") rather than title-casing it ("Mit"/"Cdc").
   if (['edu', 'gov', 'mil', 'ac'].includes(tld)) {
-    return sld.charAt(0).toUpperCase() + sld.slice(1);
+    return ['edu', 'gov', 'mil'].includes(tld)
+      ? sld.toUpperCase()
+      : sld.charAt(0).toUpperCase() + sld.slice(1);
   }
 
-  // Compound SLDs like co.uk, com.au — org is one level higher
+  // Compound SLDs like co.uk, com.au, gov.uk — org is one level higher, and
+  // only when there's a label in front (parts.length >= 3). 'gov' appears here
+  // for gov.uk-style domains; the root-TLD case (cdc.gov) is already handled by
+  // the TLD branch above, so listing 'gov' in both lists previously left this
+  // branch unreachable for it and mis-cased gov.uk (PARSE-017, audit-2026-05-28).
   if (['co', 'com', 'org', 'net', 'gov'].includes(sld) && parts.length >= 3) {
     const org = parts[parts.length - 3];
     if (PERSONAL_DOMAINS.has(org)) return undefined;
@@ -120,17 +151,15 @@ export class AnalyticsService {
    * Build the contact map from both inbox (received) and sent emails.
    * - inbox emails → the `from` address sent a message to us
    * - sent emails  → the `to` addresses received a message from us
+   *
+   * Sent recipients are processed FIRST. The MAX_CONTACTS cap drops new
+   * contacts in insertion order once full; people the user actually emails are
+   * the highest-value contacts, so they must claim their map slots before a
+   * flood of one-off inbox senders (newsletters, bounces) can exhaust the cap
+   * (PARSE-004, audit-2026-05-28).
    */
   private processContacts(): void {
     this.contacts.clear();
-
-    for (const email of this.inboxEmails) {
-      const fromAddress = extractEmailAddress(email.from);
-      const fromName    = extractName(email.from);
-      if (fromAddress) {
-        this.updateContact(fromAddress, 'received', email.date, fromName);
-      }
-    }
 
     for (const email of this.sentEmails) {
       for (const to of email.to) {
@@ -139,6 +168,14 @@ export class AnalyticsService {
         if (toAddress) {
           this.updateContact(toAddress, 'sent', email.date, toName);
         }
+      }
+    }
+
+    for (const email of this.inboxEmails) {
+      const fromAddress = extractEmailAddress(email.from);
+      const fromName    = extractName(email.from);
+      if (fromAddress) {
+        this.updateContact(fromAddress, 'received', email.date, fromName);
       }
     }
 
@@ -237,7 +274,9 @@ export class AnalyticsService {
       totalBytes += email.body?.length ?? 0;
       if (email.attachments) {
         for (const att of email.attachments) {
-          totalBytes += att.size;
+          // att.size is number|undefined; an unguarded += yields NaN that then
+          // poisons storageUsedMB (PARSE-015, audit-2026-05-28).
+          totalBytes += att.size ?? 0;
         }
       }
     }
@@ -309,19 +348,24 @@ export class AnalyticsService {
   private calculateResponseTimeStats(): EmailAnalytics['responseTimeStats'] {
     const responseTimes: number[] = [];
 
-    // Build a lookup from Message-ID to inbox email date
+    // Build a lookup from Message-ID to inbox email date. Both the stored
+    // header and inReplyTo are normalized by stripping surrounding angle
+    // brackets and whitespace so `<abc@x.com>` (mailparser default) matches a
+    // bare `abc@x.com`; without this the lookup misses every reply and the
+    // whole stat block returns null even with data (PARSE-016, audit-2026-05-28).
     const inboxById = new Map<string, Date>();
     for (const email of this.inboxEmails) {
       const msgIdRaw = email.headers?.['message-id'];
       const msgId = Array.isArray(msgIdRaw) ? msgIdRaw[0] : msgIdRaw;
-      if (msgId) {
-        inboxById.set(msgId.trim(), email.date);
+      const key = normalizeMessageId(msgId);
+      if (key) {
+        inboxById.set(key, email.date);
       }
     }
 
     for (const sent of this.sentEmails) {
       if (!sent.inReplyTo) continue;
-      const originalDate = inboxById.get(sent.inReplyTo.trim());
+      const originalDate = inboxById.get(normalizeMessageId(sent.inReplyTo));
       if (!originalDate) continue;
 
       const diffHours = (sent.date.getTime() - originalDate.getTime()) / (1000 * 60 * 60);
@@ -335,7 +379,12 @@ export class AnalyticsService {
 
     responseTimes.sort((a, b) => a - b);
     const average = responseTimes.reduce((a, b) => a + b, 0) / responseTimes.length;
-    const median = responseTimes[Math.floor(responseTimes.length / 2)];
+    // Conventional median: mean of the two middle elements for even-length
+    // arrays, not the upper-middle element (PARSE-007, audit-2026-05-28).
+    const n = responseTimes.length;
+    const median = n % 2
+      ? responseTimes[(n - 1) / 2]
+      : (responseTimes[n / 2 - 1] + responseTimes[n / 2]) / 2;
 
     return {
       average: parseFloat(average.toFixed(1)),
@@ -348,30 +397,35 @@ export class AnalyticsService {
 
   /**
    * Volume trends split by received (inbox) and sent (sent folder).
+   *
+   * TIME BASIS: host-local time. Day boundaries (this method) and the hour of
+   * day (calculatePeakActivityHours) are both computed against the host's local
+   * zone so the two charts derived from the same dataset agree, and so a "Mon"
+   * bar reflects the day the user actually experienced rather than UTC. An
+   * email received at 9 PM ET Monday now counts toward Monday, not Tuesday-UTC
+   * (PARSE-005/006, audit-2026-05-28). No TZ library is used — date keys come
+   * from local Date accessors via localDateKey().
+   *
+   * Buckets are seeded by walking back `days` *calendar* days using local
+   * y/m/d construction (not fixed 86.4M-ms steps), so a DST transition can
+   * never collapse two local days onto one key or skip a day.
    */
   private calculateVolumeTrends(days: number): EmailAnalytics['volumeTrends'] {
     const trends = new Map<string, { received: number; sent: number }>();
 
-    // Use pure UTC arithmetic so DST transitions don't cause two local days
-    // to collapse onto the same ISO date string, which would produce fewer
-    // than `days` buckets.
     const now = new Date();
-    const todayUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
-    const msPerDay = 86_400_000;
     for (let i = 0; i < days; i++) {
-      const dateStr = new Date(todayUtc - i * msPerDay).toISOString().split('T')[0];
-      trends.set(dateStr, { received: 0, sent: 0 });
+      const d = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+      trends.set(localDateKey(d), { received: 0, sent: 0 });
     }
 
     for (const email of this.inboxEmails) {
-      const dateStr = email.date.toISOString().split('T')[0];
-      const entry = trends.get(dateStr);
+      const entry = trends.get(localDateKey(email.date));
       if (entry) entry.received++;
     }
 
     for (const email of this.sentEmails) {
-      const dateStr = email.date.toISOString().split('T')[0];
-      const entry = trends.get(dateStr);
+      const entry = trends.get(localDateKey(email.date));
       if (entry) entry.sent++;
     }
 
@@ -380,6 +434,8 @@ export class AnalyticsService {
       .sort((a, b) => a.date.localeCompare(b.date));
   }
 
+  // Peak activity hours use email.date.getHours() (host-local), matching the
+  // local-day basis of calculateVolumeTrends — see that method's TIME BASIS note.
   private calculatePeakActivityHours(): { hour: number; count: number }[] {
     const hourCounts = new Map<number, number>();
     for (let i = 0; i < 24; i++) hourCounts.set(i, 0);
@@ -404,7 +460,7 @@ export class AnalyticsService {
       if (email.attachments) {
         totalAttachments += email.attachments.length;
         for (const att of email.attachments) {
-          totalSizeBytes += att.size;
+          totalSizeBytes += att.size ?? 0; // guard number|undefined → no NaN (PARSE-015)
           const type = att.contentType?.split('/')[0] || 'other';
           typeCounts.set(type, (typeCounts.get(type) || 0) + 1);
         }

--- a/src/services/content-parser.test.ts
+++ b/src/services/content-parser.test.ts
@@ -258,4 +258,69 @@ describe("parseIcs", () => {
     expect(meeting?.summary).toBe("mix");
     expect(meeting?.start).toBe("20260420T140000Z");
   });
+
+  // ─── audit-2026-05-28 parser hardening (v3.0.54) ───────────────────────────
+
+  it("PARSE-010: captures DTSTART;TZID parameter as startTzid", () => {
+    const ics = [
+      "BEGIN:VEVENT",
+      "SUMMARY:Zoned",
+      "DTSTART;TZID=America/Los_Angeles:20260601T090000",
+      "END:VEVENT",
+    ].join("\r\n");
+    const meeting = parseIcs(ics);
+    expect(meeting?.start).toBe("20260601T090000");
+    expect(meeting?.startTzid).toBe("America/Los_Angeles");
+  });
+
+  it("PARSE-010: leaves startTzid undefined for a UTC DTSTART", () => {
+    const ics = "BEGIN:VEVENT\nSUMMARY:utc\nDTSTART:20260601T090000Z\nEND:VEVENT";
+    expect(parseIcs(ics)?.startTzid).toBeUndefined();
+  });
+
+  it("PARSE-011: parses a BEGIN:VEVENT line carrying parameters", () => {
+    const ics = [
+      "BEGIN:VEVENT;X-MICROSOFT-CDO-BUSYSTATUS=BUSY",
+      "SUMMARY:Legacy",
+      "DTSTART:20260601T090000Z",
+      "END:VEVENT",
+    ].join("\r\n");
+    expect(parseIcs(ics)?.summary).toBe("Legacy");
+  });
+
+  it("PARSE-012: keeps SUMMARY when the first line has a leading space", () => {
+    // Leading whitespace on the very first line is not a fold continuation.
+    const ics = " BEGIN:VEVENT\nSUMMARY:Indented\nDTSTART:20260601T090000Z\nEND:VEVENT";
+    expect(parseIcs(ics)?.summary).toBe("Indented");
+  });
+});
+
+describe("extractActionItems — audit-2026-05-28 hardening (v3.0.54)", () => {
+  it("PARSE-018: dedups items differing only by trailing punctuation", () => {
+    const items = extractActionItems(["- Fix bug.", "- Fix bug!", "- Fix bug"].join("\n"));
+    expect(items).toHaveLength(1);
+  });
+
+  it("PARSE-019: recognizes Unicode and em-dash bullets", () => {
+    const body = [
+      "→ send the report",
+      "▪ review the draft",
+      "‣ schedule the kickoff",
+      "— call the vendor",
+    ].join("\n");
+    const texts = extractActionItems(body).map(i => i.text);
+    expect(texts).toContain("send the report");
+    expect(texts).toContain("review the draft");
+    expect(texts).toContain("schedule the kickoff");
+    expect(texts).toContain("call the vendor");
+  });
+
+  it("PARSE-013: enforces the body cap in bytes for multibyte input", () => {
+    // 60k 2-byte chars = 120 KB > 100 KB cap. A char-count slice would keep
+    // all 60k chars (only 60k of the 100k budget), letting a trailing marker
+    // survive; a byte slice cuts at ~50k chars and drops it.
+    const padding = "é".repeat(60 * 1024);
+    const items = extractActionItems(padding + "\nTODO: never seen because truncated");
+    expect(items.find(i => /never seen/.test(i.text))).toBeUndefined();
+  });
 });

--- a/src/services/content-parser.ts
+++ b/src/services/content-parser.ts
@@ -20,6 +20,9 @@ export interface ActionItem {
 export interface Meeting {
   summary: string;
   start: string;
+  /** IANA/Olson zone from a `DTSTART;TZID=...` parameter, when present. The
+   *  `start` value itself stays the raw RFC 5545 date-time string. */
+  startTzid?: string;
   end?: string;
   location?: string;
   organizer?: string;
@@ -53,8 +56,10 @@ const ACTION_VERBS = [
 ];
 const ACTION_VERB_RE = new RegExp(`\\b(${ACTION_VERBS.join("|")})\\b`, "i");
 
-/** Bullet markers we recognise at the start of a line. */
-const BULLET_RE = /^\s*(?:[-*•]|\d+[.)]|\[[ xX]\])\s+/;
+/** Bullet markers we recognise at the start of a line. Includes the Unicode
+ *  bullets Mac/Office plaintext commonly emits (‣ ▪ ◦ ◾ ○ ▶ →) and the em-dash
+ *  (—) used as a dash bullet (PARSE-019, audit-2026-05-28). */
+const BULLET_RE = /^\s*(?:[-*•‣▪◦◾○▶→—]|\d+[.)]|\[[ xX]\])\s+/;
 
 /** Explicit "TODO:" / "ACTION:" / "ACTION ITEM:" markers — prefix is stripped. */
 const TODO_MARKER_RE = /^\s*(?:TODO|ACTION(?:\s+ITEM)?|FOLLOW[\s-]?UP)\s*:\s*/i;
@@ -80,10 +85,14 @@ const DEADLINE_RE = /\b(?:by|due(?:\s+by)?|before)\s+([A-Za-z0-9][\w,:/ -]{2,40}
 export function extractActionItems(body: string): ActionItem[] {
   if (typeof body !== "string" || body.length === 0) return [];
 
-  // Cap input size to avoid pathological scans. Byte length on UTF-8 rather
-  // than char count — emojis etc. shouldn't let a 1 MB body sneak through.
-  const truncated = Buffer.byteLength(body, "utf-8") > MAX_BODY_BYTES
-    ? body.slice(0, MAX_BODY_BYTES)
+  // Cap input size to avoid pathological scans. Both the check and the cut are
+  // in UTF-8 *bytes*: slicing a Buffer and decoding back keeps the cap honest
+  // for multibyte bodies, where a char-count slice would let ~4x the bytes
+  // through (PARSE-013, audit-2026-05-28). A multibyte char straddling the
+  // boundary decodes to U+FFFD, which is harmless for downstream line scanning.
+  const bytes = Buffer.from(body, "utf-8");
+  const truncated = bytes.length > MAX_BODY_BYTES
+    ? bytes.subarray(0, MAX_BODY_BYTES).toString("utf-8")
     : body;
 
   const lines = truncated.split(/\r?\n/);
@@ -119,7 +128,9 @@ export function extractActionItems(body: string): ActionItem[] {
     // email bodies are full of those and false-positive rate gets ugly.
     if (!hasMarker && !hasAssignee && !(hasBullet && hasVerb)) continue;
 
-    const key = text.toLowerCase().replace(/\s+/g, " ").trim();
+    // Dedup key is case-, whitespace-, and trailing-punctuation-insensitive so
+    // "Fix bug." and "Fix bug!" collapse to one item (PARSE-018, audit-2026-05-28).
+    const key = text.toLowerCase().replace(/\s+/g, " ").trim().replace(/[.,;:!?]+$/, "");
     if (seen.has(key)) continue;
     seen.add(key);
 
@@ -155,12 +166,18 @@ function unfoldLines(text: string): string[] {
   const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const rawLines = normalized.split("\n");
   const folded: string[] = [];
-  for (const line of rawLines) {
+  for (let i = 0; i < rawLines.length; i++) {
+    const line = rawLines[i];
     if (line.startsWith(" ") || line.startsWith("\t")) {
       if (folded.length > 0) {
         folded[folded.length - 1] += line.slice(1);
         continue;
       }
+      // A leading space/tab on the very first line is not a fold continuation
+      // (there's nothing to fold onto). Trim it so splitProperty doesn't read
+      // the property name as " SUMMARY" and drop it (PARSE-012, audit-2026-05-28).
+      folded.push(line.replace(/^[ \t]+/, ""));
+      continue;
     }
     folded.push(line);
   }
@@ -169,16 +186,27 @@ function unfoldLines(text: string): string[] {
 
 /**
  * Split a property line like `ATTENDEE;CN=Alice;RSVP=TRUE:mailto:a@x.com`
- * into its name, parameters, and value.
+ * into its name, parameters, and value. Parameter keys are upper-cased; values
+ * keep their original case (TZID zone names are case-sensitive).
  */
-function splitProperty(line: string): { name: string; value: string } | null {
+function splitProperty(
+  line: string,
+): { name: string; value: string; params: Record<string, string> } | null {
   const colonIdx = line.indexOf(":");
   if (colonIdx < 0) return null;
   const left = line.slice(0, colonIdx);
   const value = line.slice(colonIdx + 1);
   const semiIdx = left.indexOf(";");
   const name = (semiIdx < 0 ? left : left.slice(0, semiIdx)).trim().toUpperCase();
-  return { name, value };
+  const params: Record<string, string> = {};
+  if (semiIdx >= 0) {
+    for (const part of left.slice(semiIdx + 1).split(";")) {
+      const eq = part.indexOf("=");
+      if (eq < 0) continue;
+      params[part.slice(0, eq).trim().toUpperCase()] = part.slice(eq + 1).trim();
+    }
+  }
+  return { name, value, params };
 }
 
 /**
@@ -215,16 +243,25 @@ export function parseIcs(text: string): Meeting | null {
   // Locate the first VEVENT block. ICS files often contain multiple VEVENTs
   // (recurring exceptions, etc.) — we return just the first to keep the tool
   // response shape simple; callers that need more can iterate themselves.
+  // A VEVENT block may legally carry parameters on its BEGIN line, e.g.
+  // `BEGIN:VEVENT;X-MICROSOFT-CDO-BUSYSTATUS=BUSY` from some legacy producers.
+  // Match on the property name/value rather than strict equality so those
+  // aren't silently skipped (PARSE-011, audit-2026-05-28).
+  const isBoundary = (line: string, value: string): boolean => {
+    const prop = splitProperty(line);
+    return prop !== null && prop.name === "BEGIN" &&
+      prop.value.trim().toUpperCase().split(";")[0] === value;
+  };
   let inEvent = false;
   let eventLines: string[] = [];
   for (const line of lines) {
     const upper = line.trim().toUpperCase();
-    if (upper === "BEGIN:VEVENT") {
+    if (isBoundary(line, "VEVENT")) {
       inEvent = true;
       eventLines = [];
       continue;
     }
-    if (upper === "END:VEVENT") {
+    if (upper === "END:VEVENT" || upper.startsWith("END:VEVENT;")) {
       if (inEvent) break;
     }
     if (inEvent) eventLines.push(line);
@@ -233,6 +270,7 @@ export function parseIcs(text: string): Meeting | null {
 
   let summary: string | undefined;
   let start: string | undefined;
+  let startTzid: string | undefined;
   let end: string | undefined;
   let location: string | undefined;
   let organizer: string | undefined;
@@ -243,7 +281,7 @@ export function parseIcs(text: string): Meeting | null {
   for (const raw of eventLines) {
     const prop = splitProperty(raw);
     if (!prop) continue;
-    const { name, value } = prop;
+    const { name, value, params } = prop;
 
     switch (name) {
       case "SUMMARY":
@@ -251,6 +289,9 @@ export function parseIcs(text: string): Meeting | null {
         break;
       case "DTSTART":
         start = value.trim();
+        // Capture the zone from `DTSTART;TZID=America/New_York:...` so the
+        // naïve local date-time string isn't presented zoneless (PARSE-010).
+        if (params.TZID) startTzid = params.TZID;
         break;
       case "DTEND":
         end = value.trim();
@@ -286,6 +327,7 @@ export function parseIcs(text: string): Meeting | null {
   if (!summary || !start) return null;
 
   const meeting: Meeting = { summary, start };
+  if (startTzid) meeting.startTzid = startTzid;
   if (end) meeting.end = end;
   if (location) meeting.location = location;
   if (organizer) meeting.organizer = organizer;

--- a/src/services/content-parser.ts
+++ b/src/services/content-parser.ts
@@ -247,21 +247,20 @@ export function parseIcs(text: string): Meeting | null {
   // `BEGIN:VEVENT;X-MICROSOFT-CDO-BUSYSTATUS=BUSY` from some legacy producers.
   // Match on the property name/value rather than strict equality so those
   // aren't silently skipped (PARSE-011, audit-2026-05-28).
-  const isBoundary = (line: string, value: string): boolean => {
+  const isBoundary = (line: string, keyword: "BEGIN" | "END", value: string): boolean => {
     const prop = splitProperty(line);
-    return prop !== null && prop.name === "BEGIN" &&
+    return prop !== null && prop.name === keyword &&
       prop.value.trim().toUpperCase().split(";")[0] === value;
   };
   let inEvent = false;
   let eventLines: string[] = [];
   for (const line of lines) {
-    const upper = line.trim().toUpperCase();
-    if (isBoundary(line, "VEVENT")) {
+    if (isBoundary(line, "BEGIN", "VEVENT")) {
       inEvent = true;
       eventLines = [];
       continue;
     }
-    if (upper === "END:VEVENT" || upper.startsWith("END:VEVENT;")) {
+    if (isBoundary(line, "END", "VEVENT")) {
       if (inEvent) break;
     }
     if (inEvent) eventLines.push(line);

--- a/src/services/fts-service.test.ts
+++ b/src/services/fts-service.test.ts
@@ -245,4 +245,53 @@ describeMaybe("FtsIndexService", () => {
       expect(svc.stats().messageCount).toBe(3);
     });
   });
+
+  // ─── audit-2026-05-28 parser/analytics hardening (v3.0.54) ─────────────────
+
+  describe("PARSE-001 — malformed FTS5 query returns empty, does not throw", () => {
+    it("swallows an unterminated-quote query", () => {
+      svc.upsert(sampleRecord({ subject: "hello world" }));
+      expect(() => svc.search({ query: '"unterminated' })).not.toThrow();
+      expect(svc.search({ query: '"unterminated' })).toEqual([]);
+    });
+
+    it("swallows a bare unbalanced paren / column-filter garbage", () => {
+      svc.upsert(sampleRecord());
+      expect(() => svc.search({ query: "foo (((" })).not.toThrow();
+      expect(svc.search({ query: "foo (((" })).toEqual([]);
+      // Also exercise the allowedFolders SQL path.
+      expect(svc.search({ query: '"bad', allowedFolders: ["INBOX"] })).toEqual([]);
+    });
+
+    it("still returns hits for a well-formed query", () => {
+      svc.upsert(sampleRecord({ subject: "roadmap sync" }));
+      expect(svc.search({ query: "roadmap" }).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("PARSE-003 — rebuild is atomic", () => {
+    it("repopulates the index in a single transaction", () => {
+      svc.upsert(sampleRecord({ id: "old", subject: "stale entry" }));
+      const indexed = svc.rebuild([
+        sampleRecord({ id: "n1", subject: "fresh one" }),
+        sampleRecord({ id: "n2", subject: "fresh two" }),
+      ]);
+      expect(indexed).toBe(2);
+      expect(svc.stats().messageCount).toBe(2);
+      // Old record is gone; new ones are searchable.
+      expect(svc.search({ query: "stale" })).toEqual([]);
+      expect(svc.search({ query: "fresh" }).length).toBe(2);
+    });
+
+    it("leaves the prior index intact when a record throws mid-rebuild", () => {
+      svc.upsert(sampleRecord({ id: "keep", subject: "keep me" }));
+      // A record whose body is a non-string Buffer makes upsert's bound write
+      // throw; the transaction must roll back the DELETE.
+      const bad = sampleRecord({ id: "bad" });
+      (bad as { body: unknown }).body = Symbol("not bindable");
+      expect(() => svc.rebuild([bad])).toThrow();
+      expect(svc.stats().messageCount).toBe(1);
+      expect(svc.search({ query: "keep" }).length).toBe(1);
+    });
+  });
 });

--- a/src/services/fts-service.ts
+++ b/src/services/fts-service.ts
@@ -201,6 +201,47 @@ export class FtsIndexService {
     return res.changes > 0;
   }
 
+  /**
+   * Atomically clear the index and repopulate it from `records`. The clear and
+   * the bulk upsert run inside a single transaction, so a throw mid-rebuild
+   * (e.g. a malformed record) rolls the whole thing back and leaves the prior
+   * index intact rather than wiping it. Returns the number of records indexed.
+   *
+   * Callers must prefer this over a bare clear()+upsertMany() pair: a separate
+   * clear() commits immediately and a subsequent failure leaves an empty index
+   * (PARSE-003, audit-2026-05-28).
+   */
+  rebuild(records: FtsRecord[]): number {
+    const tx = this.db.transaction((batch: FtsRecord[]) => {
+      this.db.exec(`DELETE FROM messages`);
+      for (const r of batch) this.upsert(r);
+      return batch.length;
+    });
+    return tx(records);
+  }
+
+  /**
+   * Run a prepared FTS query, translating an FTS5 query-DSL syntax error into a
+   * clean empty result instead of letting better-sqlite3's SqliteError escape
+   * to the MCP client. The MATCH operand is a user-supplied query in FTS5's own
+   * mini-language (quotes, NEAR(), column filters, etc.); a stray `"` or `(`
+   * raises `fts5: syntax error near "..."`. SQL injection is already impossible
+   * (the operand is a bound parameter) — this only swallows malformed-DSL
+   * throws (PARSE-001, audit-2026-05-28). Any other error is re-thrown.
+   */
+  private runMatch(stmt: SqliteStatement, params: unknown[]): unknown[] {
+    try {
+      return stmt.all(...params) as unknown[];
+    } catch (err) {
+      const msg = (err as Error)?.message ?? "";
+      if (/fts5: syntax error|malformed MATCH|unterminated string/i.test(msg)) {
+        logger.debug(`FTS query syntax rejected: ${msg}`, "FtsIndexService");
+        return [];
+      }
+      throw err;
+    }
+  }
+
   search(opts: FtsSearchOptions): FtsHit[] {
     const limit = Math.min(Math.max(1, opts.limit ?? 20), 200);
     const folder = opts.folder?.trim();
@@ -237,11 +278,11 @@ export class FtsIndexService {
       const params: unknown[] = [opts.query, ...opts.allowedFolders];
       if (folder) params.push(folder);
       params.push(limit);
-      hits = stmt.all(...params) as unknown[];
+      hits = this.runMatch(stmt, params);
     } else {
       hits = folder
-        ? (this.stmts.searchFolder.all(opts.query, folder, limit) as unknown[])
-        : (this.stmts.searchAll.all(opts.query, limit) as unknown[]);
+        ? this.runMatch(this.stmts.searchFolder, [opts.query, folder, limit])
+        : this.runMatch(this.stmts.searchAll, [opts.query, limit]);
     }
     const rows = hits as Array<Record<string, unknown>>;
     let mapped: FtsHit[] = rows.map(r => ({


### PR DESCRIPTION
## Summary

Parser/analytics correctness batch closing the 2026-05-28 audit's DATA-PARSERS findings. Closes 15 of the 18 PARSE-* findings in scope (PARSE-002 was already resolved in v3.0.48; PARSE-014 is owned by the IMAP batch; PARSE-008/009 live in `simple-imap-service.ts` and are deferred to the IMAP batch). Scope is `fts-service.ts`, `analytics-service.ts`, `content-parser.ts`, and their tests.

**FTS (`fts-service.ts`)**
- **PARSE-001:** `search()` no longer throws on malformed FTS5 query syntax. A new `runMatch()` wrapper around every `.all()` call site catches FTS5 query-DSL syntax errors and returns a clean empty result; any other error is re-thrown. SQL injection was already impossible (bound parameter).
- **PARSE-003:** New `FtsIndexService.rebuild(records)` runs the `DELETE` + bulk upsert inside one `db.transaction`, rolling back to the prior index on any throw. (The `fts_rebuild` tool handler in `src/tools/reading.ts` should be switched from `clear()`+`upsertMany()` to `rebuild()` — flagged to the tools batch; out of this batch's ownership.)

**Analytics (`analytics-service.ts`)**
- **PARSE-004:** `processContacts()` processes sent recipients before inbox senders so the user's own most-frequent contacts survive the 10,000-contact cap.
- **PARSE-005/006 — TIME BASIS DECISION:** host-local time for **both** charts. Peak-activity-hours is inherently a human-experience metric and only reads correctly in local time; volume-trend day buckets were changed to match (via `localDateKey()`), with buckets seeded by walking back N *calendar* days so DST can't collapse/skip a day. No TZ library introduced; documented in a TIME BASIS comment.
- **PARSE-007:** `responseTimeStats.median` uses the even/odd convention (`[1,2,3,4] -> 2.5`).
- **PARSE-016:** Message-ID / `inReplyTo` normalized (strip surrounding `<>`) before keying, so `<abc@x.com>` matches `abc@x.com`.
- **PARSE-015:** `att.size` added as `?? 0` at both sites to avoid `NaN` in `storageUsedMB`/`totalSizeMB`.
- **PARSE-017:** `'gov'` de-duped across the TLD and compound-SLD lists; acronym TLDs (`edu`/`gov`/`mil`) upper-cased whole (`cdc.gov -> CDC`), compound `gov.uk` title-cased.

**Content parser (`content-parser.ts`)**
- **PARSE-010:** `splitProperty` returns a parameter map; `DTSTART;TZID=...` persisted on a new optional `Meeting.startTzid` (`start` stays the raw RFC 5545 string).
- **PARSE-011:** `BEGIN:VEVENT;X-...=BUSY` recognized via property name/value match (and `END:VEVENT;…` tolerated).
- **PARSE-012:** `unfoldLines` trims leading whitespace on the first line (not a fold continuation).
- **PARSE-013:** action-item body cap truncates on a UTF-8 `Buffer` so the 100 KB cap is honest in bytes for multibyte input.
- **PARSE-018:** action-item dedup key strips trailing `[.,;:!?]` so `Fix bug.`/`Fix bug!` collapse.
- **PARSE-019:** `BULLET_RE` recognizes `‣ ▪ ◦ ◾ ○ ▶ →` and the em-dash `—`.

## Verification

- `npm run typecheck` → clean.
- `npm test` → **1709 unit tests pass** (+18 new regression tests this batch across the three suites).
- `PRESHIP_NO_BRIDGE=1 npm run preship` → typecheck, lint, version-sync, secrets, npm-audit, license-inv, and **unit** all green.
  - The `e2e:greenmail` stage has pre-existing flaky failures in `actions.e2e.test.ts` / `folders.e2e.test.ts` / `deletion.e2e.test.ts` (IMAP flag/move/sync operations against the Greenmail container — `ECONNREFUSED 127.0.0.1:3143`). Verified these fail identically with this batch's source changes stashed, so they are unrelated to parser/analytics work and outside this batch's ownership. The analytics and search E2E scenarios (adjacent to this work) pass.

## Audit doc reconciliation

`docs/audit-2026-05-28.md` annotated inline:
- PARSE-001/003/004/005/006/007/010/011/012/013/015/016/017/018/019 → "Resolved in v3.0.54 — parser/analytics hardening."
- PARSE-008/009 → "Deferred — owned by the IMAP batch" (`stripHtml` lives in `simple-imap-service.ts`).

## Test plan

- [x] Type-check (`tsc --noEmit`)
- [x] Unit suite (1709 passes)
- [x] Targeted suites (`fts-service`, `analytics-service`, `content-parser` — 102 pass)
- [x] preship static stages (license-inv / npm-audit / secrets / version-sync) green
- [ ] Greenmail E2E — pre-existing flaky failures in IMAP action/folder/deletion suites (out of scope; verified unrelated)

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] No new attack surface (PARSE-001 *closes* an uncaught-exception surface)
- [x] Dependencies unchanged
- [x] No Docker / capability changes

## Needs a file outside this batch's ownership

- `src/tools/reading.ts` (`fts_rebuild` handler) should adopt `FtsIndexService.rebuild()` for the PARSE-003 fix to take full effect end-to-end — tools batch.
- `src/services/simple-imap-service.ts` `stripHtml` — PARSE-008 (entity-decode-before-strip order) and PARSE-009 (HTML-comment stripping) — IMAP batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
