### PR TITLE
fix(validation): unify folder validators, draft/send attachment caps, stripHtml + fts_rebuild wiring (v3.0.58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.58] — 2026-05-30
+
+### Fixed
+Validator unification + draft/send symmetry + IMAP/parser residuals (W3-A batch of the 2026-05-28 audit). Scope: `src/utils/helpers.ts`, `src/services/simple-imap-service.ts`, `src/tools/sending.ts`, `src/tools/drafts.ts`, `src/tools/reading.ts`.
+
+- **SMTP-011** — `saveDraft` now returns a structured, actionable error ("No Drafts folder found…") instead of appending to a literal "Drafts" path; `findDraftsFolder` returns `null` when no Drafts mailbox is resolvable.
+- **SMTP-012** — `saveDraft` strips CR/LF/NUL from `subject`/`to`/`cc`/`bcc` (not just `inReplyTo`/`references`/attachments), closing the header-injection asymmetry the old comment falsely claimed.
+- **VALID-002** — `search_emails` length-caps `body`/`text`/`bcc` at 500 chars; the service's `sanitizeImapStr` now also strips `\r`/`\n`/NUL to block IMAP command-line smuggling.
+- **VALID-003** — unified the two divergent `validateFolderName` implementations: the IMAP service now delegates to a single shared `validateImapPath()` in `helpers.ts`.
+- **VALID-005** — `saveDraft` enforces the same attachment count (20) and per-file/total size caps (25 MB) as the SMTP send path.
+- **VALID-006** — `validateAttachments` now caps per-file and aggregate attachment content size.
+- **VALID-015** — tools route `args.attachments` through a new `sanitizeAttachments()` that keeps only known fields, stripping attacker-controlled keys (`path`/`href`/`raw`/`encoding`) that nodemailer would otherwise honor.
+- **PARSE-008** — `stripHtml` now decodes HTML entities (incl. numeric decimal/hex) BEFORE stripping tags, so encoded `&lt;script&gt;` cannot emerge as live markup in FTS/bodyPreview.
+- **PARSE-009** — `stripHtml` strips HTML comments (`<!-- … -->`) up front so their contents don't survive as prose.
+- **PARSE-003 (wiring)** — `fts_rebuild` tool handler switched from non-atomic `clear()`+`upsertMany()` to the atomic `rebuild(records)` (the atomic method shipped in v3.0.54).
+
 ## [3.0.57] — 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.57-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.58-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -359,6 +359,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: When `findDraftsFolder` finds no `\Drafts` special-use folder and no name match, it returns the literal string `"Drafts"`. `saveDraft` then calls `this.client.append("Drafts", rawMime, ['\\Draft'])`. If the account has no "Drafts" mailbox (Proton's name is `Drafts` so usually OK, but custom-named accounts, non-English locales, or accounts where the user renamed/deleted the folder), the IMAP server will return `NO [TRYCREATE]` or similar. `saveDraft` catches it (line 1454) and returns `{success:false, error: <imap message>}` — so the user sees a generic IMAP error rather than an actionable "no Drafts folder configured." Worse, if Drafts is read-only/no-perm (subscribed but `\Noselect`), append will fail late.
 - Repro hypothesis: rename Drafts → "Brouillons" in Proton UI; call `save_draft` — returns IMAP error like `Mailbox doesn't exist: Drafts`.
 - Suggested next step: when fallback is taken, log a warning + return a structured `error: "Drafts folder not found; configure or create one"`; optionally try `client.mailboxCreate("Drafts")` before append.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** `findDraftsFolder` now returns `null` (instead of the literal `"Drafts"`) when no `\Drafts` special-use folder and no name match exist; `saveDraft` logs a warning and returns `{success:false, error:"No Drafts folder found for this account; create or configure a Drafts mailbox."}` without attempting the append.
 
 #### SMTP-012 — `saveDraft` does not strip CRLF from `subject` like SMTP path does
 - Location: `src/services/simple-imap-service.ts:1404-1416`
@@ -368,6 +369,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: SMTP `sendEmail` runs `stripHeaderInjection(options.subject)` (`smtp-service.ts:321`); the IMAP draft path passes `options.subject || '(No Subject)'` straight into nodemailer's `mailOptions.subject` with no sanitization. Nodemailer is generally CRLF-aware on the well-known `subject` header so this may be mitigated downstream, but the asymmetry contradicts the comment block on lines 1411-1413 that explicitly claims "Mirrors the stripHeaderInjection() call in smtp-service.ts" (it only mirrors for `inReplyTo` / `references` / `attachments`, NOT subject, To, Cc, Bcc). A draft can be saved with a header-injected subject; once the user opens and sends it from Proton web, the behavior depends on Proton's own re-encoding.
 - Repro hypothesis: call `save_draft` with `subject: "Hello\r\nBcc: leak@evil.com"`; inspect the appended MIME for an injected `Bcc:` line.
 - Suggested next step: pre-strip subject / to / cc / bcc through the same regex `[\r\n\x00]` before passing to nodemailer; update the comment.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** `saveDraft` now runs `subject`, `to`, `cc`, and `bcc` through a `stripCrlf()` (`[\r\n\x00]`) helper before handing them to nodemailer, matching `stripHeaderInjection()` on the SMTP path; the misleading comment was corrected.
 
 #### SMTP-008 — `processDue` "isProcessing" guard skips items silently across overlapping ticks
 - Location: `src/services/scheduler.ts:156-168`
@@ -1231,6 +1233,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The MCP handler enforces `MAX_SEARCH_TEXT = 500` on `from`, `to`, `subject` but the `body`, `text`, and `bcc` filters are read with only `typeof === 'string'` and forwarded unbounded. The service layer's `sanitizeImapStr = s.replace(/["\\]/g, "")` strips quotes/backslashes but leaves CRLF, NUL, and the full C0 class intact.
 - Repro hypothesis: Pass a 5 MB `body` filter — server burns memory; pass `body: "x\r\nA002 LOGOUT"` — sanitiser passes it untouched.
 - Suggested next step: Length-cap `body`/`text`/`bcc` at `MAX_SEARCH_TEXT`; extend `sanitizeImapStr` to also strip `\r`, `\n`, `\x00`.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** The `search_emails` handler now length-caps `body`/`text`/`bcc` at `MAX_SEARCH_TEXT` (500), and `sanitizeImapStr` strips `\r`/`\n`/`\x00` in addition to quote/backslash.
 
 #### VALID-003 — Two `validateFolderName` functions with the same name and contradictory rules
 - Location: `src/services/simple-imap-service.ts:326-342` vs `src/utils/helpers.ts:205-216`
@@ -1240,6 +1243,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The helpers' version is a "leaf only" check (rejects `/`, cap 255); the IMAP service's version is a "full-path" check (allows `/`, cap 1000). Code review at call sites must constantly disambiguate which one is in scope. This is exactly the shape of the v3.0.41 bug.
 - Repro hypothesis: A future tool that imports `validateFolderName` from helpers but means to pass `Folders/Work` will throw `"folder contains invalid characters"`.
 - Suggested next step: Rename the IMAP-private one to `validateImapPath` (or fold both into one well-named helper). Match length caps.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** Added a single shared full-path validator `validateImapPath()` in `helpers.ts`; the IMAP service's private `validateFolderName(name)` now delegates to it (rethrowing the message as an `Error`). The two no longer diverge. (The leaf-only `validateFolderName` in helpers stays distinct by design and is unchanged.)
 
 #### VALID-005 — `saveDraft` has no attachment count or size cap (asymmetric to `sendEmail`)
 - Location: `src/services/simple-imap-service.ts:1418-1442` vs `src/services/smtp-service.ts:378-415`
