### PR TITLE
fix(transport): OAuth/transport hardening — CSRF, clickjacking, redirect_uri allowlist (v3.0.56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.56] — 2026-05-30
+
+### Security — OAuth/transport hardening (audit 2026-05-28, batch M4)
+
+- **XPORT-001** — Static-bearer rate-limit bucket is now keyed per caller IP (`bearer:static:<ip>`) instead of a single global bucket, so one busy or malicious caller can no longer DoS every other legitimate user of the shared token.
+- **XPORT-003** — OAuth consent page now sets `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and a `frame-ancestors 'none'` CSP directive, blocking clickjacking of the Approve button.
+- **XPORT-006** — `oauth-handlers.ts` now reuses the exported `clientIp()` from the transport layer, so the OAuth rate-limit / IP-pin trust model matches the rest of the transport (XFF trusted only behind a loopback peer) instead of socket-only.
+- **XPORT-007** — The consent POST now re-runs the GET handler's `code_challenge` / `code_challenge_method` / `state` format checks, so a direct POST can no longer mint an auth code with an empty/malformed/plain (non-S256) challenge.
+- **XPORT-008** — Consent POST now requires a per-flow CSRF token (HMAC of `client_id` with a per-process secret, issued by the GET page) and rejects cross-site `Origin` headers, closing the password-known cross-site submission vector.
+- **XPORT-009** — DCR `redirect_uri` registration now enforces a scheme allowlist (https, http-loopback, custom native-app reverse-DNS scheme) and rejects `javascript:`/`data:`/`file:`/`blob:`/other schemes with `invalid_redirect_uri`.
+- **XPORT-015** — Startup now logs a high-severity warning when serving auth over plain HTTP on a non-loopback bind, and never advertises `0.0.0.0`/`::` as the OAuth issuer/resource host (falls back to loopback) so RFC 8414/9728 discovery doesn't break.
+
 ## [3.0.55] — 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.55-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.56-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -488,6 +488,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: All requests that authenticate with the configured `remoteBearerToken` are keyed as the literal string `"bearer:static"` for `authLimiter.take(tokenKey)`. The module header claims "the authed /mcp endpoint is rate-limited per token key so a compromised token can't DoS Bridge," but every legitimate user of the static bearer (CLI, phone, the dev's laptop, an MCP host) shares the same bucket. A single high-volume caller can lock out the others, and an attacker who steals the bearer can deliberately DoS the owner.
 - Repro hypothesis: With `remoteBearerToken=secret`, run `for i in $(seq 1 200); do curl -s -H 'Authorization: Bearer secret' -d '{}' http://127.0.0.1:8788/mcp & done` from one host — concurrent legitimate calls from another host begin to receive 429s within ~2 s.
 - Suggested next step: Key the auth limiter on `bearer:static:<clientIp>` so static-bearer callers get per-IP buckets while OAuth callers stay per-client.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** The static-bearer auth-limiter key is now `bearer:static:${caller}` (the XFF-aware `clientIp`), giving each caller its own bucket; a separate `isStaticBearer` flag carries the caller-context distinction.
 
 #### XPORT-003 — OAuth consent page lacks clickjacking protection
 - Location: `src/transports/oauth-handlers.ts:230-270, 393-450`
@@ -497,6 +498,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `handleAuthorizeGet` writes the consent HTML with `Content-Type: text/html` and the CSP `default-src 'none'; style-src 'unsafe-inline'; form-action 'self'`. CSP has no `frame-ancestors` directive, and no `X-Frame-Options` header is set. An attacker page can frame the consent screen and overlay UI tricking the admin into clicking "Approve" with their cached password autofilled. `src/settings/server.ts:534-536` sets `X-Frame-Options: DENY` on the settings UI — that protection wasn't carried over to OAuth.
 - Repro hypothesis: Host an `<iframe src="http://127.0.0.1:8788/oauth/authorize?...">` on a malicious LAN page with z-index overlays — the consent button is clickable through the overlay.
 - Suggested next step: Add `frame-ancestors 'none'` to the CSP and set `X-Frame-Options: DENY` + `X-Content-Type-Options: nosniff` on the consent response.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** Consent CSP now carries `frame-ancestors 'none'`; the GET response sets `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, and `Referrer-Policy: no-referrer`, mirroring the settings server.
 
 #### XPORT-006 — OAuth dispatch uses socket-only IP, mismatching the loopback-XFF model
 - Location: `src/transports/oauth-handlers.ts:101-106, 137-144`
@@ -506,6 +508,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `clientIp()` inside `oauth-handlers.ts` deliberately ignores `X-Forwarded-For`, but the rest of the transport (`src/transports/http.ts:134-151`) trusts XFF when the direct peer is loopback specifically so reverse-proxied deployments work. When `mailpouch` runs behind a localhost reverse proxy (Caddy/Cloudflare Tunnel as the docs encourage), every OAuth request appears to come from `127.0.0.1` and shares a single rate-limit bucket — the admin-password brute-force attempts from any attacker land in the same bucket as legitimate consent traffic. Conversely, the per-token IP pinning at `src/transports/http.ts:270-275` uses the XFF-aware caller, so a token issued during DCR will appear pinned to the *real* client IP and reject the *socket* IP later, breaking re-use under proxy.
 - Repro hypothesis: Run behind `caddy reverse_proxy`. Burst 50 OAuth `/oauth/register` calls from one external IP — confirm that the bucket key is `oauth:127.0.0.1` and legitimate users from other IPs are immediately throttled.
 - Suggested next step: Replace the local `clientIp` in `oauth-handlers.ts` with the exported one from `http.ts` so both paths agree on the trust model.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** The socket-only `clientIp` in `oauth-handlers.ts` was deleted; the module now imports and uses the exported `clientIp` from `http.ts`, so OAuth rate-limit keys and token IP-pinning use the same loopback-XFF trust model as the rest of the transport.
 
 #### XPORT-007 — POST `/oauth/authorize` trusts form-supplied `code_challenge`, `state`, `resource`
 - Location: `src/transports/oauth-handlers.ts:274-302`
@@ -515,6 +518,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `handleAuthorizeGet` carefully validates `code_challenge` format (43-128 base64url, S256 required) before rendering the form. `handleAuthorizePost` then reads `body.code_challenge`, `body.state`, `body.redirect_uri`, `body.resource` straight from the form body and writes them into the issued auth code with no re-validation — anyone with the admin password can POST directly to `/oauth/authorize` with an empty / malformed / plain (non-S256) challenge.
 - Repro hypothesis: `curl -X POST http://127.0.0.1:8788/oauth/authorize -d 'admin_password=...&client_id=valid&redirect_uri=valid&code_challenge=&state=&scope=mcp:full'` — the server still mints a code with an empty `codeChallenge`.
 - Suggested next step: Re-run the same format checks in `handleAuthorizePost` that the GET handler enforces, and bind the auth code to the values that were displayed on the consent page (e.g., HMAC the GET parameters into a hidden field).
