### PR TITLE
fix(persistence): atomic scheduler/reminder writes + config file-lock (v3.0.55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.55] — 2026-05-30
+
+### Fixed
+Persistence-atomicity batch from the 2026-05-28 audit (SMTP-003/004/005/006/007, CRED-008, UI-005). Scope: `scheduler.ts`, `reminder-service.ts`, `config/loader.ts`, `accounts/registry.ts`, `index.ts`.
+
+- **Scheduler retries now back off per item** (SMTP-003). A failed send sets `nextAttemptAt = now + exp_backoff(retryCount)` (60s → 120s → … capped at 30m); `processDue()` skips items whose `nextAttemptAt` is still in the future, so a brief Bridge outage no longer re-burns every pending item on every 60s poll tick.
+- **Scheduler persists after each item's status flip** (SMTP-004). `persist()` now runs after every per-item terminal/retry transition, not only at the end of the batch loop, so a crash mid-loop cannot leave an already-sent item recorded as `pending` and re-send it (non-idempotent SMTP) on restart.
+- **Reminder writes use a same-filesystem temp file** (SMTP-005). `persist()` builds the temp path as `${this.path}.<rand>.tmp` (sibling of the store) instead of `tmpdir()`, so `rename(2)` stays atomic and no longer fails `EXDEV` on containerised / NFS-home installs where `$HOME` and `/tmp` are on different mounts.
+- **Reminder persist failures roll back in-memory state** (SMTP-006). Every mutating method snapshots `reminders` before mutating and routes the write through `persistOrRollback()`, which on a write failure restores the snapshot, logs at error level, and re-throws — so a failed write can never later be flushed as a half-baked mutation.
+- **`scanDue()` commits the fired transition before returning** (SMTP-007, partially-addressed). The `pending → fired` flip is now persisted (and rolled back atomically on failure) before the due list is returned, closing the partial-write window. The at-least-once delivery limitation (a dropped MCP response after a successful persist) remains by design pending a dedicated acknowledge tool — see the audit note cross-referencing SMTP-006.
+- **Config read-modify-write is serialized with an exclusive file lock** (CRED-008). `saveConfig` and `writeRegistry` now take an `O_EXCL` lock on `${config}.lock` (with stale-lock reclamation, reentrancy, and always-release-in-finally) plus an in-process async mutex, so racing settings-UI POSTs / registry writes can no longer clobber each other. No new dependency.
+- **Tray "Open Settings" item is gated on a live settings URL** (UI-005). Verified already in place: the tray entry is only built when `_settingsEnabled && _settingsUrl`, so a failed UI bind no longer shows a dead menu item.
+
 ## [3.0.54] — 2026-05-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.54-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.55-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -309,6 +309,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: When `sendEmail` returns `{success:false}` for a transient reason that is not classified by `isTransientAbuseError` (e.g. DNS hiccup, connection reset), `processDue` increments `retryCount` and leaves status `"pending"`. The next `setInterval` tick (60 s later) re-tries. There is no per-item next-attempt delay — if 50 items are pending and Bridge is briefly down, every cycle re-burns all 50 through `sendEmail` in a tight for-loop. Combined with SMTP-service-level `BackoffTracker` only firing on abuse-coded errors, a generic transient blast will hammer Bridge once per minute until the 3-attempt cap is hit.
 - Repro hypothesis: stop Bridge; schedule 20 due items; observe 20 connect attempts per minute against the down Bridge.
 - Suggested next step: store `nextAttemptAt` on each item, set to `now + exp_backoff(retryCount)`; skip items whose `nextAttemptAt > now`.
+> **Resolved in v3.0.55 — persistence atomicity.** Added `nextAttemptAt` (exp backoff 60s→…→30m cap) on each failed send; `processDue()` skips items whose `nextAttemptAt > now`, and clears it on success.
 
 #### SMTP-004 — `retryCount` bumped before send actually fails to commit, but `persist()` only fires after the whole loop
 - Location: `src/services/scheduler.ts:174-207`
@@ -318,6 +319,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `processDue` mutates `item.status`, `item.retryCount`, `item.error` in-memory inside the loop but only calls `this.persist()` once after the `for` loop completes (line 203). If the process crashes (uncaught throw in an unrelated handler, or SIGKILL during the 30+ second SMTP timeout window) mid-loop, items already sent in this batch have `status="sent"` in memory but the file still says `"pending"`. On restart `start()` → `load()` → `processDue()` will re-send those messages. SMTP is not idempotent — recipients get duplicates.
 - Repro hypothesis: 5 due items; kill -9 the process after item 3 finishes. Restart: items 1–3 re-sent (re-Message-IDed), Proton accepts.
 - Suggested next step: `persist()` after each item's status flip, not only at end of batch.
+> **Resolved in v3.0.55 — persistence atomicity.** `persist()` now runs after every per-item terminal/retry status flip inside the loop, so a crash mid-batch cannot leave a sent item on disk as `pending` and re-send it on restart.
 
 #### SMTP-005 — Reminder `persist()` uses non-atomic cross-device rename
 - Location: `src/services/reminder-service.ts:70-75`
@@ -327,6 +329,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The tmp file is written under `tmpdir()` (typically `/tmp`, often `tmpfs`) then `renameSync` into `this.path` (typically `$HOME/.mailpouch-reminders.json`). On Linux `rename(2)` across mounts (tmpfs → ext4) fails with `EXDEV`, throwing synchronously from `add()` / `cancel()` / `scanDue()`. The scheduler peer (`src/services/scheduler.ts:271-282`) deliberately writes the tmp in the same directory as the store for this reason. Result: on systems where `$HOME` is on a different mount than `/tmp` (containerised installs, autofs-mounted homedirs), every reminder write throws — `add()` is called from `remind_if_no_reply` and the McpError surfaced says "Failed to persist reminder: EXDEV: cross-device link not permitted".
 - Repro hypothesis: mount `$HOME` on a different fs than `/tmp` (Docker volume, NFS home); call `remind_if_no_reply` — throws EXDEV. All reminder writes are unrecoverable.
 - Suggested next step: build tmp path as `this.path + ".tmp"` (or use `dirname(this.path)`), matching `scheduler.ts`.
+> **Resolved in v3.0.55 — persistence atomicity.** `persist()` now writes the tmp file as `${this.path}.<rand>.tmp` (sibling of the store), so `rename(2)` stays within one filesystem and no longer throws `EXDEV` on split `$HOME`/`/tmp` mounts.
 
 #### SMTP-006 — Reminder `persist()` exception is unhandled — corrupts in-memory state
 - Location: `src/services/reminder-service.ts:81-108`, `122-128`, `188-201`