@@ -1249,6 +1253,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: SMTP send enforces `MAX_ATTACHMENTS = 20`, `MAX_ATTACHMENT_BYTES = 25 MB`. The IMAP `saveDraft` path mirrors the *sanitisation* but does **not** mirror the *size caps*. An agent can `save_draft` an unbounded Buffer/base64 payload, which nodemailer then buffers in RAM before `client.append`.
 - Repro hypothesis: `save_draft` with a 500 MB base64 attachment — process OOMs.
 - Suggested next step: Lift the per-file / total-size caps into a shared helper and apply in `saveDraft`.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** Shared caps (`MAX_ATTACHMENT_COUNT=20`, `MAX_ATTACHMENT_BYTES`/`MAX_TOTAL_ATTACHMENT_BYTES=25 MB`) and an `attachmentByteSize()` helper now live in `helpers.ts`; `saveDraft` enforces count + per-file + aggregate size before nodemailer buffers the payload, matching the SMTP send path.
 
 #### VALID-006 — `validateAttachments` allows arbitrarily large `content` strings
 - Location: `src/utils/helpers.ts:298-325`
@@ -1257,6 +1262,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: The helper guards `Array.isArray`, `length > 50`, `filename` is non-empty string, and `content` is string-or-Buffer. There is no length cap on the string/buffer itself.
 - Suggested next step: Add a per-element byte cap inside `validateAttachments`.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** `validateAttachments` now computes decoded byte size per element (`attachmentByteSize`) and rejects when any single file exceeds `MAX_ATTACHMENT_BYTES` or the aggregate exceeds `MAX_TOTAL_ATTACHMENT_BYTES`. The count cap was also tightened from 50 to `MAX_ATTACHMENT_COUNT` (20) to match the send path.
 
 #### VALID-009 — Tools that call `getEmailById(_, args.folder)` skip `validateTargetFolder`
 - Location: `src/tools/reading.ts:516-520, 719-726, 835-849`
@@ -1274,6 +1280,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `validateAttachments` rejects non-arrays and non-objects but doesn't strip extra keys. Casts then carry unknown attacker-controlled fields (`encoding`, `path`, `href`, `raw`) into nodemailer, which interprets some — e.g. `path` causes nodemailer to read a file from disk.
 - Repro hypothesis: `send_email({ attachments: [{ filename: "x", content: "y", path: "/etc/passwd" }] })` — nodemailer would prefer `path` over `content`.
 - Suggested next step: In `validateAttachments`, return a new sanitised array with only `{filename, content, contentType, contentId}`.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** Added `sanitizeAttachments()` in `helpers.ts` that rebuilds each element with only `{filename, content, contentType, size, contentId}`, dropping attacker-controlled keys (`path`/`href`/`raw`/`encoding`). `send_email`, `save_draft`, and `schedule_email` now use it instead of `args.attachments as EmailAttachment[]`.
 
 #### VALID-004 — Helpers `validateLabelName` and `validateFolderName` are byte-identical duplicates
 - Location: `src/utils/helpers.ts:185-196` and `205-216`
@@ -1421,6 +1428,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Inject a malformed `EmailMessage` with `body` of type `Buffer` instead of string → `stripHtml` throws on `.replace`, leaving the index wiped.
 - Suggested next step: Wrap clear+upsertMany in a single `db.transaction`.
 > **Resolved in v3.0.54 — parser/analytics hardening.** Added `FtsIndexService.rebuild(records)` that runs the `DELETE` + bulk upsert inside one `db.transaction`, rolling back to the prior index on any throw. The `fts_rebuild` tool handler in `src/tools/reading.ts` (not in this batch's ownership) should be switched from `clear()`+`upsertMany()` to `rebuild()` — flagged to the tools batch.
+> **Wiring completed in v3.0.58 — validator/draft/parser hardening.** The `fts_rebuild` tool handler in `src/tools/reading.ts` now calls `fts.rebuild([...])` instead of the non-atomic `fts.clear()` + `fts.upsertMany(...)` pair, so a throw mid-rebuild no longer leaves the index wiped.
 
 #### PARSE-004 — `processContacts()` silently drops every new contact past the 10 000-cap including the largest senders
 - Location: `src/services/analytics-service.ts:124-146, 148-164`
@@ -1498,6 +1506,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Inject an email whose plaintext body literally contains `&lt;script&gt;evil()&lt;/script&gt;`; observe FTS body now contains raw `<script>...</script>`.
 - Suggested next step: Decode entities FIRST, then strip tags (the standard order); handle numeric entities for parity.
 > **Deferred — owned by the IMAP batch (v3.0.54 parser batch).** `stripHtml` lives in `src/services/simple-imap-service.ts`, which the parser/analytics batch must not touch. Flagged to the IMAP batch for the entity-decode-order fix.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** `stripHtml` now decodes entities (named + numeric decimal `&#NN;` and hex `&#xNN;`) BEFORE stripping tags, so encoded markup like `&lt;script&gt;…&lt;/script&gt;` decodes to real tags that the subsequent tag-strip removes, rather than surfacing as literal `<script>` in the FTS body / bodyPreview. `&amp;` is decoded last so double-encoded sequences are not collapsed into live markup.
 
 #### PARSE-009 — `stripHtml` ignores HTML comments
 - Location: `src/services/simple-imap-service.ts:61-75`
@@ -1507,6 +1516,7 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: HTML comments are `<!-- ... -->`; the regex consumes `<!--` and `-->`, but leaves any HTML inside the comment visible as tag-stripped prose. `<!-- secret: pw123 -->` becomes `  -- secret: pw123 --` in the FTS body.
 - Suggested next step: Add `.replace(/<!--[\s\S]*?-->/g, ' ')` as the first pass.
 > **Deferred — owned by the IMAP batch (v3.0.54 parser batch).** `stripHtml` lives in `src/services/simple-imap-service.ts`, outside this batch's ownership. Flagged to the IMAP batch for the comment-stripping pass.
+> **Resolved in v3.0.58 — validator/draft/parser hardening.** `stripHtml` now drops HTML comments (`/<!--[\s\S]*?-->/g`) as the first pass, so the contents of `<!-- secret: pw123 -->` no longer survive as tag-stripped prose in the FTS body.
 
 #### PARSE-011 — iCal parser ignores `BEGIN:VEVENT` lines with parameters
 - Location: `src/services/content-parser.ts:220-232`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.57",
+  "version": "3.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.57",
+      "version": "3.0.58",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.57",
+  "version": "3.0.58",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/folder-management.test.ts
+++ b/src/services/folder-management.test.ts
@@ -290,13 +290,14 @@ describe('validateFolderName edge cases', () => {
   it('throws when folder name is empty (line 240)', async () => {
     const svc = new SimpleIMAPService();
     await svc.connect('localhost', 1143, 'user', 'pass');
-    await expect(svc.createFolder('')).rejects.toThrow('Folder name must not be empty');
+    // VALID-003: message now comes from the shared validateImapPath().
+    await expect(svc.createFolder('')).rejects.toThrow(/non-empty string/i);
   });
 
   it('throws when folder name exceeds 1000 chars (line 244)', async () => {
     const svc = new SimpleIMAPService();
     await svc.connect('localhost', 1143, 'user', 'pass');
-    await expect(svc.createFolder('a'.repeat(1001))).rejects.toThrow('Folder name is too long');
+    await expect(svc.createFolder('a'.repeat(1001))).rejects.toThrow(/exceeds maximum length/i);
   });
 });
 

--- a/src/services/simple-imap-service.newfeatures.test.ts
+++ b/src/services/simple-imap-service.newfeatures.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { SimpleIMAPService } from "./simple-imap-service.js";
+import { SimpleIMAPService, stripHtml } from "./simple-imap-service.js";
 
 // ─── downloadAttachment tests ─────────────────────────────────────────────────
 
@@ -241,6 +241,16 @@ describe("SimpleIMAPService.downloadAttachment", () => {
 // ─── saveDraft tests ──────────────────────────────────────────────────────────
 
 describe("SimpleIMAPService.saveDraft", () => {
+  // SMTP-011: findDraftsFolder now returns null (→ structured error) when no
+  // Drafts mailbox is resolvable. Tests that exercise the append path must seed
+  // a Drafts folder into the cache so resolution succeeds.
+  const seedDraftsCache = (svc: SimpleIMAPService) => {
+    (svc as any).folderCache.set("Drafts", {
+      name: "Drafts", path: "Drafts", totalMessages: 0, unreadMessages: 0,
+      folderType: "system", specialUse: "\\Drafts",
+    });
+  };
+
   it("returns error when not connected", async () => {
     const svc = new SimpleIMAPService();
     // client is null, isConnected is false by default
@@ -256,6 +266,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 42 }),
     };
+    seedDraftsCache(svc);
 
     const result = await svc.saveDraft({
       to: "bob@example.com",
@@ -273,6 +284,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockRejectedValue(new Error("APPEND failed")),
     };
+    seedDraftsCache(svc);
 
     const result = await svc.saveDraft({ subject: "Test", body: "Hello" });
     expect(result.success).toBe(false);
@@ -285,6 +297,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 1 }),
     };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({});
     expect(result.success).toBe(true);
   });