+> **Resolved in v3.0.56 — OAuth/transport hardening.** `handleAuthorizePost` now re-runs the GET handler's `code_challenge_method` (S256), `code_challenge` format (shared `CODE_CHALLENGE_RE`), and `state` length checks before minting a code, so a direct POST can no longer mint a code with an empty/plain/malformed challenge.
 
 #### XPORT-008 — Consent POST has no Origin/Referer or CSRF check
 - Location: `src/transports/oauth-handlers.ts:274-311`
@@ -524,6 +528,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The consent form is unauthenticated until the password is typed, but the POST handler accepts any submission with a valid password — no `Origin`/`Referer` check, no per-form CSRF token. Combined with XPORT-002, a malicious in-browser context with knowledge of the admin password (e.g., a compromised browser extension or a phished form auto-filled by a password manager) can submit `/oauth/authorize` with an attacker-controlled `client_id` and `redirect_uri` without going through the GET page first.
 - Repro hypothesis: JavaScript on `http://attacker.local/` does `fetch('http://127.0.0.1:8788/oauth/authorize', {method:'POST', mode:'no-cors', credentials:'include', body:'admin_password=X&client_id=Y&redirect_uri=Z'})` — same-origin policy blocks reading the response but the auth code is issued and redirected to attacker.
 - Suggested next step: Require the GET to set an `HttpOnly`+`SameSite=Strict` cookie tying the consent decision to that browser, validate `Sec-Fetch-Site: same-origin`, and reject POSTs whose `Origin` header does not match the issuer.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** The GET consent page now embeds a per-flow CSRF token (`HMAC(client_id)` keyed by a per-process random secret), and `handleAuthorizePost` constant-time-verifies it plus rejects any cross-site `Origin` header before checking the password. A cross-site context cannot read the GET response to learn the token, so it cannot forge a submission even with the password.
 
 #### XPORT-009 — DCR `redirect_uri` accepts any URL scheme including `javascript:`/`data:`/`file:`
 - Location: `src/transports/oauth-handlers.ts:202-209, 304-308`
@@ -533,6 +538,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Registration validates `redirect_uris` only with `new URL(u)` which accepts `javascript:`, `data:`, `file:` and any custom scheme. The consent POST emits a 302 `Location:` to whatever scheme was registered. Most browsers refuse to navigate top-frame to `javascript:` via `Location:`, but `data:text/html,...` still loads with an opaque origin and `file://` can be used for local exfiltration on platforms that resolve it.
 - Repro hypothesis: `curl -X POST .../oauth/register -d '{"client_name":"x","redirect_uris":["javascript:alert(1)"]}'` — succeeds. Repeat with `data:text/html,<script>...</script>` — succeeds.
 - Suggested next step: Constrain registration to `http://localhost(:port)?/...`, `http://127.0.0.1...`, `https://...`, and well-known native-app loopback / custom-scheme patterns per the OAuth 2.1 native-apps BCP. Reject everything else with 400 `invalid_redirect_uri`.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** New `isAllowedRedirectUri()` enforces a scheme allowlist at DCR: `https` (any host), `http` for loopback hosts only (RFC 8252 §7.3), and reverse-DNS custom native-app schemes (RFC 8252 §7.1). `javascript:`/`data:`/`file:`/`blob:`/`vbscript:` and bare non-dotted schemes are rejected with 400 `invalid_redirect_uri`.
 
 #### XPORT-015 — Plain HTTP allowed with arbitrary bind host; no warning at startup
 - Location: `src/transports/http.ts:156-181`, `src/index.ts:2058-2073`