@@ -336,6 +339,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `add()`, `cancel()`, `scanDue()`, `prune()`, and `detectRepliesAndCancel()` mutate `this.reminders` before calling `persist()`. If `persist()` throws (out-of-space, EXDEV per SMTP-005, EACCES on the file), the in-memory state is already advanced (status flipped to "fired", new reminder appended) but the disk doesn't reflect it. On the next `persist()` call the disk catches up — so a *successful* later call can flush the half-baked mutations from the failed one (e.g., a "fired" reminder that the caller never received gets persisted later as "fired", losing the at-least-once delivery guarantee `check_reminders` implies).
 - Repro hypothesis: make `path` read-only; call `scanDue()` — pending reminders flip to "fired" in memory and are returned, but writeback throws. Then `chmod +w`; call `cancel()` on an unrelated reminder; the failed "fired" mutations now land on disk silently.
 - Suggested next step: try/catch around `persist()`; on failure, roll back the in-memory mutation, log loudly.
+> **Resolved in v3.0.55 — persistence atomicity.** `add`/`cancel`/`scanDue`/`prune`/`detectRepliesAndCancel` snapshot `reminders` before mutating and persist via `persistOrRollback()`, which on write failure restores the snapshot, logs at `error` level, and re-throws — so a failed write can never be silently flushed later.
 
 #### SMTP-007 — `scanDue()` is destructive and not idempotent under partial-write failure
 - Location: `src/services/reminder-service.ts:188-201`
@@ -345,6 +349,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `scanDue()` is invoked by the `check_reminders` MCP tool (`src/tools/drafts.ts:524-537`). It transitions every due reminder to `"fired"` *and* returns it in the same call. If the network/MCP transport drops the response before the agent receives it, the disk has already been written: the agent will never see those reminders again, and the user gets no notification. There is no acknowledgment step.
 - Repro hypothesis: kill the MCP transport between persist (line 199) and the tool response writeback in `check_reminders`. Reminders are lost.
 - Suggested next step: defer the status transition to a separate `acknowledge_reminder(id)` tool, or add an `ack` step the agent must call.
+> **Resolved in v3.0.55 — persistence atomicity (partially-addressed).** The crash-safety half is closed: the `pending → fired` transition is now persisted (and rolled back atomically with the in-memory state on a write failure — see SMTP-006) *before* `scanDue()` returns the due list, so a write that didn't reach disk never hands the caller reminders it can't re-fire. The at-least-once limitation (a dropped MCP transport response *after* a successful persist) remains **by design** pending a dedicated `acknowledge_reminder` tool; adding that tool is a product change deliberately out of scope for this batch.
 
 #### SMTP-011 — `saveDraft` falls back to literal "Drafts" path with no existence check
 - Location: `src/services/simple-imap-service.ts:1341-1357` & `1448-1449`
@@ -1099,6 +1104,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The 15s cache keys on `mtimeMs` of the config file, not the keychain. After `saveConfigWithCredentials` writes to the keychain and blanks the file fields, mtime updates and the cache is invalidated — fine. But `writeRegistry → saveConfig` and an independent settings-UI POST that races within 15ms can produce two near-simultaneous writes (no flock); the second `renameSync` clobbers the first. `invalidateConfigCache()` runs synchronously after rename, so any reader between the two renames may see a half-merged file with credentialStorage="keychain" and live plaintext for a different field. No file-lock anywhere in loader.ts or registry.ts.
 - Repro hypothesis: Two tabs of the settings UI saving simultaneously (one changes username, one changes smtp token). Race window is large (entire JSON write + rename). Last writer wins, plus the cache can serve the loser briefly.
 - Suggested next step: Take an exclusive lock on `${dest}.lock` (`O_EXCL` open or `proper-lockfile`) around the read-modify-write in saveConfig and writeRegistry.
+> **Resolved in v3.0.55 — persistence atomicity.** Added `withConfigLock`/`withConfigWriteLockAsync` in `loader.ts`: an `O_EXCL` lock on `${config}.lock` with stale-lock reclamation, reentrancy (so the inner `saveConfig` reuses the outer lock), and always-release-in-finally, plus an in-process async mutex so concurrent same-process async writers can't deadlock the event loop. `saveConfig` and `writeRegistry`'s full read-modify-write now run under it. No new dependency.
 
 #### CRED-010 — `loadCredentialsFromKeychain` falls through to plaintext config when encrypted-blob decryption throws — masks compromise indicators
 - Location: `src/config/loader.ts:392-430`
@@ -1587,6 +1593,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: If a non-mailpouch listener holds port 8765, the MCP gives up after 5 retries, logs warn, and continues without the UI. The tray will still build an "Open Settings" item; clicking does nothing because `_settingsUrl` is empty.
 - Repro hypothesis: Run `python3 -m http.server 8765` in one terminal, then start the MCP. Watchdog logs "could not bind…", tray "Open Settings" item still appears but clicking fails.
 - Suggested next step: Gate the tray "Open Settings" item visibility on `_settingsEnabled && _settingsUrl`; offer to try `port+1`.
+> **Resolved in v3.0.55 — persistence atomicity (tray-gating half; verified already in place).** `_buildTrayItems()` in `index.ts` only emits the "Open Settings" entry when `_settingsEnabled && _settingsUrl`, so a failed bind no longer shows a dead menu item. The `port+1` fallback suggestion remains an open enhancement out of scope for this batch.
 
 #### UI-006 — `/api/shutdown` calls `process.exit(0)` without destroying tray subprocess
 - Location: `src/settings/server.ts:1777-1782`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.54",
+  "version": "3.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.54",
+      "version": "3.0.55",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.54",
+  "version": "3.0.55",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/accounts/registry.test.ts
+++ b/src/accounts/registry.test.ts
@@ -43,6 +43,11 @@ vi.mock("fs", async () => {
       diskByPath.set(String(to), s);
     }),
     statSync: vi.fn(),   // returns undefined → mtime check throws → cache bypassed
+    // CRED-008 config-lock primitives: no-op so writeRegistry's lock doesn't
+    // touch the real home dir. Real concurrency is covered by config-lock.test.ts.
+    openSync: vi.fn(() => 3),
+    closeSync: vi.fn(),
+    unlinkSync: vi.fn(),
     appendFile: vi.fn((_path: string, _data: string, _enc: string, cb: () => void) => cb()),
   };
 });