@@ -294,6 +307,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     const appendMock = vi.fn().mockResolvedValue({ uid: 5 });
     (svc as any).isConnected = true;
     (svc as any).client = { append: appendMock };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({
       subject: "With attachment",
       body: "See attached",
@@ -336,6 +350,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 6 }),
     };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({
       subject: "HTML draft",
       body: "<p>Hello</p>",
@@ -349,6 +364,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     const appendMock = vi.fn().mockResolvedValue({ uid: 7 });
     (svc as any).isConnected = true;
     (svc as any).client = { append: appendMock };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({
       subject: "Reply",
       body: "See above",
@@ -375,6 +391,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 8 }),
     };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({
       to: ["alice@example.com", "bob@example.com"],  // array → line 1154 branch 0
       cc: "carol@example.com",                        // string → line 1157 branch 1
@@ -391,6 +408,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 9 }),
     };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({
       to: "alice@example.com",               // string → existing coverage
       cc: ["cc1@example.com", "cc2@example.com"], // array → line 1157 branch 0
@@ -407,6 +425,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue(null), // result is null → typeof result !== 'object' is... actually null IS typeof object
     };
+    seedDraftsCache(svc);
     // Actually: null → typeof null === 'object' but result && ... is false (null is falsy)
     const result = await svc.saveDraft({ subject: "Test", body: "Body" });
     expect(result.success).toBe(true);
@@ -419,6 +438,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 10 }),
     };
+    seedDraftsCache(svc);
     // isHtml=true AND body='' → html: (options.body || '') evaluates the || branch
     const result = await svc.saveDraft({
       subject: "HTML Draft",
@@ -434,6 +454,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 11 }),
     };