@@ -542,6 +548,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Nothing checks the combination of `host !== "127.0.0.1"` and missing TLS cert. The docstring hints "Use 0.0.0.0 for LAN exposure" but no warning fires when the operator binds publicly without TLS. Static bearer goes over the wire in plaintext; an OAuth `access_token` returned at `/oauth/token` does the same. The OAuth issuer URL is derived as `http://0.0.0.0:8788` in that case — `0.0.0.0` is unroutable but lands in the RFC 8414 metadata, breaking the protected-resource discovery for any well-behaved MCP host.
 - Repro hypothesis: Set `remoteHost: "0.0.0.0", remoteMode: true, remoteBearerToken: "x"` with no TLS — server starts; `/.well-known/oauth-authorization-server` reports `issuer: "http://0.0.0.0:8788"`.
 - Suggested next step: At startup, log a high-severity warning (or refuse to start unless an `allowPlainHttpRemote` opt-in is set) when `host` is not loopback and `tlsCertPath`/`tlsKeyPath` are absent; reject `0.0.0.0` as an issuer host.
+> **Resolved in v3.0.56 — OAuth/transport hardening.** `startHttpTransport` now logs a high-severity warning when serving auth over plain HTTP on a non-loopback bind (warn, not refuse — TLS-terminating proxies bind `0.0.0.0` legitimately), and substitutes loopback for `0.0.0.0`/`::` when deriving the issuer host so the RFC 8414/9728 metadata never advertises a wildcard address.
 
 #### XPORT-004 — Token endpoint leaks resource/redirect/PKCE-mismatch via `invalid_target`
 - Location: `src/transports/oauth-handlers.ts:343-359`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.55",
+      "version": "3.0.56",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -77,6 +77,53 @@ describe("clientIp — X-Forwarded-For trust model", () => {
   });
 });
 