--- a/src/accounts/registry.ts
+++ b/src/accounts/registry.ts
@@ -11,7 +11,7 @@
 
 import { randomBytes } from "crypto";
 import type { ServerConfig } from "../config/schema.js";
-import { loadConfig, saveConfig, defaultConfig } from "../config/loader.js";
+import { loadConfig, saveConfig, defaultConfig, withConfigWriteLockAsync } from "../config/loader.js";
 import type { AccountSpec, AccountRegistry, AccountStatus } from "./types.js";
 import {
   loadAccountCredentials,
@@ -132,6 +132,11 @@ export async function readRegistryWithSecrets(): Promise<AccountRegistry> {
  * sites that used to fire-and-forget should `await` it.
  */
 export async function writeRegistry(reg: AccountRegistry): Promise<void> {
+  // CRED-008: hold the exclusive config lock across the whole read-modify-write
+  // (loadConfig → merge → saveConfig) so a racing settings-UI POST or a second
+  // writeRegistry cannot clobber this write. The inner saveConfig reuses the
+  // held lock reentrantly.
+  await withConfigWriteLockAsync(async () => {
   const cfg = loadConfig() ?? defaultConfig();
 
   // Clone the specs so we can blank secrets without mutating the
@@ -194,6 +199,7 @@ export async function writeRegistry(reg: AccountRegistry): Promise<void> {
     };
   }
   saveConfig(cfg);
+  });
 }
 
 export function listStatuses(): AccountStatus[] {

--- a/src/config/config-lock.test.ts
+++ b/src/config/config-lock.test.ts
@@ -1,0 +1,106 @@
+/**
+ * CRED-008 — exclusive file-lock around config read-modify-write.
+ *
+ * Unlike loader.test.ts (which mocks fs), this suite runs against the REAL
+ * filesystem so the O_EXCL lock, stale-lock reclamation, and reentrancy are
+ * exercised end-to-end. The config path is pointed at a throwaway file inside
+ * the home directory (getConfigPath() refuses paths outside $HOME).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, closeSync, openSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { randomBytes } from "crypto";
+import { saveConfig, withConfigWriteLock, withConfigWriteLockAsync, defaultConfig, invalidateConfigCache } from "./loader.js";
+
+describe("config file lock (CRED-008)", () => {
+  let dir: string;
+  let cfgPath: string;
+  let lockPath: string;
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    // mkdtemp inside $HOME so getConfigPath()'s home-containment check passes.
+    dir = mkdtempSync(join(homedir(), ".mailpouch-lock-test-"));
+    cfgPath = join(dir, `cfg-${randomBytes(4).toString("hex")}.json`);
+    lockPath = `${cfgPath}.lock`;
+    savedEnv = process.env.MAILPOUCH_CONFIG;
+    process.env.MAILPOUCH_CONFIG = cfgPath;
+    invalidateConfigCache();
+  });
+
+  afterEach(() => {
+    if (savedEnv !== undefined) process.env.MAILPOUCH_CONFIG = savedEnv;
+    else delete process.env.MAILPOUCH_CONFIG;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("saveConfig writes the file and leaves no lock behind", () => {
+    const cfg = defaultConfig();
+    cfg.connection.username = "alice@example.com";
+    saveConfig(cfg);
+    expect(existsSync(cfgPath)).toBe(true);
+    expect(existsSync(lockPath)).toBe(false); // released in finally
+    expect(JSON.parse(readFileSync(cfgPath, "utf-8")).connection.username).toBe("alice@example.com");
+  });
+
+  it("reclaims a STALE lock left by a crashed holder", () => {
+    // Simulate a crashed holder: create the lock file and backdate its mtime
+    // well past the staleness window.
+    closeSync(openSync(lockPath, "w"));
+    const old = Date.now() / 1000 - 3600; // 1h ago, in seconds
+    require("fs").utimesSync(lockPath, old, old);
+
+    const cfg = defaultConfig();
+    cfg.connection.username = "bob@example.com";
+    // Must NOT hang/throw — the stale lock is reclaimed.
+    saveConfig(cfg);
+    expect(JSON.parse(readFileSync(cfgPath, "utf-8")).connection.username).toBe("bob@example.com");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("is reentrant: saveConfig inside withConfigWriteLock reuses the held lock", () => {
+    const cfg = defaultConfig();
+    cfg.connection.username = "carol@example.com";
+    expect(() =>
+      withConfigWriteLock(() => {
+        saveConfig(cfg); // inner acquisition must not deadlock on the outer lock
+      })
+    ).not.toThrow();
+    expect(JSON.parse(readFileSync(cfgPath, "utf-8")).connection.username).toBe("carol@example.com");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("serializes concurrent read-modify-write so neither writer clobbers the other (CRED-008)", async () => {
+    // Seed a config with two independent fields.
+    const seed = defaultConfig();
+    seed.connection.username = "start";
+    saveConfig(seed);
+
+    // Two racing writers, each doing a full load→modify→save under the lock.
+    // Writer A sets username, writer B sets smtpToken. With proper locking the
+    // final file contains BOTH mutations (no last-writer-wins clobber).
+    const writerA = withConfigWriteLockAsync(async () => {
+      const c = JSON.parse(readFileSync(cfgPath, "utf-8"));
+      await Promise.resolve(); // yield, widening the race window
+      c.connection.username = "alice";
+      saveConfig(c);
+    });
+    const writerB = withConfigWriteLockAsync(async () => {
+      const c = JSON.parse(readFileSync(cfgPath, "utf-8"));
+      await Promise.resolve();
+      c.connection.smtpToken = "tokenB";
+      saveConfig(c);
+    });
+
+    await Promise.all([writerA, writerB]);
+
+    const final = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    // The later writer read the earlier writer's result (serialized), so both
+    // fields survive.
+    expect(final.connection.username).toBe("alice");
+    expect(final.connection.smtpToken).toBe("tokenB");
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -14,6 +14,12 @@ vi.mock("fs", async (importOriginal) => {
     writeFileSync: vi.fn(),
     renameSync: vi.fn(),
     statSync: vi.fn(),   // returns undefined by default → mtime check throws → cache invalidated
+    // CRED-008 config-lock primitives: no-op in unit tests so the lock around
+    // saveConfig doesn't touch the real home dir. Concurrency behavior is
+    // covered by config-lock.test.ts against a real filesystem.
+    openSync: vi.fn(() => 3),
+    closeSync: vi.fn(),
+    unlinkSync: vi.fn(),
     appendFile: vi.fn((_path: string, _data: string, _enc: string, cb: () => void) => cb()),
   };
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,7 +8,7 @@
  * to reduce the risk of credential exposure.
  */
 
-import { readFileSync, writeFileSync, existsSync, renameSync, statSync } from "fs";
+import { readFileSync, writeFileSync, existsSync, renameSync, statSync, openSync, closeSync, unlinkSync } from "fs";
 import { homedir, tmpdir } from "os";
 import { join, resolve, normalize } from "path";
 import { randomBytes } from "crypto";
@@ -349,9 +349,98 @@ export function loadConfig(): ServerConfig | null {
   return config;
 }
 
+// ─── Config file lock (CRED-008) ─────────────────────────────────────────────
+//
+// Read-modify-write callers (saveConfig, and writeRegistry's load→merge→save)
+// race with each other and with the settings-UI POST handler. Without a lock,
+// two near-simultaneous renames clobber one another (last-writer-wins) and a
+// reader caught between them can observe a half-merged file. We serialize via
+// an exclusive O_EXCL lock file next to the config — no new dependency.
+
+/** Max attempts to acquire the lock before giving up. */
+const LOCK_MAX_RETRIES = 50;
+/** Delay between lock acquisition attempts (busy-wait; writes are sub-ms). */
+const LOCK_RETRY_DELAY_MS = 20;
+/** A lock file older than this is treated as abandoned by a crashed holder. */
+const LOCK_STALE_MS = 10_000;
+
+/**
+ * Reentrancy depth. writeRegistry holds the lock across its whole
+ * read-modify-write and calls saveConfig() inside it; the inner saveConfig
+ * must reuse the held lock rather than deadlock on its own O_EXCL.
+ */
+let _lockDepth = 0;
+
+/**
+ * In-process async serialization. The on-disk O_EXCL lock guards against OTHER
+ * processes (settings UI, a second MCP), but two concurrent async writers in
+ * THIS process cannot busy-wait on it — a synchronous spin would block the
+ * event loop and deadlock the holder mid-await. This promise chain queues
+ * same-process async writers so they run one at a time.
+ */
+let _asyncLockChain: Promise<void> = Promise.resolve();
+
+function blockMs(ms: number): void {
+  // Synchronous sleep for the sync acquire path (saveConfig). Node lacks a sync
+  // sleep; Atomics.wait on a throwaway buffer is the standard no-dep idiom.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` while holding an exclusive lock on `${dest}.lock`. Reentrant for the
+ * same process (depth-counted). Reclaims a stale lock left by a crashed holder.
+ * The lock is always released in the outermost frame via try/finally.
+ */
+function withConfigLock<T>(dest: string, fn: () => T): T {
+  if (_lockDepth > 0) {
+    // Already held by an outer frame in this process — reuse it.
+    _lockDepth++;
+    try { return fn(); }
+    finally { _lockDepth--; }
+  }
+
+  const lockPath = `${dest}.lock`;
+  let fd: number | null = null;
+  for (let attempt = 0; attempt < LOCK_MAX_RETRIES; attempt++) {
+    try {
+      fd = openSync(lockPath, "wx", 0o600); // O_CREAT | O_EXCL
+      break;
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      // Lock held by someone else — reclaim it if it's stale (crashed holder),
+      // otherwise back off and retry.
+      try {
+        const age = Date.now() - statSync(lockPath).mtimeMs;
+        if (age > LOCK_STALE_MS) {
+          unlinkSync(lockPath);
+          continue; // retry immediately after clearing the stale lock
+        }
+      } catch { /* lock vanished between open and stat — just retry */ }
+      blockMs(LOCK_RETRY_DELAY_MS);
+    }
+  }
+  if (fd === null) {
+    throw new Error(`Could not acquire config lock at ${lockPath} after ${LOCK_MAX_RETRIES} attempts`);
+  }
+
+  _lockDepth++;
+  try {
+    return fn();
+  } finally {
+    _lockDepth--;
+    try { closeSync(fd); } catch { /* already closed */ }
+    try { unlinkSync(lockPath); } catch { /* already removed */ }
+  }
+}
+
 export function saveConfig(config: ServerConfig): void {
   tracer.spanSync('config.save', {}, () => {
   const dest    = getConfigPath();
+  withConfigLock(dest, () => {
   const payload = JSON.stringify(config, null, 2);
   // Atomic write: write to a temp file then rename into place.
   // rename(2) is atomic on POSIX only when both sides live on the same
@@ -362,7 +451,73 @@ export function saveConfig(config: ServerConfig): void {
   writeFileSync(tmp, payload, { encoding: "utf-8", mode: 0o600 });
   renameSync(tmp, dest);
   invalidateConfigCache();
+  });
   }); // end tracer.spanSync('config.save')
+}
+
+/**
+ * Run a read-modify-write of the config file under the exclusive lock so the
+ * read (loadConfig) and the write (saveConfig) cannot interleave with a racing
+ * writer. saveConfig() reuses the held lock reentrantly. CRED-008.
+ */
+export function withConfigWriteLock<T>(fn: () => T): T {
+  return withConfigLock(getConfigPath(), fn);
+}
+
+/**
+ * Async variant of withConfigWriteLock for callers whose read-modify-write
+ * spans an await (e.g. writeRegistry, which routes secrets through the
+ * keychain between load and save). The lock is held for the full duration and
+ * released only after the promise settles. CRED-008.
+ */
+export async function withConfigWriteLockAsync<T>(fn: () => Promise<T>): Promise<T> {
+  // Reentrant: an async writer already holding the lock (e.g. a future nested
+  // call) reuses it rather than enqueuing behind itself.
+  if (_lockDepth > 0) {
+    _lockDepth++;
+    try { return await fn(); }
+    finally { _lockDepth--; }
+  }
+
+  // Queue behind any in-flight same-process async writer. Chain on settle (not
+  // resolve) so one writer's failure doesn't wedge the queue.
+  const prior = _asyncLockChain;
+  let release!: () => void;
+  _asyncLockChain = new Promise<void>(r => { release = r; });
+  await prior.catch(() => {});
+
+  const dest = getConfigPath();
+  const lockPath = `${dest}.lock`;
+  let fd: number | null = null;
+  try {
+    for (let attempt = 0; attempt < LOCK_MAX_RETRIES; attempt++) {
+      try {
+        fd = openSync(lockPath, "wx", 0o600); // O_CREAT | O_EXCL
+        break;
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+        try {
+          const age = Date.now() - statSync(lockPath).mtimeMs;
+          if (age > LOCK_STALE_MS) { unlinkSync(lockPath); continue; }
+        } catch { /* lock vanished — retry */ }
+        await sleepMs(LOCK_RETRY_DELAY_MS); // async sleep — never blocks the loop
+      }
+    }
+    if (fd === null) {
+      throw new Error(`Could not acquire config lock at ${lockPath} after ${LOCK_MAX_RETRIES} attempts`);
+    }
+
+    _lockDepth++;
+    try {
+      return await fn();
+    } finally {
+      _lockDepth--;
+      try { closeSync(fd); } catch { /* already closed */ }
+      try { unlinkSync(lockPath); } catch { /* already removed */ }
+    }
+  } finally {
+    release();
+  }
 }
 
 // ─── Keychain-aware credential helpers ──────────────────────────────────────

--- a/src/services/reminder-service.test.ts
+++ b/src/services/reminder-service.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ReminderService } from "./reminder-service.js";
-import { rmSync, existsSync } from "fs";
+import { rmSync, existsSync, readdirSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { randomBytes } from "crypto";
@@ -201,6 +201,86 @@ describe("ReminderService", () => {
     it("is a no-op when there are no pending reminders", () => {
       const svc = new ReminderService(path);
       expect(svc.detectRepliesAndCancel([{ headers: { "in-reply-to": "<anything@x>" } }])).toEqual([]);
+    });
+  });
+
+  describe("persistence atomicity (SMTP-005/006/007)", () => {
+    it("writes the tmp file alongside the store, not in tmpdir (SMTP-005)", () => {
+      // A persist into a directory whose tmpdir() lives on a different mount must
+      // still succeed. We assert the regression indirectly: after a successful
+      // persist no stray tmp file is left in tmpdir() (the old code wrote
+      // `mailpouch-reminders-*.json.tmp` there), and the on-disk store exists
+      // next to `path`.
+      const svc = new ReminderService(path);
+      svc.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 });
+      expect(existsSync(path)).toBe(true);
+      const strays = readdirSync(tmpdir()).filter(f => f.startsWith("mailpouch-reminders-") && f.endsWith(".json.tmp"));
+      expect(strays).toEqual([]);
+    });
+
+    // Force a persist() failure by pointing the store at a path whose PARENT
+    // directory does not exist: `writeFileSync(tmp)` then throws ENOENT,
+    // exercising the rollback branch deterministically and cross-platform.
+    function svcWithFailingPersist(): { svc: ReminderService; goodPath: string } {
+      const goodPath = tmpPath();
+      const svc = new ReminderService(goodPath);
+      return { svc, goodPath };
+    }
+
+    it("add() rolls back the in-memory mutation when persist fails (SMTP-006)", () => {
+      const { svc } = svcWithFailingPersist();
+      svc.add({ messageId: "<seed>", recipient: "a@x", subject: "seed", sentAt: new Date(), afterDays: 1 });
+      const before = svc.listAll().length;
+      // Break the destination: replace the store path with a directory so the
+      // rename target is invalid (EISDIR / ENOTEMPTY), failing persist().
+      rmSync((svc as unknown as { path: string }).path, { force: true });
+      mkdirSync((svc as unknown as { path: string }).path);
+      expect(() => svc.add({ messageId: "<b>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 })).toThrow();
+      // The failed add must NOT remain in memory.
+      expect(svc.listAll().length).toBe(before);
+      expect(svc.listAll().some(r => r.messageId === "<b>")).toBe(false);
+      rmSync((svc as unknown as { path: string }).path, { recursive: true, force: true });
+    });
+
+    it("cancel() rolls back when persist fails (SMTP-006)", () => {
+      const { svc } = svcWithFailingPersist();
+      const rec = svc.add({ messageId: "<a>", recipient: "a@x", subject: "s", sentAt: new Date(), afterDays: 1 });
+      const p = (svc as unknown as { path: string }).path;
+      rmSync(p, { force: true });
+      mkdirSync(p);
+      expect(() => svc.cancel(rec.id)).toThrow();
+      // Status must still be pending — the failed cancel was rolled back.
+      expect(svc.listPending().map(r => r.id)).toEqual([rec.id]);
+      rmSync(p, { recursive: true, force: true });
+    });
+
+    it("scanDue() rolls back the fired transition when persist fails — at-least-once preserved (SMTP-007)", () => {
+      const { svc } = svcWithFailingPersist();
+      const sentAt = new Date("2026-04-01T00:00:00Z");
+      svc.add({ messageId: "<a>", recipient: "a@x", subject: "due", sentAt, afterDays: 1 });
+      const p = (svc as unknown as { path: string }).path;
+      rmSync(p, { force: true });
+      mkdirSync(p);
+      const now = new Date(sentAt.getTime() + 5 * 86_400_000);
+      expect(() => svc.scanDue(now)).toThrow();
+      // The reminder must remain pending so a later scan re-fires it (no silent loss).
+      expect(svc.listPending()).toHaveLength(1);
+      rmSync(p, { recursive: true, force: true });
+      // After the destination is healthy again, scanDue fires it durably.
+      const fired = svc.scanDue(now);
+      expect(fired).toHaveLength(1);
+    });
+
+    it("scanDue() persists the fired transition before returning (SMTP-007)", () => {
+      const svc = new ReminderService(path);
+      const sentAt = new Date("2026-04-01T00:00:00Z");
+      svc.add({ messageId: "<a>", recipient: "a@x", subject: "due", sentAt, afterDays: 1 });
+      const now = new Date(sentAt.getTime() + 5 * 86_400_000);
+      svc.scanDue(now);
+      // A fresh instance loading from disk must already see the fired state.
+      const reloaded = new ReminderService(path);
+      expect(reloaded.listPending()).toEqual([]);
+      expect(reloaded.listAll().find(r => r.messageId === "<a>")?.status).toBe("fired");
     });
   });
 });

--- a/src/services/reminder-service.ts
+++ b/src/services/reminder-service.ts
@@ -11,8 +11,6 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, renameSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
 import { randomBytes } from "crypto";
 import { logger } from "../utils/logger.js";
 
@@ -69,9 +67,49 @@ export class ReminderService {
 
   private persist(): void {
     const payload: ReminderFile = { version: 1, reminders: this.reminders };
-    const tmp = join(tmpdir(), `mailpouch-reminders-${randomBytes(8).toString("hex")}.json.tmp`);
+    // SMTP-005: write the tmp file alongside the destination, not in tmpdir().
+    // rename(2) is only atomic within a single filesystem; a tmpfs /tmp →
+    // ext4 $HOME rename throws EXDEV on containerised / NFS-home installs.
+    const tmp = `${this.path}.${randomBytes(8).toString("hex")}.tmp`;
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { encoding: "utf-8", mode: 0o600 });
     renameSync(tmp, this.path);
+  }
+
+  /**
+   * SMTP-006: persist the current in-memory state, rolling it back to the
+   * supplied snapshot if the write fails. Without this, a failed persist()
+   * (EXDEV, ENOSPC, EACCES) leaves `this.reminders` advanced past disk; a
+   * later successful persist() would then silently flush the half-baked
+   * mutation — e.g. a "fired" reminder the caller never received getting
+   * written as "fired", breaking check_reminders' at-least-once guarantee.
+   *
+   * SMTP-007: scanDue() routes its fire-transition through here, so the
+   * "fired" flip is committed to disk before the method returns or rolled
+   * back atomically with the in-memory state. The at-least-once limitation
+   * (a dropped MCP response after a successful persist) remains by design
+   * pending a dedicated acknowledge tool — see the SMTP-007 audit note.
+   *
+   * @param snapshot Deep copy of `this.reminders` taken BEFORE the mutation.
+   * @throws Re-throws the underlying persist error after rolling back so the
+   *         caller (and the MCP tool layer) sees the failure.
+   */
+  private persistOrRollback(snapshot: Reminder[]): void {
+    try {
+      this.persist();
+    } catch (err) {
+      this.reminders = snapshot;
+      logger.error(
+        `ReminderService: persist failed — rolled back in-memory state to last durable snapshot`,
+        "ReminderService",
+        err,
+      );
+      throw err;
+    }
+  }
+
+  /** Deep-clone the current reminders for use as a rollback snapshot. */
+  private snapshot(): Reminder[] {
+    return this.reminders.map(r => ({ ...r }));
   }
 
   /**
@@ -102,8 +140,9 @@ export class ReminderService {
       status: "pending",
       note: args.note,
     };
+    const snapshot = this.snapshot();
     this.reminders.push(record);
-    this.persist();
+    this.persistOrRollback(snapshot);
     return record;
   }
 
@@ -122,8 +161,9 @@ export class ReminderService {
   cancel(id: string): boolean {
     const r = this.reminders.find(x => x.id === id);
     if (!r || r.status !== "pending") return false;
+    const snapshot = this.snapshot();
     r.status = "cancelled";
-    this.persist();
+    this.persistOrRollback(snapshot);
     return true;
   }
 
@@ -139,6 +179,8 @@ export class ReminderService {
   detectRepliesAndCancel(inbox: Array<{ headers?: Record<string, string | string[]> }>): string[] {
     const pending = this.reminders.filter(r => r.status === "pending");
     if (pending.length === 0) return [];
+
+    const snapshot = this.snapshot();
 
     // Build a lowercased set of the Message-IDs we're watching for,
     // tolerating both <id@host> and bare id@host forms.
@@ -176,7 +218,7 @@ export class ReminderService {
         }
       }
     }
-    if (cancelled.length > 0) this.persist();
+    if (cancelled.length > 0) this.persistOrRollback(snapshot);
     return cancelled;
   }
 
@@ -188,6 +230,7 @@ export class ReminderService {
   scanDue(now: Date = new Date()): Reminder[] {
     const cutoffMs = now.getTime();
     const fired: Reminder[] = [];
+    const snapshot = this.snapshot();
     let mutated = false;
     for (const r of this.reminders) {
       if (r.status === "pending" && Date.parse(r.fireAt) <= cutoffMs) {
@@ -196,20 +239,25 @@ export class ReminderService {
         mutated = true;
       }
     }
-    if (mutated) this.persist();
+    // SMTP-007: commit the "fired" transition to disk BEFORE returning it. On
+    // persist failure persistOrRollback() restores the snapshot and throws, so
+    // we never hand the caller reminders whose fired-state didn't reach disk —
+    // they stay pending and resurface on the next scan (at-least-once).
+    if (mutated) this.persistOrRollback(snapshot);
     return fired;
   }
 
   /** Remove fired/cancelled reminders older than the retention window. */
   prune(retainDays = 30): number {
     const cutoff = Date.now() - retainDays * 24 * 60 * 60 * 1000;
+    const snapshot = this.snapshot();
     const before = this.reminders.length;
     this.reminders = this.reminders.filter(r => {
       if (r.status === "pending") return true;
       return Date.parse(r.fireAt) >= cutoff;
     });
     const removed = before - this.reminders.length;
-    if (removed > 0) this.persist();
+    if (removed > 0) this.persistOrRollback(snapshot);
     return removed;
   }
 }

--- a/src/services/scheduler.test.ts
+++ b/src/services/scheduler.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { SchedulerService } from "./scheduler.js";
 import type { SMTPService } from "./smtp-service.js";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -131,17 +131,98 @@ describe("SchedulerService", () => {
     const svc = new SchedulerService(smtp, storePath);
     const id = svc.schedule(makeOptions(), futureDate(120));
     vi.advanceTimersByTime(121 * 1000);
-    // Retry up to MAX_RETRIES (3) times before permanently failing
+    // Retry up to MAX_RETRIES (3) times before permanently failing. Each failed
+    // attempt sets a per-item backoff (SMTP-003), so advance past it between
+    // attempts or the item is skipped as not-yet-eligible.
     await svc.processDue();
     expect(svc.list().find(i => i.id === id)!.status).toBe("pending"); // still retrying
+    vi.advanceTimersByTime(61 * 1000); // past attempt-1 backoff (60s)
     await svc.processDue();
     expect(svc.list().find(i => i.id === id)!.status).toBe("pending"); // still retrying
+    vi.advanceTimersByTime(121 * 1000); // past attempt-2 backoff (120s)
     await svc.processDue();
     const item = svc.list().find(i => i.id === id)!;
     expect(item.status).toBe("failed");
     expect(item.error).toBe("SMTP error");
     expect(item.retryCount).toBe(3);
     expect(smtp.sendEmail).toHaveBeenCalledTimes(3);
+  });
+
+  it("processDue() applies per-item exponential backoff between retries (SMTP-003)", async () => {
+    const smtp = makeSMTP({ success: false, error: "transient" });
+    const svc = new SchedulerService(smtp, storePath);
+    const id = svc.schedule(makeOptions(), futureDate(120));
+    vi.advanceTimersByTime(121 * 1000);
+
+    // First attempt fails → retryCount 1, nextAttemptAt ~60s out.
+    await svc.processDue();
+    const afterFirst = svc.list().find(i => i.id === id)!;
+    expect(afterFirst.retryCount).toBe(1);
+    expect(afterFirst.nextAttemptAt).toBeTruthy();
+    expect(new Date(afterFirst.nextAttemptAt!).getTime()).toBeGreaterThan(Date.now());
+
+    // A poll tick BEFORE the backoff window elapses must NOT re-send.
+    vi.advanceTimersByTime(30 * 1000);
+    await svc.processDue();
+    expect(smtp.sendEmail).toHaveBeenCalledTimes(1);
+    expect(svc.list().find(i => i.id === id)!.retryCount).toBe(1);
+
+    // After the window elapses it retries once more.
+    vi.advanceTimersByTime(31 * 1000);
+    await svc.processDue();
+    expect(smtp.sendEmail).toHaveBeenCalledTimes(2);
+    expect(svc.list().find(i => i.id === id)!.retryCount).toBe(2);
+  });
+
+  it("processDue() clears nextAttemptAt on success", async () => {
+    // Fail once (sets backoff), then succeed; nextAttemptAt should be cleared.
+    const smtp = {
+      sendEmail: vi.fn()
+        .mockResolvedValueOnce({ success: false, error: "x" })
+        .mockResolvedValueOnce({ success: true, messageId: "m" }),
+    } as unknown as SMTPService;
+    const svc = new SchedulerService(smtp, storePath);
+    const id = svc.schedule(makeOptions(), futureDate(120));
+    vi.advanceTimersByTime(121 * 1000);
+    await svc.processDue();
+    expect(svc.list().find(i => i.id === id)!.nextAttemptAt).toBeTruthy();
+    vi.advanceTimersByTime(61 * 1000);
+    await svc.processDue();
+    const item = svc.list().find(i => i.id === id)!;
+    expect(item.status).toBe("sent");
+    expect(item.nextAttemptAt).toBeUndefined();
+  });
+
+  it("processDue() persists after each item's status flip, not only at loop end (SMTP-004)", async () => {
+    // Two due items. The second send stays pending; while it is in flight we
+    // inspect the on-disk store. With per-item persist the first item is
+    // already "sent" on disk — under the old loop-end-only persist a crash here
+    // would re-send it on restart.
+    let resolveSecond!: (v: { success: boolean; messageId: string }) => void;
+    const secondPromise = new Promise<{ success: boolean; messageId: string }>(r => { resolveSecond = r; });
+    const smtp = {
+      sendEmail: vi.fn()
+        .mockResolvedValueOnce({ success: true, messageId: "m1" })
+        .mockReturnValueOnce(secondPromise),
+    } as unknown as SMTPService;
+    const svc = new SchedulerService(smtp, storePath);
+    svc.schedule(makeOptions(), futureDate(120));
+    svc.schedule(makeOptions(), futureDate(120));
+    vi.advanceTimersByTime(121 * 1000);
+
+    const due = svc.processDue();
+    // Let the first send resolve and its post-send persist run, while the
+    // second send is still pending (loop has NOT reached its end-of-loop persist).
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const onDisk = JSON.parse(readFileSync(storePath, "utf-8"));
+    const sentCount = onDisk.filter((r: { status: string }) => r.status === "sent").length;
+    expect(sentCount).toBe(1);
+
+    resolveSecond({ success: true, messageId: "m2" });
+    await due;
   });
 
   it("processDue() does not send items that are not due yet", async () => {
@@ -369,9 +450,11 @@ describe("SchedulerService", () => {
     const id = svc.schedule(makeOptions(), futureDate(120));
     vi.advanceTimersByTime(121 * 1000);
 
-    // Exhaust retries
+    // Exhaust retries — advance past each per-item backoff window (SMTP-003).
     await svc.processDue();
+    vi.advanceTimersByTime(61 * 1000);
     await svc.processDue();
+    vi.advanceTimersByTime(121 * 1000);
     await svc.processDue();
 
     const item = svc.list().find(i => i.id === id)!;
@@ -388,9 +471,12 @@ describe("SchedulerService", () => {
     const id = svc.schedule(makeOptions(), futureDate(120));
     vi.advanceTimersByTime(121 * 1000);
 
-    // Run processDue 3 times (MAX_RETRIES) to exhaust retries via the catch branch
+    // Run processDue 3 times (MAX_RETRIES) to exhaust retries via the catch
+    // branch, advancing past each per-item backoff window (SMTP-003).
     await svc.processDue();
+    vi.advanceTimersByTime(61 * 1000);
     await svc.processDue();
+    vi.advanceTimersByTime(121 * 1000);
     await svc.processDue();
 
     const item = svc.list().find(i => i.id === id)!;

--- a/src/services/scheduler.ts
+++ b/src/services/scheduler.ts
@@ -22,6 +22,20 @@ const MIN_LEAD_TIME_MS = 60 * 1000;
 const POLL_INTERVAL_MS = 60 * 1000;
 /** Number of send attempts before marking an item as permanently failed. */
 const MAX_RETRIES = 3;
+/** Base unit for per-item exponential backoff between retry attempts. */
+const RETRY_BACKOFF_BASE_MS = 60 * 1000;
+/** Ceiling on a single backoff delay so a high retryCount can't push it absurdly far out. */
+const RETRY_BACKOFF_MAX_MS = 30 * 60 * 1000;
+
+/**
+ * Exponential per-item backoff: attempt N waits base * 2^(N-1), capped.
+ * SMTP-003 — without this, a transient Bridge outage causes every due item to
+ * be re-attempted on every 60 s poll tick (a tight blast against a down peer).
+ */
+function backoffMs(retryCount: number): number {
+  const exp = RETRY_BACKOFF_BASE_MS * Math.pow(2, Math.max(0, retryCount - 1));
+  return Math.min(exp, RETRY_BACKOFF_MAX_MS);
+}
 /** Maximum age (ms) for completed/failed/cancelled records kept in history. */
 const MAX_HISTORY_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 /** Hard cap on non-pending records retained in history (safety valve). */
@@ -194,7 +208,12 @@ export class SchedulerService {
 
     const now = new Date();
     const due = this.items.filter(
-      i => i.status === "pending" && new Date(i.scheduledAt) <= now
+      i =>
+        i.status === "pending" &&
+        new Date(i.scheduledAt) <= now &&
+        // SMTP-003: honor per-item backoff — a failed attempt sets nextAttemptAt
+        // into the future; skip until that window has elapsed.
+        (!i.nextAttemptAt || new Date(i.nextAttemptAt) <= now)
     );
 
     if (due.length === 0) {
@@ -223,18 +242,25 @@ export class SchedulerService {
           }
           if (result.success) {
             item.status = "sent";
+            delete item.nextAttemptAt;
             logger.info(`Scheduled email sent`, "Scheduler", { id: item.id, messageId: result.messageId });
           } else {
             item.retryCount = (item.retryCount ?? 0) + 1;
             item.error = result.error;
             if ((item.retryCount ?? 0) >= MAX_RETRIES) {
               item.status = "failed";
+              delete item.nextAttemptAt;
               logger.warn(`Scheduled email permanently failed after ${MAX_RETRIES} attempts`, "Scheduler", { id: item.id, error: result.error });
             } else {
               item.status = "pending";
+              item.nextAttemptAt = new Date(Date.now() + backoffMs(item.retryCount)).toISOString();
               logger.warn(`Scheduled email send failed (attempt ${item.retryCount}/${MAX_RETRIES}), will retry`, "Scheduler", { id: item.id, error: result.error });
             }
           }
+          // SMTP-004: persist after each item's terminal/retry status flip so a
+          // crash mid-loop cannot leave a "sent" item on disk as "pending"
+          // (which would re-send a non-idempotent message on restart).
+          this.persist();
         } catch (err: unknown) {
           // Same post-await guard for the throw path.
           if (item.status !== "sending") {
@@ -247,11 +273,15 @@ export class SchedulerService {
           item.error = errMsg;
           if ((item.retryCount ?? 0) >= MAX_RETRIES) {
             item.status = "failed";
+            delete item.nextAttemptAt;
             logger.error(`Scheduled email permanently failed after ${MAX_RETRIES} attempts`, "Scheduler", { id: item.id, error: errMsg });
           } else {
             item.status = "pending";
+            item.nextAttemptAt = new Date(Date.now() + backoffMs(item.retryCount)).toISOString();
             logger.warn(`Scheduled email threw (attempt ${item.retryCount}/${MAX_RETRIES}), will retry`, "Scheduler", { id: item.id, error: errMsg });
           }
+          // SMTP-004: persist after each item's status flip (throw path too).
+          this.persist();
         }
       }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -233,6 +233,8 @@ export interface ScheduledEmail {
   createdAt: string; // ISO 8601
   error?: string;
   retryCount?: number;
+  /** ISO-8601 earliest time the next send attempt may run (per-item backoff). */
+  nextAttemptAt?: string;
 }
 
 export interface ConnectionStatus {


### PR DESCRIPTION
## Batch M2 — persistence atomicity (v3.0.55)

Closes one root-cause batch of the 2026-05-28 audit. **DO NOT MERGE yet.**

### Findings closed
- **SMTP-003** (`scheduler.ts`) — per-item exponential backoff via `nextAttemptAt` (60s → 120s → … capped 30m); `processDue()` skips items still in their backoff window and clears `nextAttemptAt` on success. Stops a brief Bridge outage re-burning every pending item each 60s tick.
- **SMTP-004** (`scheduler.ts`) — `persist()` now runs after every per-item status flip inside the loop, not just at batch end, so a crash mid-loop can't leave a sent item recorded `pending` and re-send it on restart.
- **SMTP-005** (`reminder-service.ts`) — tmp file written as `${this.path}.<rand>.tmp` (sibling of the store) instead of `tmpdir()`; `rename(2)` stays atomic, no more `EXDEV` on split `$HOME`/`/tmp` mounts.
- **SMTP-006** (`reminder-service.ts`) — every mutating method snapshots `reminders` and persists via `persistOrRollback()`, which on write failure restores the snapshot, logs at `error` level, and re-throws.
- **SMTP-007** (`reminder-service.ts`, **partially-addressed**) — `scanDue()` now commits the `pending → fired` transition (rolled back atomically on failure) before returning the due list. The at-least-once limitation (dropped MCP response *after* a successful persist) remains **by design** pending a dedicated `acknowledge_reminder` tool, which is a product change deliberately out of scope. Cross-referenced to SMTP-006 in the audit annotation.
- **CRED-008** (`config/loader.ts`, `accounts/registry.ts`) — `O_EXCL` lock on `${config}.lock` with stale-lock reclamation, reentrancy, and always-release-in-finally, plus an in-process async mutex (so concurrent same-process async writers can't deadlock the event loop). Wraps the full read-modify-write in `saveConfig` and `writeRegistry`. No new dependency.
- **UI-005** (`index.ts`) — verified the tray "Open Settings" item is already gated on `_settingsEnabled && _settingsUrl`; annotated as resolved. (The `port+1` fallback enhancement is left out of scope.)

### Verification
- `npm run typecheck` — clean
- Targeted vitest: `scheduler.test.ts`, `reminder-service.test.ts`, `config/loader.test.ts`, `config/config-lock.test.ts` (new), `accounts/registry.test.ts` — 122 passing
- Full `npm test` — **1765 passing** (50 files)
- `PRESHIP_NO_BRIDGE=1 npm run preship:fast` — **PASS** (typecheck, lint, version-sync, secrets, npm-audit, license-inv, build, unit)
- E2E (Greenmail) not run locally per worktree constraint — CI runs the authoritative pass.

### Version + docs
package.json + both package-lock fields → 3.0.55; README badge → v3.0.55; CHANGELOG `## [3.0.55]` entry at top; audit findings annotated `Resolved in v3.0.55`.

### Rollback note
Self-contained, additive change set. Revert this single squash-merge commit to fully restore v3.0.54 behavior: removes the `nextAttemptAt` field/backoff, the per-item persist, the reminder tmp-path/rollback wrapper, and the config file-lock. No data migration — `nextAttemptAt` is an optional field ignored by older code, and stray `*.lock` files are reclaimed/ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)