+    seedDraftsCache(svc);
     // filename = "\r\n\x00" → after replace becomes "" → "" || "attachment" = "attachment"
     const result = await svc.saveDraft({
       subject: "Test",
@@ -453,6 +474,7 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockResolvedValue({ uid: 12 }),
     };
+    seedDraftsCache(svc);
     // contentType is undefined → rawCt = undefined → safeContentType = undefined
     const result = await svc.saveDraft({
       subject: "Test",
@@ -472,9 +494,80 @@ describe("SimpleIMAPService.saveDraft", () => {
     (svc as any).client = {
       append: vi.fn().mockRejectedValue("string-error"), // string, not Error instance
     };
+    seedDraftsCache(svc);
     const result = await svc.saveDraft({ subject: "Test", body: "Hello" });
     expect(result.success).toBe(false);
     expect(result.error).toBe("string-error"); // String("string-error")
+  });
+
+  // SMTP-011: no Drafts folder → actionable error, append never attempted.
+  it("SMTP-011: returns an actionable error when no Drafts folder exists", async () => {
+    const svc = new SimpleIMAPService();
+    const appendMock = vi.fn();
+    (svc as any).isConnected = true;
+    (svc as any).client = { append: appendMock };
+    // Cache empty + getFolders returns no draft-like folder → findDraftsFolder null.
+    vi.spyOn(svc, "getFolders").mockResolvedValue([
+      { name: "INBOX", path: "INBOX", totalMessages: 0, unreadMessages: 0, folderType: "system" as const },
+    ]);
+    const result = await svc.saveDraft({ subject: "x", body: "y" });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/no drafts folder/i);
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  // SMTP-012: subject / to / cc / bcc CRLF must be stripped before append.
+  it("SMTP-012: strips CRLF from subject and address fields", async () => {
+    const svc = new SimpleIMAPService();
+    const appendMock = vi.fn().mockResolvedValue({ uid: 99 });
+    (svc as any).isConnected = true;
+    (svc as any).client = { append: appendMock };
+    seedDraftsCache(svc);
+    const result = await svc.saveDraft({
+      subject: "Hello\r\nBcc: leak@evil.com",
+      to: "alice@example.com\r\nBcc: leak2@evil.com",
+      body: "hi",
+    });
+    expect(result.success).toBe(true);
+    const [, rawMime] = appendMock.mock.calls[0];
+    const wire = Buffer.isBuffer(rawMime) ? rawMime.toString("utf8") : String(rawMime);
+    // The injected "Bcc:" must not appear as its own header line.
+    expect(wire).not.toMatch(/\r?\n\s*Bcc:\s*leak@evil\.com/);
+    expect(wire).not.toMatch(/\r?\nBcc:\s*leak2@evil\.com/);
+  });
+
+  // VALID-005: per-file size cap mirrors the SMTP send path.
+  it("VALID-005: rejects an oversized attachment before append", async () => {
+    const svc = new SimpleIMAPService();
+    const appendMock = vi.fn().mockResolvedValue({ uid: 1 });
+    (svc as any).isConnected = true;
+    (svc as any).client = { append: appendMock };
+    seedDraftsCache(svc);
+    const huge = Buffer.alloc(26 * 1024 * 1024); // 26 MB > 25 MB cap
+    const result = await svc.saveDraft({
+      subject: "big",
+      body: "see attached",
+      attachments: [{ filename: "big.bin", content: huge, contentType: "application/octet-stream", size: huge.length }],
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too large/i);
+    expect(appendMock).not.toHaveBeenCalled();
+  });
+
+  // VALID-005: count cap mirrors the SMTP send path.
+  it("VALID-005: rejects more than MAX_ATTACHMENT_COUNT attachments", async () => {
+    const svc = new SimpleIMAPService();
+    const appendMock = vi.fn().mockResolvedValue({ uid: 1 });
+    (svc as any).isConnected = true;
+    (svc as any).client = { append: appendMock };
+    seedDraftsCache(svc);
+    const many = Array.from({ length: 21 }, (_, i) => ({
+      filename: `f${i}.txt`, content: "x", contentType: "text/plain", size: 1,
+    }));
+    const result = await svc.saveDraft({ subject: "many", body: "x", attachments: many });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/too many attachments/i);
+    expect(appendMock).not.toHaveBeenCalled();
   });
 });
 
@@ -494,11 +587,11 @@ describe("SimpleIMAPService private findDraftsFolder", () => {
     expect(path).toBe("Drafts");
   });
 
-  it("falls through to 'Drafts' when cache is empty and getFolders() throws", async () => {
+  it("returns null when cache is empty and getFolders() throws (SMTP-011)", async () => {
     const svc = new SimpleIMAPService();
     vi.spyOn(svc, "getFolders").mockRejectedValue(new Error("no connection"));
     const path = await (svc as any).findDraftsFolder();
-    expect(path).toBe("Drafts");
+    expect(path).toBeNull();
   });
 
   it("returns path from getFolders() when cache is empty but folders are found", async () => {
@@ -511,7 +604,7 @@ describe("SimpleIMAPService private findDraftsFolder", () => {
     expect(path).toBe("MyDrafts");
   });
 
-  it("falls through to 'Drafts' when getFolders() returns no matching folders (line 1109 branch1)", async () => {
+  it("returns null when getFolders() returns no matching folders (SMTP-011)", async () => {
     const svc = new SimpleIMAPService();
     // Return real folders that don't match drafts patterns
     vi.spyOn(svc, "getFolders").mockResolvedValue([
@@ -519,7 +612,7 @@ describe("SimpleIMAPService private findDraftsFolder", () => {
       { name: "Sent", path: "Sent", totalMessages: 0, unreadMessages: 0, folderType: "system" as const },
     ]);
     const path = await (svc as any).findDraftsFolder();
-    expect(path).toBe("Drafts");
+    expect(path).toBeNull();
   });
 });
 
@@ -829,17 +922,17 @@ describe("SimpleIMAPService.healthCheck", () => {
 describe("SimpleIMAPService private validateFolderName — path traversal guard", () => {
   it("throws for a folder name containing '..'", () => {
     const svc = new SimpleIMAPService();
-    expect(() => (svc as any).validateFolderName("../../etc")).toThrow(/path traversal/i);
+    expect(() => (svc as any).validateFolderName("../../etc")).toThrow(/invalid characters/i);
   });
 
   it("throws for a folder name that is exactly '..'", () => {
     const svc = new SimpleIMAPService();
-    expect(() => (svc as any).validateFolderName("..")).toThrow(/path traversal/i);
+    expect(() => (svc as any).validateFolderName("..")).toThrow(/invalid characters/i);
   });
 
   it("throws for 'Folders/../INBOX' traversal", () => {
     const svc = new SimpleIMAPService();
-    expect(() => (svc as any).validateFolderName("Folders/../INBOX")).toThrow(/path traversal/i);
+    expect(() => (svc as any).validateFolderName("Folders/../INBOX")).toThrow(/invalid characters/i);
   });
 
   it("accepts a normal folder path with no traversal", () => {
@@ -855,6 +948,23 @@ describe("SimpleIMAPService private validateFolderName — path traversal guard"
   it("still throws for control characters (existing behaviour preserved)", () => {
     const svc = new SimpleIMAPService();
     expect(() => (svc as any).validateFolderName("INBOX\x00evil")).toThrow(/control characters/i);
+  });
+
+  // VALID-003: the service-private validateFolderName and the shared
+  // helpers.validateImapPath must agree on the same set of malicious inputs.
+  it("VALID-003: service and shared validator reject the same malicious names", async () => {
+    const { validateImapPath } = await import("../utils/helpers.js");
+    const svc = new SimpleIMAPService();
+    const bad = ["", "   ", "..", "Folders/../etc", "INBOX\x00x", "a\r\nA1 LOGOUT", "x".repeat(1001)];
+    for (const name of bad) {
+      expect(validateImapPath(name), `helpers should reject ${JSON.stringify(name)}`).not.toBeNull();
+      expect(() => (svc as any).validateFolderName(name), `service should reject ${JSON.stringify(name)}`).toThrow();
+    }
+    const good = ["INBOX", "Folders/Work", "Labels/MyLabel"];
+    for (const name of good) {
+      expect(validateImapPath(name)).toBeNull();
+      expect(() => (svc as any).validateFolderName(name)).not.toThrow();
+    }
   });
 });
 
@@ -1021,5 +1131,52 @@ describe("SimpleIMAPService.stopIdle", () => {
     (svc as any).idleClient = null;
     (svc as any).idleActive = false;
     expect(() => svc.stopIdle()).not.toThrow();
+  });
+});
+
+// ─── stripHtml — entity-decode order (PARSE-008) + comment stripping (PARSE-009) ─
+describe("stripHtml", () => {
+  it("PARSE-008: encoded <script> does not emerge as literal HTML tags", () => {
+    const out = stripHtml("&lt;script&gt;alert(1)&lt;/script&gt;");
+    // Decoded to real <script>...</script>, then tag-stripped → no raw markup.
+    expect(out).not.toMatch(/<script/i);
+    expect(out).not.toMatch(/<\/script>/i);
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+  });
+
+  it("PARSE-008: numeric entities (decimal + hex) are decoded then stripped", () => {
+    const dec = stripHtml("&#60;script&#62;x&#60;/script&#62;");
+    expect(dec).not.toContain("<");
+    const hex = stripHtml("&#x3c;script&#x3e;x&#x3c;/script&#x3e;");
+    expect(hex).not.toContain("<");
+  });
+
+  it("PARSE-009: HTML comment contents do not survive as prose", () => {
+    const out = stripHtml("before<!-- secret: pw123 -->after");
+    expect(out).not.toMatch(/secret/);
+    expect(out).not.toMatch(/pw123/);
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+  });
+
+  it("PARSE-009: multi-line comments are fully removed", () => {
+    const out = stripHtml("a<!--\nhidden\nlines\n-->b");
+    expect(out).not.toMatch(/hidden/);
+    expect(out).toContain("a");
+    expect(out).toContain("b");
+  });
+
+  it("still strips style/script blocks and plain tags", () => {
+    expect(stripHtml("<style>.x{}</style><p>hi</p>")).toBe("hi");
+    expect(stripHtml("<script>evil()</script>visible")).toBe("visible");
+  });
+
+  it("decodes &amp; without re-interpreting it", () => {
+    expect(stripHtml("Tom &amp; Jerry")).toBe("Tom & Jerry");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripHtml("")).toBe("");
   });
 });

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -10,6 +10,13 @@ import { simpleParser } from 'mailparser';
 import nodemailer, { type SendMailOptions } from 'nodemailer';
 import { EmailMessage, EmailFolder, SearchEmailOptions, SaveDraftOptions } from '../types/index.js';
 import { logger } from '../utils/logger.js';
+import {
+  validateImapPath,
+  attachmentByteSize,
+  MAX_ATTACHMENT_COUNT,
+  MAX_ATTACHMENT_BYTES,
+  MAX_TOTAL_ATTACHMENT_BYTES,
+} from '../utils/helpers.js';
 import { buildBridgeTlsOptions, readPinnedBridgeCert } from './bridge-tls.js';
 import { tracer, type SpanTags } from '../utils/tracer.js';
 import { BRIDGE_MIN_VERSION } from '../config/schema.js';
@@ -74,16 +81,31 @@ interface ImapBodyNode {
  */
 export function stripHtml(html: string): string {
   if (!html) return '';
-  return html
+  // Decode entities BEFORE stripping tags (PARSE-008). The old order stripped
+  // tags first then decoded, so an encoded `&lt;script&gt;...&lt;/script&gt;`
+  // emerged as a literal `<script>...</script>` in the FTS body / bodyPreview —
+  // stored-XSS if any consumer rendered those fields as HTML. Decoding first
+  // turns the encoded markup into real tags that the tag-strip then removes.
+  // HTML comments are dropped up front (PARSE-009) so their inner text (e.g.
+  // `<!-- secret: pw123 -->`) doesn't survive as tag-stripped prose.
+  const decodeEntities = (s: string): string =>
+    s
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&#x27;/gi, "'")
+      // Numeric entities (decimal &#60; and hex &#x3c;) for parity, so
+      // `&#60;script&#62;` is also neutralised by the subsequent tag-strip.
+      .replace(/&#(\d{1,7});/g, (_m, d) => String.fromCodePoint(Number(d)))
+      .replace(/&#x([0-9a-f]{1,6});/gi, (_m, h) => String.fromCodePoint(parseInt(h, 16)))
+      .replace(/&amp;/g, '&');
+
+  return decodeEntities(html.replace(/<!--[\s\S]*?-->/g, ' '))
     .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
     .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
     .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -483,20 +505,14 @@ export class SimpleIMAPService {
    *  is well above any real-world folder name and caps the DoS surface.
    */
   private validateFolderName(name: string): void {
-    if (!name || name.trim().length === 0) {
-      throw new Error('Folder name must not be empty');
-    }
-    // RFC 5321 / practical sanity: no folder name should exceed 1 000 chars.
-    if (name.length > 1_000) {
-      throw new Error(`Folder name is too long: ${name.length} characters (max 1000)`);
-    }
-    if (/[\x00-\x1f]/.test(name)) {
-      throw new Error(`Folder name contains invalid control characters: ${JSON.stringify(name.slice(0, 80))}`);
-    }
-    // Reject path-traversal sequences (e.g. "../../etc") — defence-in-depth
-    // alongside the handler-level validateTargetFolder() checks.
-    if (name.includes('..')) {
-      throw new Error(`Folder name contains invalid path traversal sequence: ${JSON.stringify(name.slice(0, 80))}`);
+    // VALID-003: delegate to the shared full-path validator in helpers.ts so the
+    // service no longer carries a second, drifting copy of the rules (empty /
+    // length-1000 / C0-control / ".." traversal). This is a `targetFolder`-style
+    // full path (separators allowed), NOT the leaf-only validateFolderName in
+    // helpers — hence validateImapPath, the unified full-path check.
+    const err = validateImapPath(name);
+    if (err) {
+      throw new Error(`Invalid folder path: ${err} ${JSON.stringify(String(name).slice(0, 80))}`);
     }
   }
 
@@ -1135,7 +1151,9 @@ export class SimpleIMAPService {
       // search criteria injection.  imapflow passes these as quoted strings
       // in the IMAP SEARCH command, so an unescaped '"' would close the
       // quoted string early, and '\' could escape the closing quote.
-      const sanitizeImapStr = (s: string) => s.replace(/["\\]/g, "");
+      // VALID-002: also strip CR/LF/NUL — a value like "x\r\nA002 LOGOUT" would
+      // otherwise smuggle a command line into the IMAP stream.
+      const sanitizeImapStr = (s: string) => s.replace(/["\\\r\n\x00]/g, "");
       if (options.from) searchCriteria.from = sanitizeImapStr(options.from);
       if (options.to) searchCriteria.to = sanitizeImapStr(options.to);
       if (options.subject) searchCriteria.subject = sanitizeImapStr(options.subject);
@@ -1529,9 +1547,15 @@ export class SimpleIMAPService {
   /**
    * Resolve the server-side Drafts folder path.
    * Prefers the folder with specialUse === '\\Drafts'; falls back to a
-   * case-insensitive name match against common names; last resort 'Drafts'.
+   * case-insensitive name match against common names.
+   *
+   * SMTP-011: returns `null` when no Drafts folder can be resolved instead of a
+   * literal "Drafts" string. The old fallback caused `append("Drafts", ...)` to
+   * fail late with an opaque server error on accounts where Drafts was renamed
+   * (e.g. "Brouillons"), localised, or deleted. `saveDraft` turns the null into
+   * an actionable error.
    */
-  private async findDraftsFolder(): Promise<string> {
+  private async findDraftsFolder(): Promise<string | null> {
     // Check folder cache first (populated by getFolders / markEmailRead etc.)
     const cached = Array.from(this.folderCache.values());
     const fromCache = this.pickDraftsFolder(cached);
@@ -1543,10 +1567,10 @@ export class SimpleIMAPService {
       const found = this.pickDraftsFolder(folders);
       if (found) return found;
     } catch {
-      // swallow — fall through to default
+      // swallow — fall through to "not found"
     }
 
-    return 'Drafts';
+    return null;
   }
 
   private pickDraftsFolder(folders: EmailFolder[]): string | null {
@@ -1581,34 +1605,59 @@ export class SimpleIMAPService {
     }
 
     try {
+      // SMTP-012: strip CR/LF/NUL from header-bound fields (subject, to, cc,
+      // bcc) before handing them to nodemailer, mirroring stripHeaderInjection()
+      // in smtp-service.ts. The previous comment claimed parity but only the
+      // inReplyTo/references/attachment paths were sanitised — subject/to/cc/bcc
+      // flowed through raw, so "Hello\r\nBcc: leak@evil.com" could inject a
+      // header line into the appended MIME.
+      const stripCrlf = (s: string) => s.replace(/[\r\n\x00]/g, "");
+
       // Build the raw MIME message using nodemailer's buffer transport
       const transport = nodemailer.createTransport({ streamTransport: true, buffer: true, newline: 'crlf' });
 
-      const toAddresses = !options.to
-        ? undefined
-        : Array.isArray(options.to) ? options.to.join(', ') : options.to;
-      const ccAddresses = !options.cc
-        ? undefined
-        : Array.isArray(options.cc) ? options.cc.join(', ') : options.cc;
-      const bccAddresses = !options.bcc
-        ? undefined
-        : Array.isArray(options.bcc) ? options.bcc.join(', ') : options.bcc;
+      const joinAddrs = (v: string | string[] | undefined) =>
+        !v ? undefined : stripCrlf(Array.isArray(v) ? v.join(', ') : v);
+      const toAddresses = joinAddrs(options.to);
+      const ccAddresses = joinAddrs(options.cc);
+      const bccAddresses = joinAddrs(options.bcc);
 
       const mailOptions: SendMailOptions = {
         to: toAddresses,
         cc: ccAddresses,
         bcc: bccAddresses,
-        subject: options.subject || '(No Subject)',
+        subject: stripCrlf(options.subject || '(No Subject)'),
         text: options.isHtml ? undefined : (options.body || ''),
         html: options.isHtml ? (options.body || '') : undefined,
         // Strip CRLF and NUL from inReplyTo to prevent Message-ID header injection
         // (e.g. a crafted value like "<id>\r\nBcc: evil@x.com" would inject a raw
         // MIME header line).  Mirrors the stripHeaderInjection() call in smtp-service.ts.
-        inReplyTo: options.inReplyTo ? options.inReplyTo.replace(/[\r\n\x00]/g, "") : undefined,
+        inReplyTo: options.inReplyTo ? stripCrlf(options.inReplyTo) : undefined,
         references: options.references?.map(r => r.replace(/[\x00-\x1f\x7f]/g, "")).join(' '),
       };
 
       if (options.attachments && options.attachments.length > 0) {
+        // VALID-005: enforce the SAME count/size caps as the SMTP send path
+        // (smtp-service.ts). saveDraft previously mirrored only the sanitisation,
+        // so an unbounded base64 payload could OOM the process before append.
+        if (options.attachments.length > MAX_ATTACHMENT_COUNT) {
+          return { success: false, error: `Too many attachments: ${options.attachments.length} supplied, max ${MAX_ATTACHMENT_COUNT} allowed.` };
+        }
+        let totalBytes = 0;
+        for (const att of options.attachments) {
+          const bytes = attachmentByteSize(att.content);
+          if (bytes === null) {
+            return { success: false, error: `Attachment '${att.filename ?? "unnamed"}': content must be a Buffer or base64 string.` };
+          }
+          if (bytes > MAX_ATTACHMENT_BYTES) {
+            return { success: false, error: `Attachment '${att.filename ?? "unnamed"}' is too large: ${Math.round(bytes / 1024 / 1024)}MB exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per-file limit.` };
+          }
+          totalBytes += bytes;
+          if (totalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
+            return { success: false, error: `Total attachment size exceeds the ${MAX_TOTAL_ATTACHMENT_BYTES / 1024 / 1024}MB limit.` };
+          }
+        }
+
         // Mirror the sanitization performed in smtp-service.ts sendEmail() to prevent
         // MIME header injection via crafted attachment filenames or content-type values.
         // A filename like "a.pdf\r\nContent-Type: text/html" or a contentType like
@@ -1637,8 +1686,14 @@ export class SimpleIMAPService {
       const info = await transport.sendMail(mailOptions);
       const rawMime = info.message as Buffer;
 
-      // Append to Drafts folder with the \Draft IMAP flag
+      // Append to Drafts folder with the \Draft IMAP flag.
+      // SMTP-011: surface an actionable error when no Drafts mailbox exists
+      // instead of appending to a literal "Drafts" path that the server rejects.
       const draftsPath = await this.findDraftsFolder();
+      if (!draftsPath) {
+        logger.warn('No Drafts folder found for this account', 'IMAPService');
+        return { success: false, error: 'No Drafts folder found for this account; create or configure a Drafts mailbox.' };
+      }
       const result = await this.client.append(draftsPath, rawMime, ['\\Draft']);
 
       const uid = result && typeof result === 'object' ? (result as AppendResult).uid : undefined;

--- a/src/tools/drafts.ts
+++ b/src/tools/drafts.ts
@@ -6,8 +6,8 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { isValidEmail, requireNumericEmailId, validateAttachments } from "../utils/helpers.js";
-import type { EmailAttachment, EmailMessage } from "../types/index.js";
+import { isValidEmail, requireNumericEmailId, validateAttachments, sanitizeAttachments } from "../utils/helpers.js";
+import type { EmailMessage } from "../types/index.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const ACTION_RESULT_SCHEMA = {
@@ -309,7 +309,7 @@ export const handlers: Record<string, ToolHandler> = {
       subject: args.subject as string | undefined,
       body: args.body as string | undefined,
       isHtml: args.isHtml as boolean | undefined,
-      attachments: args.attachments as EmailAttachment[] | undefined,
+      attachments: sanitizeAttachments(args.attachments),
       inReplyTo: args.inReplyTo as string | undefined,
       references: args.references as string[] | undefined,
     });
@@ -370,7 +370,7 @@ export const handlers: Record<string, ToolHandler> = {
         isHtml: args.isHtml as boolean | undefined,
         priority: args.priority as "high" | "normal" | "low" | undefined,
         replyTo: args.replyTo as string | undefined,
-        attachments: args.attachments as EmailAttachment[] | undefined,
+        attachments: sanitizeAttachments(args.attachments),
       }, sendAt);
       return ok({ success: true, id: schedId, scheduledAt: sendAt.toISOString() },
         `Scheduled for ${sendAt.toISOString()} (ID: ${schedId})`);

--- a/src/tools/input-hygiene.test.ts
+++ b/src/tools/input-hygiene.test.ts
@@ -69,6 +69,30 @@ describe("tool input hygiene (v3.0.53)", () => {
     });
   });
 
+  // ── VALID-002 — search_emails length-caps body/text/bcc ────────────────
+  describe("VALID-002 search_emails body/text/bcc length cap", () => {
+    const over = "x".repeat(501);
+    for (const field of ["body", "text", "bcc"] as const) {
+      it(`rejects an over-long '${field}' filter`, async () => {
+        const ctx = makeCtx({
+          args: { [field]: over },
+          imapService: { searchEmails: vi.fn() } as never,
+        });
+        await expect(readingHandlers.search_emails(ctx)).rejects.toBeInstanceOf(McpError);
+      });
+    }
+
+    it("accepts body/text/bcc filters at the 500-char boundary", async () => {
+      const searchEmails = vi.fn().mockResolvedValue([]);
+      const ctx = makeCtx({
+        args: { body: "x".repeat(500), text: "y".repeat(500), bcc: "z".repeat(500) },
+        imapService: { searchEmails } as never,
+      });
+      await expect(readingHandlers.search_emails(ctx)).resolves.toBeDefined();
+      expect(searchEmails).toHaveBeenCalledOnce();
+    });
+  });
+
   // ── TOOL-002 — request_permission_escalation reason required ───────────
   describe("TOOL-002 escalation reason", () => {
     const escCtx = (args: Record<string, unknown>): EscalationContext =>
@@ -242,6 +266,31 @@ describe("tool input hygiene (v3.0.53)", () => {
     it("rejects a NaN sinceEpoch", async () => {
       const ctx = ftsCtx({ query: "x", sinceEpoch: Number.NaN });
       await expect(readingHandlers.fts_search(ctx)).rejects.toBeInstanceOf(McpError);
+    });
+  });
+
+  // ── PARSE-003 — fts_rebuild uses the atomic rebuild(), not clear()+upsertMany() ─
+  describe("PARSE-003 fts_rebuild wiring", () => {
+    it("calls rebuild() and never the non-atomic clear()/upsertMany() pair", async () => {
+      const rebuild = vi.fn().mockReturnValue(3);
+      const clear = vi.fn();
+      const upsertMany = vi.fn();
+      const stats = vi.fn().mockReturnValue({ messageCount: 3, dbPath: "/tmp/x.db" });
+      const ctx = makeCtx({
+        args: {},
+        getFts: () => ({ rebuild, clear, upsertMany, stats }) as never,
+        getAnalyticsEmails: async () => ({
+          inbox: [{ id: "1" }] as never,
+          sent: [{ id: "2" }, { id: "3" }] as never,
+        }),
+        recordFromEmail: ((e: { id: string }) => ({ id: e.id })) as never,
+      });
+      const res = await readingHandlers.fts_rebuild(ctx);
+      expect(rebuild).toHaveBeenCalledOnce();
+      expect(rebuild.mock.calls[0][0]).toHaveLength(3);
+      expect(clear).not.toHaveBeenCalled();
+      expect(upsertMany).not.toHaveBeenCalled();
+      expect((res.structuredContent as { indexed: number }).indexed).toBe(3);
     });
   });
 

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -603,9 +603,21 @@ export const handlers: Record<string, ToolHandler> = {
         throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must not be later than 'dateTo'.");
       }
     }
+    // VALID-002: length-cap body/text/bcc at MAX_SEARCH_TEXT like from/to/subject.
+    // These were previously read with only a typeof check and forwarded unbounded,
+    // letting a multi-MB filter burn server memory.
     const body     = typeof args.body === 'string' ? args.body : undefined;
     const text     = typeof args.text === 'string' ? args.text : undefined;
     const bcc      = typeof args.bcc === 'string' ? args.bcc : undefined;
+    if (body !== undefined && body.length > MAX_SEARCH_TEXT) {
+      throw new McpError(ErrorCode.InvalidParams, `'body' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+    }
+    if (text !== undefined && text.length > MAX_SEARCH_TEXT) {
+      throw new McpError(ErrorCode.InvalidParams, `'text' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+    }
+    if (bcc !== undefined && bcc.length > MAX_SEARCH_TEXT) {
+      throw new McpError(ErrorCode.InvalidParams, `'bcc' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+    }
     const answered = typeof args.answered === 'boolean' ? args.answered : undefined;
     const isDraft  = typeof args.isDraft === 'boolean' ? args.isDraft : undefined;
     const larger   = typeof args.larger === 'number' ? args.larger : undefined;
@@ -856,8 +868,11 @@ export const handlers: Record<string, ToolHandler> = {
     try {
       const fts = getFts();
       const { inbox, sent } = await getAnalyticsEmails();
-      fts.clear();
-      const indexed = fts.upsertMany([...inbox, ...sent].map(recordFromEmail));
+      // PARSE-003: atomic clear+repopulate in one transaction. A bare
+      // clear()+upsertMany() committed the DELETE immediately, so a throw mid-map
+      // (e.g. a malformed record) left the index wiped. rebuild() rolls back to
+      // the prior index on any throw.
+      const indexed = fts.rebuild([...inbox, ...sent].map(recordFromEmail));
       const stats = fts.stats();
       return ok({ indexed, messageCount: stats.messageCount, dbPath: stats.dbPath });
     } finally {

--- a/src/tools/sending.ts
+++ b/src/tools/sending.ts
@@ -7,8 +7,7 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { isValidEmail, optionalFolderHint, validateAttachments, requireNumericEmailId } from "../utils/helpers.js";
-import type { EmailAttachment } from "../types/index.js";
+import { isValidEmail, optionalFolderHint, validateAttachments, sanitizeAttachments, requireNumericEmailId } from "../utils/helpers.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const ACTION_RESULT_SCHEMA = {
@@ -156,7 +155,7 @@ export const handlers: Record<string, ToolHandler> = {
       isHtml: args.isHtml as boolean | undefined,
       priority: args.priority as "high" | "normal" | "low" | undefined,
       replyTo: args.replyTo as string | undefined,
-      attachments: args.attachments as EmailAttachment[] | undefined,
+      attachments: sanitizeAttachments(args.attachments),
     });
     if (!result.success) {
       return { content: [{ type: "text" as const, text: "Email delivery failed" }], isError: true };

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -16,6 +16,11 @@ import {
   validateTargetFolder,
   requireNumericEmailId,
   validateAttachments,
+  validateImapPath,
+  sanitizeAttachments,
+  attachmentByteSize,
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_COUNT,
   generateId,
   retry,
   sleep,
@@ -1260,6 +1265,100 @@ describe('helpers', () => {
       ]);
       expect(err).not.toBeNull();
       expect(err).toMatch(/attachments\[1\]/);
+    });
+
+    // VALID-006 — per-file and aggregate byte caps
+    it('VALID-006: rejects a single attachment whose decoded size exceeds the per-file cap', () => {
+      // base64 length ~= bytes / 0.75; build a string just over the cap
+      const bigBase64 = 'A'.repeat(Math.ceil((MAX_ATTACHMENT_BYTES + 1) / 0.75) + 8);
+      const err = validateAttachments([{ filename: 'huge.bin', content: bigBase64 }]);
+      expect(err).not.toBeNull();
+      expect(err).toMatch(/too large/i);
+    });
+
+    it('VALID-006: rejects when the aggregate size exceeds the total cap', () => {
+      // Two files each ~60% of the cap → individually fine, together over.
+      const halfish = 'A'.repeat(Math.ceil((MAX_ATTACHMENT_BYTES * 0.6) / 0.75));
+      const err = validateAttachments([
+        { filename: 'a.bin', content: halfish },
+        { filename: 'b.bin', content: halfish },
+      ]);
+      expect(err).not.toBeNull();
+      expect(err).toMatch(/total attachment size/i);
+    });
+
+    it('VALID-005/006: count cap is now MAX_ATTACHMENT_COUNT (20), matching the send path', () => {
+      const many = Array.from({ length: MAX_ATTACHMENT_COUNT + 1 }, (_, i) => ({ filename: `f${i}`, content: 'x' }));
+      const err = validateAttachments(many);
+      expect(err).not.toBeNull();
+      expect(err).toMatch(new RegExp(`${MAX_ATTACHMENT_COUNT}`));
+    });
+  });
+
+  // ── VALID-003: unified full-path validator ─────────────────────────────────
+  describe('validateImapPath (VALID-003)', () => {
+    it('accepts a plain folder name', () => {
+      expect(validateImapPath('INBOX')).toBeNull();
+    });
+    it('accepts a path with separators (full path)', () => {
+      expect(validateImapPath('Folders/Work')).toBeNull();
+    });
+    it('rejects empty / whitespace', () => {
+      expect(validateImapPath('')).toMatch(/non-empty/i);
+      expect(validateImapPath('   ')).toMatch(/non-empty/i);
+    });
+    it('rejects path traversal', () => {
+      expect(validateImapPath('Folders/../etc')).toMatch(/invalid characters/i);
+    });
+    it('rejects C0 control characters', () => {
+      expect(validateImapPath('Work\x00hack')).toMatch(/invalid characters/i);
+      expect(validateImapPath('Work\r\nA1 LOGOUT')).toMatch(/invalid characters/i);
+    });
+    it('rejects > 1000 chars, allows 1000', () => {
+      expect(validateImapPath('c'.repeat(1001))).toMatch(/exceeds maximum length/i);
+      expect(validateImapPath('c'.repeat(1000))).toBeNull();
+    });
+    it('rejects non-strings', () => {
+      expect(validateImapPath(42)).toMatch(/non-empty string/i);
+    });
+  });
+
+  // ── VALID-015: attachment shape sanitisation ───────────────────────────────
+  describe('sanitizeAttachments (VALID-015)', () => {
+    it('returns undefined for omitted attachments', () => {
+      expect(sanitizeAttachments(undefined)).toBeUndefined();
+      expect(sanitizeAttachments(null)).toBeUndefined();
+    });
+    it('strips attacker-controlled extra keys (path/href/raw/encoding)', () => {
+      const out = sanitizeAttachments([
+        { filename: 'x.txt', content: 'abc', contentType: 'text/plain',
+          path: '/etc/passwd', href: 'http://evil', raw: 'X', encoding: 'binary' },
+      ]);
+      expect(out).toHaveLength(1);
+      const a = out![0] as Record<string, unknown>;
+      expect(a.filename).toBe('x.txt');
+      expect(a.content).toBe('abc');
+      expect(a.contentType).toBe('text/plain');
+      expect(a.path).toBeUndefined();
+      expect(a.href).toBeUndefined();
+      expect(a.raw).toBeUndefined();
+      expect(a.encoding).toBeUndefined();
+    });
+    it('preserves contentId when present', () => {
+      const out = sanitizeAttachments([{ filename: 'x', content: 'y', contentId: 'cid1' }]);
+      expect(out![0].contentId).toBe('cid1');
+    });
+  });
+
+  describe('attachmentByteSize', () => {
+    it('sizes a Buffer exactly', () => {
+      expect(attachmentByteSize(Buffer.alloc(100))).toBe(100);
+    });
+    it('estimates base64 string at ~3/4 length', () => {
+      expect(attachmentByteSize('A'.repeat(100))).toBe(75);
+    });
+    it('returns null for non-string/non-Buffer', () => {
+      expect(attachmentByteSize({ pipe() {} })).toBeNull();
     });
   });
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,6 +5,29 @@
 import { randomUUID } from "crypto";
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "./logger.js";
+import type { EmailAttachment } from "../types/index.js";
+
+/**
+ * Shared attachment caps. The SMTP send path (smtp-service.ts) and the IMAP
+ * draft path (simple-imap-service.ts) MUST enforce the same limits — VALID-005
+ * tracked the asymmetry where saveDraft mirrored sanitisation but not the caps.
+ * Bytes match Proton's own 25 MB per-message limit.
+ */
+export const MAX_ATTACHMENT_COUNT = 20;
+export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+export const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Best-effort decoded byte size of an attachment `content` value.
+ * base64 strings decode to ~3/4 of their character length; Buffers are exact.
+ * Returns `null` for anything that is neither (e.g. a Readable stream), which
+ * callers treat as "unsizable → reject".
+ */
+export function attachmentByteSize(content: unknown): number | null {
+  if (Buffer.isBuffer(content)) return content.length;
+  if (typeof content === "string") return Math.ceil(content.length * 0.75);
+  return null;
+}
 
 /**
  * Validate email address format.
@@ -241,6 +264,35 @@ export function validateTargetFolder(targetFolder: unknown): string | null {
 }
 
 /**
+ * Validate an IMAP folder *path* (full path, separators allowed) before it is
+ * serialised into an IMAP command literal. Unlike the leaf-only
+ * `validateFolderName`/`validateLabelName`, a forward slash IS permitted here
+ * because the value is a complete path (e.g. `Folders/Work`).
+ *
+ * Returns `null` on success or an error message string on failure. Rules:
+ *   - Must be a non-empty string after trimming
+ *   - Must not contain `..` (path traversal)
+ *   - Must not contain C0 control characters (U+0000–U+001F)
+ *   - Must not exceed 1000 characters
+ *
+ * VALID-003: single source of truth for the full-path check. The IMAP service's
+ * private `validateFolderName(name)` delegates here (rethrowing the message as
+ * an Error) so the two no longer diverge.
+ */
+export function validateImapPath(path: unknown): string | null {
+  if (!path || typeof path !== "string" || !path.trim()) {
+    return "folder path must be a non-empty string.";
+  }
+  if (path.includes("..") || /[\x00-\x1f]/.test(path)) {
+    return "folder path contains invalid characters (.. or control characters).";
+  }
+  if (path.length > 1000) {
+    return "folder path exceeds maximum length of 1000 characters.";
+  }
+  return null;
+}
+
+/**
  * Truncate text to a maximum length, appending "..." when truncated.
  *
  * @param text - The string to truncate.
@@ -378,9 +430,10 @@ export function validateAttachments(attachments: unknown): string | null {
   if (!Array.isArray(attachments)) {
     return "attachments must be an array.";
   }
-  if (attachments.length > 50) {
-    return "attachments must not exceed 50 items.";
+  if (attachments.length > MAX_ATTACHMENT_COUNT) {
+    return `attachments must not exceed ${MAX_ATTACHMENT_COUNT} items.`;
   }
+  let totalBytes = 0;
   for (let i = 0; i < attachments.length; i++) {
     const att = attachments[i];
     if (!att || typeof att !== "object" || Array.isArray(att)) {
@@ -396,6 +449,47 @@ export function validateAttachments(attachments: unknown): string | null {
     if (contentType !== undefined && typeof contentType !== "string") {
       return `attachments[${i}].contentType must be a string when provided.`;
     }
+    // VALID-006: cap per-file and aggregate content size so an unbounded base64
+    // payload can't OOM the process before it reaches the service layer.
+    const bytes = attachmentByteSize(content);
+    if (bytes === null) {
+      return `attachments[${i}].content must be a base64 string or Buffer.`;
+    }
+    if (bytes > MAX_ATTACHMENT_BYTES) {
+      return `attachments[${i}] is too large: ${Math.round(bytes / 1024 / 1024)}MB exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per-file limit.`;
+    }
+    totalBytes += bytes;
+    if (totalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
+      return `total attachment size exceeds the ${MAX_TOTAL_ATTACHMENT_BYTES / 1024 / 1024}MB limit.`;
+    }
   }
   return null;
+}
+
+/**
+ * Coerce a raw `args.attachments` value into a clean `EmailAttachment[]` that
+ * carries ONLY the known fields. VALID-015: tools previously did
+ * `args.attachments as EmailAttachment[]`, which let attacker-controlled extra
+ * keys (e.g. nodemailer's `path`, `href`, `raw`, `encoding`) ride through to
+ * the mailer — `path` in particular makes nodemailer read a file from disk.
+ *
+ * Call AFTER `validateAttachments` has returned null. Returns `undefined` when
+ * the input is absent so optional-attachment call sites stay unchanged.
+ */
+export function sanitizeAttachments(attachments: unknown): EmailAttachment[] | undefined {
+  if (attachments === undefined || attachments === null) return undefined;
+  if (!Array.isArray(attachments)) return undefined;
+  return attachments.map((raw) => {
+    const att = raw as Record<string, unknown>;
+    const out: EmailAttachment = {
+      filename: att.filename as string,
+      content: att.content as string | Buffer,
+      // contentType/size are part of EmailAttachment; size is metadata only and
+      // not used on the send/draft paths, so default it to 0 when absent.
+      contentType: typeof att.contentType === "string" ? att.contentType : "",
+      size: typeof att.size === "number" ? att.size : 0,
+    };
+    if (typeof att.contentId === "string") out.contentId = att.contentId;
+    return out;
+  });
 }


### PR DESCRIPTION
## W3-A — validator unification + draft/send symmetry + IMAP/parser residuals (v3.0.58)

Closes 10 findings from the 2026-05-28 audit. **DO NOT MERGE** — review first.

### Findings closed
| ID | Fix |
|----|-----|
| SMTP-011 | `saveDraft` returns a structured, actionable error when no Drafts folder is resolvable (`findDraftsFolder` → `null`, no literal `"Drafts"` append) |
| SMTP-012 | `saveDraft` strips `[\r\n\x00]` from `subject`/`to`/`cc`/`bcc` (was only inReplyTo/references/attachments); corrected the misleading comment |
| VALID-002 | `search_emails` length-caps `body`/`text`/`bcc` at 500; `sanitizeImapStr` strips `\r`/`\n`/`\x00` |
| VALID-003 | Unified the two divergent `validateFolderName`: service delegates to a single shared `validateImapPath()` in helpers |
| VALID-005 | `saveDraft` enforces the same count (20) + per-file/total (25 MB) caps as the SMTP send path |
| VALID-006 | `validateAttachments` caps per-file and aggregate content byte size |
| VALID-015 | New `sanitizeAttachments()` keeps only known fields, stripping attacker-controlled `path`/`href`/`raw`/`encoding`; used by send/draft/schedule |
| PARSE-008 | `stripHtml` decodes entities (named + numeric dec/hex) BEFORE tag-strip, so encoded `&lt;script&gt;` cannot emerge as live markup |
| PARSE-009 | `stripHtml` drops HTML comments first |
| PARSE-003 (wiring) | `fts_rebuild` handler uses atomic `rebuild()` instead of `clear()`+`upsertMany()` (atomic method shipped v3.0.54) |

### Verification
- `npm run typecheck` — clean
- Full unit suite — **1821 passed (51 files)**, including new regression tests for every finding (helpers.test.ts, simple-imap-service.newfeatures.test.ts, input-hygiene.test.ts). VALID-003 asserts the helpers validator and the service validator reject the same malicious folder names.
- `PRESHIP_NO_BRIDGE=1 npm run preship:fast` — **PASS** (typecheck, lint, version-sync, secrets, npm-audit, license-inv, build, unit). Ran `npm ci` first to align the fresh worktree's deps for the license inventory.
- Greenmail E2E runs in CI.

### Rollback
Single-commit, revertable: `git revert 85351b5`. No schema/migration changes, no new runtime deps. The unified validator preserves the service's prior accept/reject behavior (full path, separators allowed, `..`/control/empty/>1000 rejected) — only the error message text changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)