+describe("XPORT-001 — static bearer rate bucket is keyed per caller IP", () => {
+  let handle: HttpTransportHandle | null = null;
+  afterEach(async () => { if (handle) { await handle.close(); handle = null; } });
+
+  it("does not let one IP's bursts exhaust another IP's bucket", async () => {
+    // The auth limiter is keyed `bearer:static:<ip>`. We drive two distinct
+    // XFF values through the loopback peer — clientIp() trusts XFF on loopback
+    // — and assert each XFF identity gets its own bucket.
+    const port = await freePort();
+    handle = await startHttpTransport({
+      server: buildServer(),
+      port,
+      host: "127.0.0.1",
+      bearerToken: "secret",
+      rateLimitPerSecond: 1,
+      rateLimitBurst: 2, // authed cap ≈ 6 per key
+    });
+    const hammer = (xff: string) =>
+      Promise.all(Array.from({ length: 15 }, () =>
+        fetch(`http://127.0.0.1:${port}/mcp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            Authorization: "Bearer secret",
+            "X-Forwarded-For": xff,
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+        }),
+      ));
+    const a = await hammer("203.0.113.10");
+    expect(a.map(r => r.status)).toContain(429);
+    // Caller B's first request must NOT be a 429 — its bucket is independent.
+    const b = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer secret",
+        "X-Forwarded-For": "203.0.113.20",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "b", version: "0" } } }),
+    });
+    expect(b.status).not.toBe(429);
+  });
+});
+
 describe("HTTP transport", () => {
   let handle: HttpTransportHandle | null = null;
 
@@ -169,6 +216,21 @@ describe("HTTP transport", () => {
     ).rejects.toThrow(/remoteBearerToken/);
   });
 
+  it("XPORT-015 — never advertises 0.0.0.0 as the OAuth issuer host", async () => {
+    const port = await freePort();
+    handle = await startHttpTransport({
+      server: buildServer(),
+      port,
+      host: "0.0.0.0",
+      bearerToken: "",
+      oauthEnabled: true,
+      oauthAdminPassword: "admin-pw",
+    });
+    expect(handle.issuer).toBeDefined();
+    expect(handle.issuer).not.toContain("0.0.0.0");
+    expect(handle.issuer).toContain("127.0.0.1");
+  });
+
   it("dispatches an authed tools/list round-trip through the MCP transport", async () => {
     const port = await freePort();
     handle = await startHttpTransport({
@@ -259,6 +321,20 @@ describe("HTTP transport", () => {
       expect(res.status).toBe(400);
     });
 
+    // XPORT-008: the consent POST now requires a CSRF token issued by the GET
+    // consent page (bound to the client_id). Harvest it for an existing client.
+    async function csrfFor(url: string, clientId: string, redirectUri = "http://localhost:9999/cb"): Promise<string> {
+      const q = new URLSearchParams({
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code_challenge: "x".repeat(43),
+        code_challenge_method: "S256",
+      });
+      const res = await fetch(`${url}/oauth/authorize?${q.toString()}`);
+      const html = await res.text();
+      return /name="csrf_token" value="([^"]+)"/.exec(html)?.[1] ?? "";
+    }
+
     it("completes an end-to-end PKCE flow: register → authorize → token → /mcp", async () => {
       const { url } = await startOauth();
       // 1. DCR
@@ -278,10 +354,11 @@ describe("HTTP transport", () => {
       const verifier = rb(32).toString("base64url");
       const challenge = createHash("sha256").update(verifier).digest("base64url");
 
-      // 3. Consent submit (skips the GET HTML page).
+      // 3. Consent submit (harvest the CSRF token from the GET page first).
+      const csrf = await csrfFor(url, client.client_id);
       const consent = await fetch(`${url}/oauth/authorize`, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
         body: new URLSearchParams({
           client_id: client.client_id,
           redirect_uri: "http://localhost:9999/cb",
@@ -289,6 +366,7 @@ describe("HTTP transport", () => {
           state: "xyz",
           scope: "mcp:full",
           admin_password: "admin-pw",
+          csrf_token: csrf,
         }).toString(),
         redirect: "manual",
       });
@@ -345,14 +423,16 @@ describe("HTTP transport", () => {
       });
       const client = await reg.json() as { client_id: string };
 
+      const csrf = await csrfFor(url, client.client_id);
       const res = await fetch(`${url}/oauth/authorize`, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
         body: new URLSearchParams({
           client_id: client.client_id,
           redirect_uri: "http://localhost:9999/cb",
           code_challenge: "x".repeat(43),
           admin_password: "wrong",
+          csrf_token: csrf,
         }).toString(),
         redirect: "manual",
       });
@@ -370,14 +450,16 @@ describe("HTTP transport", () => {
       const { createHash: h, randomBytes: rb2 } = await import("crypto");
       const verifier = rb2(32).toString("base64url");
       const challenge = h("sha256").update(verifier).digest("base64url");
+      const csrf = await csrfFor(url, client.client_id);
       const consent = await fetch(`${url}/oauth/authorize`, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
         body: new URLSearchParams({
           client_id: client.client_id,
           redirect_uri: "http://localhost:9999/cb",
           code_challenge: challenge,
           admin_password: "admin-pw",
+          csrf_token: csrf,
         }).toString(),
         redirect: "manual",
       });
@@ -417,6 +499,149 @@ describe("HTTP transport", () => {
       const html = await res.text();
       expect(html).toContain("Authorize mailpouch");
       expect(html).toContain("Inky");
+    });
+
+    // Helper: register a client and GET the consent page; return the form's
+    // hidden CSRF token (XPORT-008) parsed out of the HTML.
+    async function getConsent(url: string, redirectUri = "http://localhost:9999/cb"): Promise<{ clientId: string; csrf: string; challenge: string; verifier: string }> {
+      const reg = await fetch(`${url}/oauth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ redirect_uris: [redirectUri] }),
+      });
+      const client = await reg.json() as { client_id: string };
+      const { createHash, randomBytes: rb } = await import("crypto");
+      const verifier = rb(32).toString("base64url");
+      const challenge = createHash("sha256").update(verifier).digest("base64url");
+      const q = new URLSearchParams({
+        client_id: client.client_id,
+        redirect_uri: redirectUri,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      });
+      const res = await fetch(`${url}/oauth/authorize?${q.toString()}`);
+      const html = await res.text();
+      const m = /name="csrf_token" value="([^"]+)"/.exec(html);
+      return { clientId: client.client_id, csrf: m?.[1] ?? "", challenge, verifier };
+    }
+
+    it("XPORT-003 — GET consent page sets clickjacking headers + frame-ancestors CSP", async () => {
+      const { url } = await startOauth();
+      const reg = await fetch(`${url}/oauth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ redirect_uris: ["http://localhost:9999/cb"] }),
+      });
+      const client = await reg.json() as { client_id: string };
+      const q = new URLSearchParams({
+        client_id: client.client_id,
+        redirect_uri: "http://localhost:9999/cb",
+        code_challenge: "x".repeat(43),
+        code_challenge_method: "S256",
+      });
+      const res = await fetch(`${url}/oauth/authorize?${q.toString()}`);
+      expect(res.headers.get("x-frame-options")).toBe("DENY");
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      const html = await res.text();
+      expect(html).toContain("frame-ancestors 'none'");
+    });
+
+    it("XPORT-008 — consent POST is rejected without a valid CSRF token", async () => {
+      const { url } = await startOauth();
+      const { clientId, challenge } = await getConsent(url);
+      const res = await fetch(`${url}/oauth/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: "http://localhost:9999/cb",
+          code_challenge: challenge,
+          admin_password: "admin-pw",
+          // no csrf_token
+        }).toString(),
+        redirect: "manual",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("XPORT-008 — consent POST with the GET-issued CSRF token succeeds", async () => {
+      const { url } = await startOauth();
+      const { clientId, csrf, challenge } = await getConsent(url);
+      expect(csrf).toBeTruthy();
+      const res = await fetch(`${url}/oauth/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
+        body: new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: "http://localhost:9999/cb",
+          code_challenge: challenge,
+          admin_password: "admin-pw",
+          csrf_token: csrf,
+        }).toString(),
+        redirect: "manual",
+      });
+      expect(res.status).toBe(302);
+    });
+
+    it("XPORT-008 — consent POST is rejected when Origin is cross-site", async () => {
+      const { url } = await startOauth();
+      const { clientId, csrf, challenge } = await getConsent(url);
+      const res = await fetch(`${url}/oauth/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: "http://attacker.local" },
+        body: new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: "http://localhost:9999/cb",
+          code_challenge: challenge,
+          admin_password: "admin-pw",
+          csrf_token: csrf,
+        }).toString(),
+        redirect: "manual",
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("XPORT-007 — consent POST re-validates the code_challenge format", async () => {
+      const { url } = await startOauth();
+      const { clientId, csrf } = await getConsent(url);
+      const res = await fetch(`${url}/oauth/authorize`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
+        body: new URLSearchParams({
+          client_id: clientId,
+          redirect_uri: "http://localhost:9999/cb",
+          code_challenge: "", // malformed / empty — GET would have rejected this
+          admin_password: "admin-pw",
+          csrf_token: csrf,
+        }).toString(),
+        redirect: "manual",
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("XPORT-009 — DCR rejects javascript:/data:/file: redirect_uri schemes", async () => {
+      const { url } = await startOauth();
+      for (const bad of ["javascript:alert(1)", "data:text/html,<script>1</script>", "file:///etc/passwd", "ftp://x/cb"]) {
+        const res = await fetch(`${url}/oauth/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ redirect_uris: [bad] }),
+        });
+        expect(res.status, `scheme ${bad} should be rejected`).toBe(400);
+        expect((await res.json() as { error: string }).error).toBe("invalid_redirect_uri");
+      }
+    });
+
+    it("XPORT-009 — DCR still accepts loopback http + https + custom native schemes", async () => {
+      const { url } = await startOauth();
+      for (const ok of ["http://localhost:9999/cb", "http://127.0.0.1:5000/cb", "https://app.example.com/cb", "com.example.app:/oauth/callback"]) {
+        const res = await fetch(`${url}/oauth/register`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ redirect_uris: [ok] }),
+        });
+        expect(res.status, `scheme ${ok} should be accepted`).toBe(201);
+      }
     });
 
     it("returns WWW-Authenticate pointing to the resource-metadata doc when OAuth is on", async () => {
@@ -503,14 +728,16 @@ describe("HTTP transport", () => {
       const { createHash, randomBytes: rb } = await import("crypto");
       const verifier = rb(32).toString("base64url");
       const challenge = createHash("sha256").update(verifier).digest("base64url");
+      const csrf = await csrfFor(url, client.client_id, "http://localhost:9998/cb");
       const consent = await fetch(`${url}/oauth/authorize`, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: url },
         body: new URLSearchParams({
           client_id: client.client_id,
           redirect_uri: "http://localhost:9998/cb",
           code_challenge: challenge,
           admin_password: "admin-pw",
+          csrf_token: csrf,
         }).toString(),
         redirect: "manual",
       });
@@ -623,15 +850,17 @@ describe("HTTP transport", () => {
       const verifier = rb(32).toString("base64url");
       const challenge = createHash("sha256").update(verifier).digest("base64url");
       // Authorize with a foreign resource URI.
+      const csrf = await csrfFor(baseUrl, client.client_id, "http://localhost:9998/cb");
       const consent = await fetch(`${baseUrl}/oauth/authorize`, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Origin: baseUrl },
         body: new URLSearchParams({
           client_id: client.client_id,
           redirect_uri: "http://localhost:9998/cb",
           code_challenge: challenge,
           resource: "https://other.example.com/mcp",
           admin_password: "admin-pw",
+          csrf_token: csrf,
         }).toString(),
         redirect: "manual",
       });

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -542,6 +542,8 @@ describe("HTTP transport", () => {
       const res = await fetch(`${url}/oauth/authorize?${q.toString()}`);
       expect(res.headers.get("x-frame-options")).toBe("DENY");
       expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      // frame-ancestors is only honoured as an HTTP header, not in a <meta> tag.
+      expect(res.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
       const html = await res.text();
       expect(html).toContain("frame-ancestors 'none'");
     });

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -177,7 +177,29 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
 
   // OAuth state (only populated when enabled).
   const scheme = opts.tlsCertPath && opts.tlsKeyPath ? "https" : "http";
-  const derivedIssuer = `${scheme}://${host}:${opts.port}`;
+
+  // XPORT-015: serving auth (static bearer or OAuth tokens) over plain HTTP on
+  // a non-loopback bind sends credentials across the wire in cleartext. We
+  // don't hard-refuse (some operators front the listener with a TLS-terminating
+  // proxy and bind 0.0.0.0 behind it), but we log a loud warning so an
+  // unintentional public-cleartext deployment is obvious in the logs.
+  const isLoopbackBind = host === "127.0.0.1" || host === "::1" || host === "localhost";
+  if (scheme === "http" && !isLoopbackBind) {
+    logger.warn(
+      `Serving authentication over PLAIN HTTP on a non-loopback bind (${host}:${opts.port}). ` +
+      `Bearer tokens and OAuth access tokens will cross the network in cleartext. ` +
+      `Configure remoteTlsCertPath/remoteTlsKeyPath, bind to 127.0.0.1, or front the ` +
+      `listener with a TLS-terminating reverse proxy.`,
+      "HttpTransport",
+    );
+  }
+
+  // XPORT-015: 0.0.0.0 is a wildcard bind address, not a routable host — it must
+  // never appear in the RFC 8414 issuer / RFC 9728 resource metadata or every
+  // well-behaved MCP host's discovery breaks. When no explicit issuer is set and
+  // we'd otherwise derive 0.0.0.0, substitute loopback for the advertised URL.
+  const issuerHost = host === "0.0.0.0" || host === "::" ? "127.0.0.1" : host;
+  const derivedIssuer = `${scheme}://${issuerHost}:${opts.port}`;
   const issuer = opts.oauthIssuer ?? derivedIssuer;
   const oauthStore = new OAuthStore();
   // Invalidate outstanding access tokens immediately when a grant transitions
@@ -245,12 +267,18 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
     const caller = clientIp(req);
     let tokenKey: string | null = null;
     let ok = false;
+    let isStaticBearer = false;
     let callerClientId = "bearer:static";
     let callerClientName = "Static bearer";
 
     if (token && opts.bearerToken && tokenMatches(token, opts.bearerToken)) {
       ok = true;
-      tokenKey = "bearer:static";
+      isStaticBearer = true;
+      // XPORT-001: key the static-bearer rate bucket per caller IP, not a
+      // single global "bearer:static" string. Otherwise every legitimate
+      // user of the shared token (CLI, phone, laptop) competes for one
+      // bucket and a single busy — or malicious — caller DoSes the rest.
+      tokenKey = `bearer:static:${caller}`;
     } else if (token && oauthHandlers) {
       const rec = oauthStore.verifyToken(token);
       if (rec) {
@@ -310,8 +338,8 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
         {
           clientId: callerClientId,
           clientName: callerClientName,
-          ip: clientIp(req),
-          staticBearer: tokenKey === "bearer:static",
+          ip: caller,
+          staticBearer: isStaticBearer,
         },
         async () => { await transport.handleRequest(req, res, body); },
       );

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -23,9 +23,10 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import { createHash } from "crypto";
+import { createHash, createHmac, randomBytes } from "crypto";
 import { OAuthStore } from "./oauth-store.js";
 import { TokenBucketLimiter } from "./rate-limit.js";
+import { clientIp } from "./http.js";
 import { logger } from "../utils/logger.js";
 import { constantTimeEqual } from "../utils/crypto.js";
 
@@ -33,6 +34,35 @@ const SCOPES = ["mcp:full"] as const;
 
 /** XPORT-002 max client_name length on the DCR registration record. */
 const DCR_CLIENT_NAME_MAX = 100;
+
+/** RFC 7636 §4.2 code_challenge shape — base64url, 43–128 chars. */
+const CODE_CHALLENGE_RE = /^[A-Za-z0-9_\-.~]{43,128}$/;
+
+/**
+ * XPORT-009: redirect_uri scheme allowlist. The DCR endpoint is public, so a
+ * `new URL(u)` parse alone accepts `javascript:`, `data:`, `file:` and any
+ * custom scheme; those then land in a 302 `Location:` after consent. We permit
+ * exactly the OAuth 2.1 native-apps BCP set:
+ *   - https (any host)
+ *   - http ONLY for loopback (localhost / 127.0.0.1 / ::1) — RFC 8252 §7.3
+ *   - a custom (reverse-DNS) private-use scheme for native apps, RFC 8252 §7.1
+ * Everything else (javascript:/data:/file:/ftp:/…) is rejected.
+ */
+function isAllowedRedirectUri(raw: string): boolean {
+  let u: URL;
+  try { u = new URL(raw); } catch { return false; }
+  if (u.protocol === "https:") return true;
+  if (u.protocol === "http:") {
+    const h = u.hostname.toLowerCase();
+    return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]";
+  }
+  // Private-use / custom native-app scheme (e.g. "com.example.app:/cb").
+  // Reject the dangerous well-knowns explicitly; require a reverse-DNS-style
+  // scheme containing a dot so a bare "evil:" can't slip through.
+  const scheme = u.protocol.replace(/:$/, "");
+  if (scheme === "javascript" || scheme === "data" || scheme === "file" || scheme === "blob" || scheme === "vbscript") return false;
+  return /^[a-z][a-z0-9+.-]*\.[a-z][a-z0-9+.-]*$/.test(scheme);
+}
 
 /**
  * Strip control characters / ANSI escapes and length-cap a DCR-supplied
@@ -120,13 +150,6 @@ function verifyPkceS256(verifier: string, challenge: string): boolean {
 // Constant-time string compare imported from ../utils/crypto.
 const safeEqual = constantTimeEqual;
 
-/** Client IP extraction — trust X-Forwarded-For only when the caller is loopback. */
-function clientIp(req: IncomingMessage): string {
-  const remote = req.socket.remoteAddress ?? "0.0.0.0";
-  // Don't let arbitrary X-Forwarded-For headers bypass the rate limit.
-  return remote;
-}
-
 export interface OAuthHandlerResult {
   /** True when the handler has already written a response. */
   handled: boolean;
@@ -137,6 +160,14 @@ export class OAuthHandlers {
   private readonly cfg: OAuthEndpointsConfig;
   private readonly limiter: TokenBucketLimiter;
   private readonly onClientRegistered?: (c: { client_id: string; client_name?: string }) => void;
+  /**
+   * XPORT-008: per-process secret used to HMAC the consent CSRF token. The
+   * token has no server-side state — it is `HMAC(client_id)` minted by the GET
+   * consent page and required (constant-time compared) on the POST. A
+   * cross-site form on attacker.local cannot read the GET response to learn the
+   * token, so it cannot forge a valid submission even if it knows the password.
+   */
+  private readonly csrfSecret = randomBytes(32);
 
   constructor(
     store: OAuthStore,
@@ -149,6 +180,29 @@ export class OAuthHandlers {
     this.limiter = limiter;
     this.onClientRegistered = onClientRegistered;
     if (!cfg.adminPassword) throw new Error("OAuth admin password is required");
+  }
+
+  /** XPORT-008: mint a CSRF token bound to the client_id of this consent flow. */
+  private mintCsrfToken(clientId: string): string {
+    return createHmac("sha256", this.csrfSecret).update(clientId).digest("base64url");
+  }
+
+  /** XPORT-008: constant-time verify a CSRF token against the expected client_id. */
+  private verifyCsrfToken(token: string, clientId: string): boolean {
+    return constantTimeEqual(token, this.mintCsrfToken(clientId));
+  }
+
+  /**
+   * XPORT-008: reject state-changing POSTs whose Origin is cross-site. The
+   * consent form is same-origin (`form-action 'self'`); a present Origin that
+   * doesn't match the issuer means a cross-site submission. A missing Origin is
+   * allowed through (some same-origin form posts omit it) — the CSRF token is
+   * the primary defence; the Origin check is belt-and-suspenders.
+   */
+  private originAllowed(req: IncomingMessage): boolean {
+    const origin = req.headers["origin"];
+    if (!origin || typeof origin !== "string") return true;
+    return origin === this.cfg.issuer;
   }
 
   /**
@@ -224,8 +278,11 @@ export class OAuthHandlers {
     const uris = Array.isArray(body.redirect_uris) ? (body.redirect_uris as string[]) : [];
     if (uris.length === 0) { error(res, 400, "invalid_redirect_uri", "At least one redirect_uri is required."); return { handled: true }; }
     for (const u of uris) {
-      try { new URL(u); } catch {
-        error(res, 400, "invalid_redirect_uri", `redirect_uri ${u} is not a valid URL.`);
+      // XPORT-009: parse AND scheme-allowlist. `new URL` alone accepts
+      // javascript:/data:/file: and arbitrary schemes that would later be
+      // emitted in a 302 Location after consent.
+      if (typeof u !== "string" || !isAllowedRedirectUri(u)) {
+        error(res, 400, "invalid_redirect_uri", `redirect_uri ${u} uses an unsupported scheme. Allowed: https, http loopback, or a custom native-app scheme.`);
         return { handled: true };
       }
     }
@@ -283,7 +340,7 @@ export class OAuthHandlers {
     // RFC 7636 §4.2: code_challenge is base64url(SHA256(verifier)), which is
     // exactly 43 chars of URL-safe alphabet. Reject anything longer or with
     // non-base64url characters.
-    if (!codeChallenge || !/^[A-Za-z0-9_\-.~]{43,128}$/.test(codeChallenge)) {
+    if (!CODE_CHALLENGE_RE.test(codeChallenge)) {
       error(res, 400, "invalid_request", "code_challenge must be 43–128 chars of base64url alphabet.");
       return { handled: true };
     }
@@ -303,10 +360,18 @@ export class OAuthHandlers {
       resource,
       scope,
       isUntrustedDcrClient,
+      csrfToken: this.mintCsrfToken(clientId),
     });
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("Cache-Control", "no-store");
+    // XPORT-003: clickjacking protection on the consent screen. The CSP gets a
+    // `frame-ancestors 'none'` (set inside consentPage), and we mirror the
+    // settings-server header set so framing/sniffing are blocked even on
+    // browsers that don't honour the meta CSP.
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Referrer-Policy", "no-referrer");
     res.end(html);
     return { handled: true };
   }
@@ -321,21 +386,45 @@ export class OAuthHandlers {
       error(res, 400, "invalid_request", "Could not parse form body."); return { handled: true };
     }
 
+    // XPORT-008: reject cross-site submissions and forged posts before the
+    // password is even examined. The CSRF token is bound to client_id and was
+    // minted by the GET consent page; a cross-site context cannot read it.
+    const clientId = body.client_id ?? "";
+    if (!this.originAllowed(req)) {
+      error(res, 403, "access_denied", "Cross-site form submission rejected.");
+      return { handled: true };
+    }
+    if (!this.verifyCsrfToken(body.csrf_token ?? "", clientId)) {
+      error(res, 403, "access_denied", "Missing or invalid CSRF token. Reload the consent page.");
+      return { handled: true };
+    }
+
     if (!safeEqual(body.admin_password ?? "", this.cfg.adminPassword)) {
       error(res, 403, "access_denied", "Incorrect admin password.");
       return { handled: true };
     }
 
-    const client = this.store.getClient(body.client_id ?? "");
+    const client = this.store.getClient(clientId);
     if (!client) { error(res, 400, "invalid_client", "Unknown client_id."); return { handled: true }; }
     const redirectUri = body.redirect_uri ?? "";
     if (!client.redirect_uris.includes(redirectUri)) { error(res, 400, "invalid_redirect_uri"); return { handled: true }; }
+
+    // XPORT-007: re-run the same format checks the GET handler enforced. A
+    // direct POST (bypassing the consent GET) must not be able to mint a code
+    // with an empty/malformed/plain challenge or an oversized state.
+    const method = body.code_challenge_method ?? "S256";
+    if (method !== "S256") { error(res, 400, "invalid_request", "PKCE S256 is required."); return { handled: true }; }
+    const codeChallenge = body.code_challenge ?? "";
+    if (!CODE_CHALLENGE_RE.test(codeChallenge)) {
+      error(res, 400, "invalid_request", "code_challenge must be 43–128 chars of base64url alphabet.");
+      return { handled: true };
+    }
     if (body.state && body.state.length > 500) { error(res, 400, "invalid_request", "state parameter exceeds 500 chars."); return { handled: true }; }
 
     const rec = this.store.issueAuthCode({
       clientId: client.client_id,
       redirectUri,
-      codeChallenge: body.code_challenge ?? "",
+      codeChallenge,
       codeChallengeMethod: "S256",
       scopes: (body.scope ?? SCOPES.join(" ")).split(/\s+/).filter(Boolean),
       resource: body.resource || undefined,
@@ -441,6 +530,7 @@ export class OAuthHandlers {
     resource: string;
     scope: string;
     isUntrustedDcrClient?: boolean;
+    csrfToken: string;
   }): string {
     // Strict 5-replacement HTML escape — handles both attribute-context
     // and body-text contexts safely. The previous 3-replacement form
@@ -457,7 +547,7 @@ export class OAuthHandlers {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; form-action 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'">
     <title>mailpouch — authorize</title>
     <style>
       body { font-family: system-ui, sans-serif; background: #111; color: #eee; margin: 0; padding: 40px; }
@@ -490,6 +580,7 @@ export class OAuthHandlers {
         ${ctx.resource ? `<dt>Resource</dt><dd>${esc(ctx.resource)}</dd>` : ""}
       </dl>
       <form method="POST" action="/oauth/authorize">
+        <input type="hidden" name="csrf_token" value="${esc(ctx.csrfToken)}">
         <input type="hidden" name="client_id" value="${esc(ctx.clientId)}">
         <input type="hidden" name="redirect_uri" value="${esc(ctx.redirectUri)}">
         <input type="hidden" name="code_challenge" value="${esc(ctx.codeChallenge)}">

--- a/src/transports/oauth-handlers.ts
+++ b/src/transports/oauth-handlers.ts
@@ -365,10 +365,14 @@ export class OAuthHandlers {
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.setHeader("Cache-Control", "no-store");
-    // XPORT-003: clickjacking protection on the consent screen. The CSP gets a
-    // `frame-ancestors 'none'` (set inside consentPage), and we mirror the
-    // settings-server header set so framing/sniffing are blocked even on
-    // browsers that don't honour the meta CSP.
+    // XPORT-003: clickjacking protection on the consent screen. `frame-ancestors`
+    // is honoured only when CSP arrives as an HTTP header (it is ignored in a
+    // `<meta http-equiv>` tag), so we send the policy as a real response header
+    // here; X-Frame-Options: DENY covers legacy browsers that predate CSP2.
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'",
+    );
     res.setHeader("X-Frame-Options", "DENY");
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("Referrer-Policy", "no-referrer");


### PR DESCRIPTION
## Batch M4 — OAuth/transport hardening (audit 2026-05-28)

Closes seven `XPORT` findings. **DO NOT MERGE** without review.

### Findings closed
- **XPORT-001** — Static-bearer rate-limit bucket keyed per caller IP (`bearer:static:<ip>`) instead of one global bucket; one busy/malicious caller can no longer DoS other users of the shared token.
- **XPORT-003** — Consent page sets `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, and `frame-ancestors 'none'` CSP — blocks clickjacking.
- **XPORT-006** — `oauth-handlers.ts` now imports/uses the exported `clientIp()` from `http.ts`; OAuth rate-limit and token IP-pinning use the same loopback-XFF trust model as the rest of the transport.
- **XPORT-007** — `handleAuthorizePost` re-runs the GET handler's `code_challenge` / `code_challenge_method` / `state` format checks; a direct POST can't mint a code with an empty/plain/malformed challenge.
- **XPORT-008** — Consent POST requires a per-flow CSRF token (`HMAC(client_id)` with a per-process secret, issued by the GET page) and rejects cross-site `Origin` headers.
- **XPORT-009** — DCR `redirect_uri` scheme allowlist (https / http-loopback / reverse-DNS native scheme); `javascript:`/`data:`/`file:`/`blob:`/`vbscript:` rejected with `invalid_redirect_uri`.
- **XPORT-015** — Plain-HTTP-on-non-loopback startup warning; `0.0.0.0`/`::` never advertised as the OAuth issuer/resource host (falls back to loopback).

### Built on prior work
- **XPORT-002** (DCR `client_name` sanitization + "Untrusted client" badge) was closed in v3.0.50 (#145). Untouched; the new CSRF/format work builds on the existing consent flow and `esc()` helper.

### Verification
- `npm run typecheck` — clean
- Targeted `src/transports/{http,oauth-handlers}.test.ts` — 51 passed (new regression tests: per-caller bucket isolation, frame-ancestors/X-Frame-Options headers, CSRF required + Origin enforced, code_challenge re-validation, redirect_uri scheme allow/deny, no-0.0.0.0 issuer)
- `npm test` — 1762 passed (49 files)
- `PRESHIP_NO_BRIDGE=1 npm run preship:fast` — PASS (typecheck, lint, version-sync, secrets, npm-audit, license-inv, build, unit)

### Rollback
Revert this single commit (`e21b0bd`). All changes are confined to the two transport source files + their test, plus version/docs metadata; the OAuth/DCR protocol surface and settings UI are unchanged in behavior for legitimate flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)