### PR TITLE
fix(tools/validation): low-severity sweep across tool surface, validators, parsers, credentials (v3.0.62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.62] — 2026-05-30
+
+### Fixed — tools / validators / parsers / credentials low-severity sweep (audit 2026-05-28)
+
+**Validators (`src/utils/helpers.ts`)**
+- VALID-004: `validateLabelName` and `validateFolderName` now delegate to a single shared `validateLeafName(value, fieldName)` core so the byte-identical rules can't drift.
+- VALID-007: every text-shape validator (`validateLeafName`, `validateTargetFolder`, `validateImapPath`) now rejects the full C0/C1 control range plus DEL (`\x7f`), not just C0.
+- VALID-008: `requireNumericEmailId` caps UID strings at 10 digits and rejects leading zeros (except `"0"`).
+- VALID-010: `parseEmails` drops tokens longer than `MAX_ADDRESS_TOKEN` (1024) before running the regex.
+- VALID-011: added `validateRequiredTargetFolder`; `create_folder`/`delete_folder`/`rename_folder` now use it instead of duplicated empty-name guards.
+- VALID-012: `validateImapPath` rejects leading/trailing whitespace.
+- VALID-013: `saveDraft` `inReplyTo` and `references` now share one header-field sanitiser.
+- VALID-016: `fts_search` validates its `folder` filter for parity with `search_emails`.
+- VALID-017: documented `validateTargetFolder("")` empty-as-default contract.
+- VALID-018: `validateAttachments` rejects path separators, traversal, control chars, and over-255-char filenames.
+- VALID-021: `optionalSourceFolder` consolidated into `helpers.ts` (was duplicated in `tools/actions.ts` + `tools/deletion.ts`).
+
+**Tools (`src/tools/*`)**
+- TOOL-011: `get_emails_by_label` outputSchema advertises `EMAIL_SUMMARY_SCHEMA` items + `required`.
+- TOOL-010: `get_thread` narrows returned messages to the summary shape (bounded `bodyPreview`), matching its schema and capping response size.
+- TOOL-013: `fts_rebuild` keys its in-progress guard per resolved DB path so concurrent rebuilds on different accounts don't collide.
+- TOOL-014: `start_bridge` flags `isError: true` when the SMTP/IMAP ports never come up.
+- TOOL-016: `search_emails` rejects negative/non-finite `larger`/`smaller`.
+- TOOL-017: `search_emails` requires parseable date strings for `sentBefore`/`sentSince`.
+
+**Parsers**
+- PARSE-020: `extractEmailAddress` takes the last angle-bracket pair (trailing address) instead of the first, so a hostile `From` header can't poison the contact map.
+
+**Credentials**
+- CRED-005: `readRegistryWithSecrets` fetches each account's keychain entry once instead of twice.
+- CRED-009: the Pass audit log is now hash-chained (`prevHash` + `hash` per row) and documented as best-effort tamper-evident.
+- CRED-011: the v1→v2 credential re-encrypt stages both blobs before saving, so a mid-migration throw can't persist a half-migrated config.
+- CRED-012: SimpleLogin error bodies are scrubbed of the configured API key and opaque token-shaped substrings before they reach logs/responses.
+- CRED-013: the Pass CLI subprocess `cwd` is pinned to the user's home directory.
+- CRED-015: `migrateCredentials` runs its read-modify-write under the config write lock against a deep clone, so concurrent readers never see an in-flight, partially-blanked config.
+
 ## [3.0.61] — 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.61-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.62-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -976,6 +976,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: When `isBridgeReachable` returns false for either port, the handler returns `ok({ success: false, reason })` — no `isError: true`. The dispatcher's `ok()` wraps that as a normal tool result; an agent that only checks `result.isError` will read this as success.
 - Suggested next step: Either flag with `isError: true` or document the convention so consumers always unpack `structuredContent.success`.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `start_bridge` now returns `isError: true` when the SMTP/IMAP ports never become reachable, while still carrying `structuredContent.success: false` + reason for richer consumers.
+
 #### TOOL-015 — `get_email_by_id`, `extract_action_items`, `extract_meeting`, `get_thread` cast `args.folder` without runtime type check
 - Location: `src/tools/reading.ts:519, 722, 838, 849`
 - Category: Correctness
@@ -983,6 +985,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `args.folder as string | undefined` is a blind cast in four handlers. A caller sending `folder: 123` flows the number through to `imapService.getEmailById`.
 - Suggested next step: Add an `args.folder !== undefined && typeof args.folder !== "string"` InvalidParams check.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** All four handlers (`get_email_by_id`, `extract_action_items`, `extract_meeting`, `get_thread`) now route `args.folder` through the shared `optionalFolderHint()` gate, which throws `McpError(InvalidParams)` on non-strings (this also closes VALID-001/009 — verified in this batch).
 
 #### TOOL-016 — `search_emails` validates length only for `from`/`to`/`subject`, not `body`/`text`/`bcc`
 - Location: `src/tools/reading.ts:546-622`
@@ -992,6 +996,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `MAX_SEARCH_TEXT = 500` is enforced for `from`, `to`, `subject` but never for `body`, `text`, `bcc`. `larger`/`smaller` accept negatives and NaN.
 - Suggested next step: Extend the 500-char clamp to all string predicates; clamp `larger`/`smaller` to `>= 0`.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `body`/`text`/`bcc` were already 500-char capped in v3.0.58 (VALID-002); this batch adds the remaining piece — `larger`/`smaller` now reject negative and non-finite (NaN/Infinity) values with `McpError(InvalidParams)`.
+
 #### TOOL-017 — `search_emails` coerces non-string `sentBefore`/`sentSince` via `new Date(args... as string)`
 - Location: `src/tools/reading.ts:597-598`
 - Category: Correctness
@@ -999,6 +1005,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `args.sentBefore ? new Date(args.sentBefore as string) : undefined`. The truthy-check accepts numbers, objects, etc.; `new Date(null)` → `Date(0)` (1970), `new Date({})` → Invalid Date.
 - Suggested next step: Require `typeof === "string"` and validate `Date.parse(s)` is not `NaN`.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `search_emails` now requires `sentBefore`/`sentSince` to be strings that `Date.parse` accepts, throwing `McpError(InvalidParams)` otherwise — no more `new Date(null)` → 1970 or `new Date({})` → Invalid Date.
 
 #### TOOL-012 — Late-group reading tools use `email_id` while early group uses `emailId`
 - Location: `src/tools/reading.ts:100, 266, 292, 420, 453`
@@ -1008,6 +1016,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `get_email_by_id` requires `emailId` (camelCase) but `download_attachment`, `get_thread`, `extract_action_items`, `extract_meeting` require `email_id` (snake_case). Same registry, two spellings.
 - Suggested next step: Accept both as input on each handler and pick one for the schema.
 
+> **Acknowledged in v3.0.62 — by design:** the two spellings are a frozen part of the published tool schema; renaming `email_id` → `emailId` (or vice versa) is a breaking change to every existing agent prompt/integration, and accepting both as input aliases would add per-handler ambiguity for a cosmetic naming difference. The shared `requireNumericEmailId(args.X, "X")` already gives both spellings identical validation/error shapes, which is the substance of the concern.
+
 #### TOOL-013 — `fts_rebuild` `_ftsRebuilding` flag is module-global, breaks multi-account
 - Location: `src/tools/reading.ts:29, 803-819`
 - Category: Concurrency
@@ -1015,6 +1025,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Per-account routing means two simultaneous `fts_rebuild` calls against different accounts share one boolean. The second caller gets "rebuild already in progress" even though its target index could be a totally different file.
 - Suggested next step: Key the flag by `accountId` (or by the resolved `dbPath`).
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `_ftsRebuilding` is now a `Set<string>` keyed by the resolved `fts.stats().dbPath`; concurrent rebuilds against different account indexes no longer collide, while a second rebuild against the SAME DB is still rejected.
 
 #### TOOL-020 — `shutdown_server`/`restart_server` audit row may be lost
 - Location: `src/tools/bridge.ts:65-83`, `src/index.ts:763-781`
@@ -1024,6 +1036,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The handler returns synchronously and schedules `gracefulShutdown` via `setImmediate`. The dispatcher's `finally` block then writes a success audit row — fire-and-forget. The audit append may be cut mid-write or skipped entirely.
 - Suggested next step: Either await the audit write before `setImmediate`, or delay `gracefulShutdown` slightly.
 
+> **Acknowledged in v3.0.62 — by design:** no fix needed. `agentAudit.write()` is a synchronous `appendFileSync` (agents/audit.ts) that runs in the dispatcher's `finally` block. `setImmediate(gracefulShutdown)` defers the shutdown to the NEXT event-loop iteration, which cannot start until the current synchronous stack — including the `finally` audit append — has fully unwound. The audit row is therefore always written before shutdown begins; the "cut mid-write / skipped" hypothesis (Suspect) does not hold for a sync append + `setImmediate` deferral.
+
 #### TOOL-010 — `get_thread` outputSchema omits `messages` field shape match
 - Location: `src/tools/reading.ts:298-309` vs handler `719-746`
 - Category: Tech-debt
@@ -1032,6 +1046,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: outputSchema declares `messages: { items: EMAIL_SUMMARY_SCHEMA }` (summary fields only), but the handler returns full `EmailMessage` objects. No body-size truncation here either, so a long thread can blow the 1 MB response budget.
 - Suggested next step: Either narrow the returned objects before `ok()` or widen the schema.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `get_thread` now maps each message to the `EMAIL_SUMMARY_SCHEMA` shape (deriving a 300-char `bodyPreview` from the body) before `ok()`, matching the declared schema AND bounding the response so a long thread can't blow the 1 MB budget.
+
 #### TOOL-011 — `get_emails_by_label` outputSchema item type is a bare `object`
 - Location: `src/tools/reading.ts:244-252`
 - Category: Tech-debt
@@ -1039,6 +1055,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `outputSchema.properties.emails.items: { type: "object" }` — no properties. The sibling tool `get_emails` advertises `EMAIL_SUMMARY_SCHEMA` for the same items.
 - Suggested next step: Replace with `items: EMAIL_SUMMARY_SCHEMA` and add `required: ["emails", "folder", "count"]`.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `get_emails_by_label`'s outputSchema now uses `items: EMAIL_SUMMARY_SCHEMA` (matching `get_emails`) and declares `required: ["emails", "folder", "count"]`.
 
 #### TOOL-018 — `get_connection_status` outputSchema has no `required` array
 - Location: `src/tools/system.ts:31-68`
@@ -1181,6 +1199,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Instrument `loadAccountCredentials` with a counter; observe N=2×accounts per `rebuildFromRegistryAsync`.
 - Suggested next step: Single call, destructure once: `const { password, smtpToken } = await loadAccountCredentials(acct.id) ?? {}`.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `readRegistryWithSecrets` now calls `loadAccountCredentials(acct.id)` once per account (skipping accounts that already have both fields) and the legacy `loadCredentials()` fall-back is loaded lazily and cached per account.
+
 #### CRED-009 — Pass audit log is append-only by file mode only — not tamper-evident
 - Location: `src/services/pass-service.ts:190-201`
 - Category: Security
@@ -1189,6 +1209,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The doc comment at line 22-23 calls the audit log "append-only", but the implementation is `appendFileSync(...)` with no chained hash, no integrity field, no log rotation, no fsync. A local attacker with write to `~/.mailpouch-pass-audit.jsonl` can rewrite history at will. For a file that records every `pass_get` (decrypted-credential access), that's a meaningful gap if the threat model includes a post-compromise forensic step.
 - Repro hypothesis: `pass_get itemId=foo`; later `sed -i '/foo/d' ~/.mailpouch-pass-audit.jsonl` — no detection.
 - Suggested next step: Add a hash-chained row (`prevHash + sha256(row)` written as a field), and document explicitly that the log is best-effort.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** Pass audit rows now carry `prevHash` + `hash` (`sha256(prevHash || rowSansHash)`), seeded lazily from the last on-disk row so the chain survives restarts. The class doc-comment now states the log is best-effort and tamper-EVIDENT (not tamper-proof): a writer with file access can recompute the whole chain.
 
 #### CRED-011 — `re-encrypt v1 → v2` migration not atomic across the two credential fields
 - Location: `src/config/loader.ts:493-518`
@@ -1199,6 +1221,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Inject a throw in the second `encrypt`; observe a config where one credential is v2 and the other v1.
 - Suggested next step: Stage both new blobs in locals, then assign both and save once; or wrap in a try/restore.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The v1→v2 re-encrypt path now stages both new blobs in locals and only assigns + `saveConfig` once BOTH encrypts succeed; if the second throws, neither field is mutated and nothing is persisted (regression-tested).
+
 #### CRED-012 — SimpleLogin error path echoes upstream JSON verbatim — token leak risk
 - Location: `src/services/simplelogin-service.ts:74-108`
 - Category: Security
@@ -1207,6 +1231,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: When the API returns an error, the code throws `Error("SimpleLogin GET /api/foo → ${parsed.error}")`. SimpleLogin's `error` payload is server-controlled; nothing in the chain prevents it from echoing back the auth header for diagnostics on certain endpoints. The thrown error reaches the MCP response and the logger; the logger's redaction is by *key*, not by value-pattern, so an `error` string carrying the API key would pass straight through to `~/.mailpouch.log`.
 - Repro hypothesis: A future SimpleLogin error message of the form `"invalid key 'sl_xxx'"` would land in the JSONL log unredacted.
 - Suggested next step: Defensively redact known-token patterns in the error path; or strip the upstream body to a status code + generic message before raising.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The error path now runs `redactSecrets()` on the upstream message before raising: it strips the exact configured API key plus any opaque token-shaped substring (24+ chars of base62/`_-`), replacing each with `[redacted]` so a hostile `error` body can't smuggle a secret into the log or MCP response.
 
 #### CRED-013 — Pass CLI child inherits `cwd`; pass-cli may write to attacker-writable dir
 - Location: `src/services/pass-service.ts:138-149`
@@ -1217,6 +1243,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: `cd /tmp && mailpouch`; later inspect what pass-cli dropped into `/tmp`.
 - Suggested next step: Add `cwd: homedir()` to the spawn options.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The pass-cli `spawn` options now pin `cwd: homedir()` so the child never inherits an attacker-writable `process.cwd()` (e.g. `/tmp`).
+
 #### CRED-015 — `migrateCredentials()` does not deep-clone the config before mutate-and-save
 - Location: `src/config/loader.ts:478-545`
 - Category: Concurrency
@@ -1225,6 +1253,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `migrateCredentials` calls `loadConfig()` (line 481), mutates the returned object, then `saveConfig(config)` (line 509/542). `loadConfig` populates `_configCache` with the read result. Between read and save, any concurrent caller within 15s gets the *in-flight, partially-mutated* config object from cache (same reference). Since the mutation now blanks `password` and adds `passwordEncrypted` before save returns, a racing `loadCredentialsFromKeychain` could observe `password=""` + missing encrypted blob and conclude "no credentials" — a transient boot failure.
 - Repro hypothesis: At boot, fire `migrateCredentials()` + `loadCredentialsFromKeychain()` in parallel; intermittent "no credentials" on the second path.
 - Suggested next step: `loadConfig` should return a deep-cloned object so callers can't see in-flight mutations; or take the lock from CRED-008.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `migrateCredentials` now runs its whole read-modify-write inside `withConfigWriteLockAsync` (the CRED-008 lock) and operates on a `structuredClone` of the loaded config — the cache keeps the un-mutated reference until `saveConfig` invalidates it, so a racing reader never sees `password=""` + missing blob mid-migration.
 
 #### CRED-014 — `SecureBuffer.toString()` allocates GC-tracked string, defeating wipe guarantee
 - Location: `src/security/memory.ts:20-45`
@@ -1247,6 +1277,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `SimpleIMAPService.getEmailById(emailId, folderHint?)` does `this.validateEmailId(emailId)` but never validates `folderHint`, then passes it straight into `getMailboxLock(folder.path)`. The tool layer (`get_email_by_id`, `get_thread`, `extract_action_items`, `extract_meeting`, `reply_to_email`, `forward_email`) all cast `args.folder as string | undefined` and forward it without `validateTargetFolder`. A `folder` of `"INBOX\r\nLOGOUT"` or `"../Trash"` flows into the IMAP wire path and the cache key without filtering.
 - Repro hypothesis: Call `get_email_by_id` with `{ emailId: "1", folder: "INBOX\r\nA001 LOGOUT" }` — imapflow will be asked to SELECT a folder containing CRLF.
 - Suggested next step: Inside `getEmailById`, call `this.validateFolderName(folderHint)` when present, and add `validateTargetFolder(args.folder)` in every tool that accepts `folder` before passing it to the service.
+
+> **Resolved in v3.0.44 — finish 3.0.41 sibling-path fix (#131).** `SimpleIMAPService.getEmailById` now calls `this.validateFolderName(folderHint)` when present (simple-imap-service.ts), and the by-id reading/sending tools (`get_email_by_id`, `get_thread`, `extract_action_items`, `extract_meeting`, `reply_to_email`, `forward_email`) route `args.folder` through the shared `optionalFolderHint()` gate instead of `as string | undefined` casts. Verified in v3.0.62.
 
 #### VALID-002 — `search_emails` does not length-cap or sanitise `body`/`text`/`bcc`
 - Location: `src/tools/reading.ts:546-598`, `src/services/simple-imap-service.ts:968-991`
@@ -1295,6 +1327,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Tool handlers in the same file split — list/search variants validate `folder` through `validateTargetFolder`, but the by-id family forwards it raw. Twin to VALID-001 at the call-site layer.
 - Suggested next step: Add `validateTargetFolder(args.folder)` to every by-id handler.
 
+> **Resolved in v3.0.44 — finish 3.0.41 sibling-path fix (#131).** Twin of VALID-001 at the call-site layer: the by-id reading tools forward `args.folder` through `optionalFolderHint()` (which runs `validateTargetFolder` and throws `McpError(InvalidParams)` on CRLF/`..`/control chars) rather than a raw cast. Verified in v3.0.62.
+
 #### VALID-015 — Tools coerce `args.attachments` via `as EmailAttachment[]` after structural-only validator
 - Location: `src/tools/sending.ts:159`, `src/tools/drafts.ts:312`
 - Category: Security
@@ -1313,6 +1347,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The two functions differ only in the error message. When tightening rules later, only one will get patched and the sibling drifts.
 - Suggested next step: Factor a `validateLeafName(value, fieldName)` and have both call it.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** Added the shared `validateLeafName(value, fieldName)`; `validateLabelName`/`validateFolderName` now both delegate to it.
+
 #### VALID-007 — `validateLabelName`/`validateFolderName` miss DEL (\x7f) and C1 control range
 - Location: `src/utils/helpers.ts:189, 209`
 - Category: Security
@@ -1320,6 +1356,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Regex is `/[\x00-\x1f]/` — `\x7f` (DEL) and `\x80-\x9f` (C1) pass through. `sanitizeText` in `src/settings/security.ts:369` already documents the full C0/C1+DEL range as risky.
 - Suggested next step: Standardise on the security.ts `CONTROL_CHARS_RE` for every text-shape validator.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** A shared `CONTROL_CHARS_RE = /[\x00-\x1f\x7f\x80-\x9f]/` now backs `validateLeafName`, `validateTargetFolder`, and `validateImapPath` — DEL and the C1 range are rejected everywhere.
 
 #### VALID-008 — `requireNumericEmailId` accepts unbounded-length numeric strings and leading zeros
 - Location: `src/utils/helpers.ts:275-280`
@@ -1329,6 +1367,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `^\d+$` admits thousand-digit strings and `"0000001"`. IMAP UIDs are 32-bit unsigned; large strings burn log space and Bridge time.
 - Suggested next step: Cap to e.g. 12 digits and disallow leading zero except `"0"`.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `requireNumericEmailId` now matches `/^(0|[1-9]\d{0,9})$/` — leading zeros rejected (except `"0"`), capped at 10 digits (32-bit UID range).
+
 #### VALID-010 — `parseEmails` has no per-token length cap, exposes regex to large inputs
 - Location: `src/utils/helpers.ts:43-63`
 - Category: Performance
@@ -1336,6 +1376,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Suspect
 - Description: `parseEmails` splits on commas without a per-token byte cap. The regex `^[^<>]*<([^<>]+)>$` runs on the whole token first.
 - Suggested next step: Reject any single token whose `trimmed.length > MAX_ADDRESS_TOKEN` (e.g. 1024).
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `parseEmails` drops (with a warning) any token longer than the exported `MAX_ADDRESS_TOKEN` (1024) before the regex runs.
 
 #### VALID-011 — Empty/whitespace `folderName` passes `validateTargetFolder`; redundant follow-up check inconsistent
 - Location: `src/utils/helpers.ts:227-241`, `src/tools/folders.ts:122-160`
@@ -1345,6 +1387,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `validateTargetFolder("")` returns `null` but `create_folder`/`delete_folder`/`rename_folder` always need a real name and each handler repeats `!args.folderName || ... trim()`.
 - Suggested next step: Add a `validateRequiredTargetFolder` wrapper used by folder-mutating tools.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** Added `validateRequiredTargetFolder`; `create_folder`/`delete_folder`/`rename_folder` now use it, replacing their duplicated `!folderName || ...trim()` guards with one `McpError(InvalidParams)` shape.
+
 #### VALID-012 — IMAP `validateFolderName` (private) doesn't reject leading/trailing whitespace or `&` escape
 - Location: `src/services/simple-imap-service.ts:326-342`
 - Category: Correctness
@@ -1352,6 +1396,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Suspect
 - Description: IMAP folder names use UTF-7 modified, where `&` is the escape character. The validator strips no whitespace and never warns about `&`. Combined with leading-whitespace, allows silently-different paths to be opened.
 - Suggested next step: Either `trim()` and re-validate, or explicitly reject leading/trailing whitespace.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `validateImapPath` (which the private `validateFolderName` delegates to since VALID-003) now rejects leading/trailing whitespace. The UTF-7 `&` escape is intentionally left intact — legitimate encoded folder names contain it.
 
 #### VALID-013 — `saveDraft` `inReplyTo` strips only `[\r\n\x00]` while `references` strips full `[\x00-\x1f\x7f]`
 - Location: `src/services/simple-imap-service.ts:1414-1415`
@@ -1361,6 +1407,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Sibling fields in the same `mailOptions` literal use different sanitisation masks.
 - Suggested next step: Use `stripHeaderInjection` for both fields.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `saveDraft` now sanitises both `inReplyTo` and `references` with one shared `stripHeaderField` (the broader `[\x00-\x1f\x7f]` mask), so the sibling fields no longer diverge.
+
 #### VALID-014 — `validateTargetFolder` length cap of 1000 lets through paths longer than the leaf cap of 255
 - Location: `src/utils/helpers.ts:237` vs `192/212`
 - Category: Correctness
@@ -1368,6 +1416,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: `validateTargetFolder` caps at 1000 — but a `Folders/<name>` constructed by a tool may originate from `validateFolderName` (cap 255 for the leaf). The three layers do not enforce a single bound.
 - Suggested next step: Pick one path-length cap and enforce it at the outer-most validator.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The 1000-char cap in `validateTargetFolder`/`validateImapPath` is now documented as the single full-path bound; the per-leaf validators enforce 255 on each segment a caller composes. A multi-segment path legitimately exceeds any single 255-char leaf, so the outer cap stays 1000.
 
 #### VALID-016 — `fts_search` accepts `folder` without any validation
 - Location: `src/tools/reading.ts:780-800`
@@ -1377,6 +1427,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `folder: typeof args.folder === "string" ? args.folder : undefined` is passed straight into `fts.search`. The inconsistency with `search_emails` means `fts_search` admits values its IMAP twin would reject.
 - Suggested next step: Run `validateTargetFolder` on the folder filter for parity.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The `fts_search` handler now runs `validateTargetFolder` on the `folder` filter and throws `McpError(InvalidParams)` on failure, matching `search_emails`.
+
 #### VALID-017 — `sourceFolder` validator allows empty string by returning `null` (silent fall-back)
 - Location: `src/utils/helpers.ts:228-230`
 - Category: UX
@@ -1384,6 +1436,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `validateTargetFolder("")` returns `null`. The `optionalSourceFolder` wrappers re-check empty-string. The contract is fragile — the next caller that simply does `validateTargetFolder(raw)` will hand `""` to imapflow.
 - Suggested next step: Either make `validateTargetFolder("")` an error, or return a normalised `string | undefined`.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** The empty-as-default contract is now documented in-code, and the fragile follow-up is closed at the dangerous call sites: folder-mutating tools use the new `validateRequiredTargetFolder` (VALID-011) and the shared `optionalSourceFolder` (VALID-021) re-checks empty-string. `validateTargetFolder("") → null` is kept deliberately for the search/list tools that fall back to INBOX.
 
 #### VALID-018 — `validateAttachments` filename allows any character including path separators
 - Location: `src/utils/helpers.ts:314-316`
@@ -1393,6 +1447,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Filename is only checked as `non-empty string`. CRLF and path traversal are scrubbed inside the SMTP/IMAP layers, but the validator itself permits `"../../../etc/passwd"`.
 - Suggested next step: In `validateAttachments`, reject path separators and control chars, and cap to 255.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `validateAttachments` now rejects `/`, `\`, `..`, control chars, and filenames over 255 chars per element.
+
 #### VALID-019 — `validateLabelName` rejects `/` but allows non-printable / non-ASCII that imapflow UTF-7 encodes
 - Location: `src/utils/helpers.ts:185-196`
 - Category: Correctness
@@ -1401,6 +1457,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: A label like `"Wörk"` becomes `Labels/Wörk`, which imapflow encodes to `Labels/W&APY-rk`. Agents using the label as an in-memory map key will mismatch the IMAP-stored name on the next listing.
 - Suggested next step: Document the UTF-7 expansion factor or measure encoded length when capping.
 
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** Documented the modified-UTF-7 expansion in the `validateLabelName` doc-comment (a non-ASCII leaf is accepted but encoded on the wire, so callers must re-list to learn the stored name). Measuring encoded length when capping is intentionally not done — the 255-char leaf cap is already conservative relative to IMAP limits.
+
 #### VALID-021 — `optionalSourceFolder` exists in two files and is duplicated
 - Location: `src/tools/actions.ts:301-309` and `src/tools/deletion.ts:22-30`
 - Category: Tech-debt
@@ -1408,6 +1466,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Identical helper, two definitions.
 - Suggested next step: Move to `src/utils/helpers.ts` and export.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `optionalSourceFolder` now lives in `src/utils/helpers.ts` and is imported by both `tools/actions.ts` and `tools/deletion.ts`; the two local copies were removed.
 
 #### VALID-020 — `requireNumericEmailId` and IMAP-private `validateEmailId` produce different error shapes
 - Location: `src/utils/helpers.ts:275-280` vs `src/services/simple-imap-service.ts:285-289`
@@ -1611,6 +1671,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: For a malformed value like `<bogus> "Alice" <real@x.com>`, this returns `bogus`. A hostile From header poisons the contact map.
 - Suggested next step: Anchor as `/^[^<>]*<([^<>]+)>\s*$/`, or split-on-last-`<`.
+
+> **Resolved in v3.0.62 — tools/validators/parsers/credentials low-severity sweep.** `extractEmailAddress` now takes the LAST angle-bracket pair (split-on-last-`<`), so `<bogus> "Alice" <real@x.com>` returns `real@x.com` instead of `bogus`.
 
 **DATA-PARSERS patterns:** three recurring shapes. (1) *Defensive caps that don't quite match their intent* — byte-length checks with char-length truncation, contact caps that drop the highest-value entries because of iteration order, FTS limits without query-DSL escaping. (2) *Time-zone schizophrenia* — analytics mixes UTC bucketing for `volumeTrends` with host-local `getHours()` for `peakActivityHours`, and the iCal parser silently discards `TZID=`. (3) *HTML/MIME shaping is one-pass, no-encoding-aware* — `stripHtml` decodes entities after tag-strip (single-pass bypass), doesn't strip HTML comments. Highest-priority: PARSE-002 (folder-scoped data leak via FTS), PARSE-014 (attachment OOM), PARSE-005/006 (timezone correctness), PARSE-010 (iCal TZID drop).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.61",
+  "version": "3.0.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.61",
+      "version": "3.0.62",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.61",
+  "version": "3.0.62",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/accounts/registry.test.ts
+++ b/src/accounts/registry.test.ts
@@ -68,6 +68,7 @@ vi.mock("../security/keychain.js", () => ({
 
 import {
   readRegistry,
+  readRegistryWithSecrets,
   createAccount,
   updateAccount,
   deleteAccount,
@@ -267,5 +268,28 @@ describe("accounts registry", () => {
     expect(acct!.password).toBe("stays-on-disk");  // keychain failed → plaintext kept
     expect(acct!.smtpToken).toBeUndefined();        // empty token coerced to undefined
     expect(onDisk.credentialStorage).toBe("config"); // NOT keychain
+  });
+
+  // ─── CRED-005 — readRegistryWithSecrets fetches the keychain at most once ──
+
+  it("CRED-005: hits loadAccountCredentials once per account, not twice", async () => {
+    const keychain = await import("../security/keychain.js");
+    const loadAcct = vi.mocked(keychain.loadAccountCredentials);
+    loadAcct.mockReset();
+    loadAcct.mockResolvedValue({ password: "pw", smtpToken: "tok" });
+    // Two accounts, both with blank password+token on disk so both need a fetch.
+    seedConfig({
+      accounts: [
+        { id: "primary", name: "A", providerType: "imap", smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1, username: "a", password: "", smtpToken: "" },
+        { id: "acct-2", name: "B", providerType: "imap", smtpHost: "s", smtpPort: 1, imapHost: "i", imapPort: 1, username: "b", password: "", smtpToken: "" },
+      ],
+      activeAccountId: "primary",
+    } as Partial<ServerConfig>);
+
+    const reg = await readRegistryWithSecrets();
+    // One keychain fetch per account (was two: one for password, one for token).
+    expect(loadAcct).toHaveBeenCalledTimes(2);
+    expect(reg.accounts.find(a => a.id === "primary")?.password).toBe("pw");
+    expect(reg.accounts.find(a => a.id === "primary")?.smtpToken).toBe("tok");
   });
 });

--- a/src/accounts/registry.ts
+++ b/src/accounts/registry.ts
@@ -79,25 +79,39 @@ export async function readRegistryWithSecrets(): Promise<AccountRegistry> {
   const reg = readRegistry();
   const { loadCredentials } = await import("../security/keychain.js");
   for (const acct of reg.accounts) {
-    if (!acct.password) {
-      const perAccount = await loadAccountCredentials(acct.id);
+    // CRED-005: fetch the per-account keychain entry at most once. The entry
+    // carries both fields, so the prior two-block form re-hit the keychain
+    // (a sync libsecret/Keychain/Cred-Manager FFI) for every account that had
+    // both password and smtpToken missing.
+    const needsPassword = !acct.password;
+    const needsSmtpToken = !acct.smtpToken;
+    if (!needsPassword && !needsSmtpToken) continue;
+
+    const perAccount = await loadAccountCredentials(acct.id);
+    // Legacy key is loaded lazily and only for the "primary" slot.
+    let legacy: Awaited<ReturnType<typeof loadCredentials>> | null | undefined;
+    const getLegacy = async () => {
+      if (legacy === undefined) legacy = (await loadCredentials()) ?? null;
+      return legacy;
+    };
+
+    if (needsPassword) {
       if (perAccount?.password) {
         acct.password = perAccount.password;
       } else if (acct.id === "primary") {
         // Back-compat: the pre-multi-account keychain entry didn't use
         // a per-account suffix. Fall back to the legacy key so existing
         // installs keep working after this change.
-        const legacy = await loadCredentials();
-        if (legacy?.password) acct.password = legacy.password;
+        const l = await getLegacy();
+        if (l?.password) acct.password = l.password;
       }
     }
-    if (!acct.smtpToken) {
-      const perAccount = await loadAccountCredentials(acct.id);
+    if (needsSmtpToken) {
       if (perAccount?.smtpToken) {
         acct.smtpToken = perAccount.smtpToken;
       } else if (acct.id === "primary") {
-        const legacy = await loadCredentials();
-        if (legacy?.smtpToken) acct.smtpToken = legacy.smtpToken;
+        const l = await getLegacy();
+        if (l?.smtpToken) acct.smtpToken = l.smtpToken;
       }
     }
   }

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -709,4 +709,39 @@ describe("migrateCredentials", () => {
     expect(result).toBe(true);
     expect(mockedMigrate).toHaveBeenCalledTimes(1);
   });
+
+  // ── CRED-011 — v1→v2 re-encrypt is atomic across both credential fields ──
+  it("CRED-011: does not save a half-migrated config when the second re-encrypt throws", async () => {
+    mockedExistsSync.mockReturnValue(true);
+    const blob = { algorithm: "aes-256-gcm", v: 1 } as unknown;
+    const cfgJson = JSON.stringify({
+      configVersion: 1,
+      credentialStorage: "encrypted-file",
+      connection: {
+        smtpHost: "localhost", smtpPort: 1025, imapHost: "localhost", imapPort: 1143,
+        username: "u", password: "", smtpToken: "",
+        passwordEncrypted: blob, smtpTokenEncrypted: blob,
+        bridgeCertPath: "", debug: false,
+      },
+      permissions: { preset: "full", tools: {} },
+    });
+    mockedReadFileSync.mockReturnValue(cfgJson as unknown as Buffer);
+
+    vi.spyOn(CredentialEncryption, "isValidEncrypted").mockReturnValue(true);
+    vi.spyOn(CredentialEncryption, "needsReencrypt").mockReturnValue(true);
+    vi.spyOn(CredentialEncryption, "decrypt").mockReturnValue("plaintext");
+    let calls = 0;
+    vi.spyOn(CredentialEncryption, "encrypt").mockImplementation(() => {
+      calls += 1;
+      if (calls >= 2) throw new Error("boom on second encrypt");
+      return { algorithm: "aes-256-gcm", v: 2 } as never;
+    });
+    const writeSpy = vi.mocked(writeFileSync);
+    writeSpy.mockClear();
+
+    const result = await migrateCredentials();
+    expect(result).toBe(false);
+    // Atomic: nothing persisted because the second field's encrypt failed.
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -721,11 +721,19 @@ export async function loadAuxiliaryCredentialsFromKeychain(): Promise<{
 export async function migrateCredentials(): Promise<boolean> {
   const tags: { migrated?: boolean } = {};
   return tracer.span('config.migrateCredentials', tags, async () => {
-  const config = loadConfig();
-  if (!config) {
+  // CRED-015: take the config write lock for the whole read-modify-write so a
+  // concurrent loadCredentialsFromKeychain() can't observe the in-flight,
+  // partially-blanked config object (loadConfig returns the cached reference).
+  return withConfigWriteLockAsync(async () => {
+  const loaded = loadConfig();
+  if (!loaded) {
     tags.migrated = false;
     return false;
   }
+  // Operate on a deep clone, then save once. The cache keeps the un-mutated
+  // reference until saveConfig() invalidates it, so racing readers within the
+  // lock window never see `password=""` + a missing encrypted blob.
+  const config = structuredClone(loaded);
 
   // Plaintext-creds path: hoist to keychain (preferred) or encrypted-file.
   const hasPlaintext = !!(config.connection.password || config.connection.smtpToken);
@@ -741,14 +749,20 @@ export async function migrateCredentials(): Promise<boolean> {
     && CredentialEncryption.needsReencrypt(smtpEncryptedField);
   if (!hasPlaintext && (pwNeedsReencrypt || smtpNeedsReencrypt)) {
     try {
+      // CRED-011: stage BOTH re-encrypted blobs in locals first. If the second
+      // encrypt throws, we must not have already mutated the first field — that
+      // would leave a config with one v2 blob and one v1 blob, and the catch
+      // below would swallow it. Assign + save only once both succeed.
+      let newPasswordEncrypted: typeof config.connection.passwordEncrypted;
+      let newSmtpEncrypted: typeof config.connection.smtpTokenEncrypted;
       if (pwNeedsReencrypt && CredentialEncryption.isValidEncrypted(passwordEncryptedField)) {
-        const plain = CredentialEncryption.decrypt(passwordEncryptedField);
-        config.connection.passwordEncrypted = CredentialEncryption.encrypt(plain);
+        newPasswordEncrypted = CredentialEncryption.encrypt(CredentialEncryption.decrypt(passwordEncryptedField));
       }
       if (smtpNeedsReencrypt && CredentialEncryption.isValidEncrypted(smtpEncryptedField)) {
-        const plain = CredentialEncryption.decrypt(smtpEncryptedField);
-        config.connection.smtpTokenEncrypted = CredentialEncryption.encrypt(plain);
+        newSmtpEncrypted = CredentialEncryption.encrypt(CredentialEncryption.decrypt(smtpEncryptedField));
       }
+      if (newPasswordEncrypted !== undefined) config.connection.passwordEncrypted = newPasswordEncrypted;
+      if (newSmtpEncrypted !== undefined) config.connection.smtpTokenEncrypted = newSmtpEncrypted;
       saveConfig(config);
       tags.migrated = true;
       return true;
@@ -785,5 +799,6 @@ export async function migrateCredentials(): Promise<boolean> {
   saveConfig(config);
   tags.migrated = true;
   return true;
+  });
   }); // end tracer.span('config.migrateCredentials')
 }

--- a/src/services/pass-service.test.ts
+++ b/src/services/pass-service.test.ts
@@ -203,4 +203,48 @@ describe("PassService", () => {
     const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
     await expect(svc.listItems()).rejects.toThrow("EACCES");
   });
+
+  // ── CRED-009 — audit rows are hash-chained ───────────────────────────────
+  it("writes a verifiable prevHash/hash chain across audit rows", async () => {
+    const { createHash } = await import("crypto");
+    spawn.mockImplementation(() => {
+      const c = makeFakeChild();
+      setImmediate(() => { c.stdout.emit("data", Buffer.from("[]")); c.emit("close", 0); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await svc.listItems();
+    await svc.listItems();
+
+    const lines = readFileSync(auditPath, "utf-8").split("\n").filter((l) => l.trim() !== "");
+    expect(lines).toHaveLength(2);
+    const r1 = JSON.parse(lines[0]);
+    const r2 = JSON.parse(lines[1]);
+    // Genesis row chains from "".
+    expect(r1.prevHash).toBe("");
+    // Second row chains from the first row's hash.
+    expect(r2.prevHash).toBe(r1.hash);
+    // Each row's hash recomputes from prevHash + the row sans hash.
+    const recompute = (row: Record<string, unknown>) => {
+      const { hash: _h, ...base } = row;
+      return createHash("sha256").update(String(base.prevHash)).update(JSON.stringify(base)).digest("hex");
+    };
+    expect(recompute(r1)).toBe(r1.hash);
+    expect(recompute(r2)).toBe(r2.hash);
+  });
+
+  // ── CRED-013 — child cwd is pinned to homedir, not process.cwd() ─────────
+  it("spawns pass-cli with cwd pinned to the user's home directory", async () => {
+    const { homedir } = await import("os");
+    let capturedOpts: { cwd?: string } = {};
+    spawn.mockImplementation((_cli: string, _args: string[], opts: { cwd?: string }) => {
+      capturedOpts = opts;
+      const c = makeFakeChild();
+      setImmediate(() => { c.stdout.emit("data", Buffer.from("[]")); c.emit("close", 0); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    await svc.listItems();
+    expect(capturedOpts.cwd).toBe(homedir());
+  });
 });

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -229,9 +229,11 @@ export class PassService {
   /**
    * Append one line to the audit log. Never includes secret values.
    *
-   * CRED-009: each row is hash-chained — `hash = sha256(prevHash || canonical)`,
-   * where `canonical` is the row JSON without the `hash` field. A reviewer can
-   * recompute the chain to detect deletion or in-place edits. This is
+   * CRED-009: each row is hash-chained — `hash = sha256(prevHash + JSON.stringify(base))`,
+   * where `base` is the row WITHOUT the `hash` field but WITH `prevHash` already
+   * embedded in it (so prevHash is bound into the row both directly and via the
+   * hash input). A reviewer can recompute the chain to detect deletion or
+   * in-place edits. This is
    * tamper-EVIDENT, not tamper-PROOF: an attacker with write access can rewrite
    * the whole file and recompute every hash. The log is best-effort (no fsync,
    * no rotation lock); treat a broken chain as "investigate", not "trusted".

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -19,16 +19,20 @@
  *
  * - PAT is read from the config file (mode 0600) OR keychain. Never from
  *   env vars the agent can inspect.
- * - Every call is logged to an append-only audit file
+ * - Every call is logged to a hash-chained audit file
  *   (~/.mailpouch-pass-audit.jsonl, mode 0600) with timestamp + tool
- *   name + item ID (but never the secret value itself).
+ *   name + item ID (but never the secret value itself). Each row carries
+ *   `prevHash` + `hash` so a reviewer can detect deletion/edits. The chain
+ *   is best-effort and tamper-EVIDENT, not tamper-proof (CRED-009).
  * - No tool returns or logs the decrypted secret in plain text unless the
  *   user has explicitly confirmed via the elicitation gate. That's the
  *   caller's responsibility — this service exposes the raw CLI output.
  */
 
 import { spawn, spawnSync } from "child_process";
-import { appendFileSync, existsSync, statSync } from "fs";
+import { createHash } from "crypto";
+import { appendFileSync, existsSync, readFileSync, statSync } from "fs";
+import { homedir } from "os";
 import { isAbsolute, sep } from "path";
 import { logger } from "../utils/logger.js";
 
@@ -105,6 +109,12 @@ export class PassService {
   private readonly cliPath: string;
   private readonly pat: string;
   private readonly auditPath: string;
+  /**
+   * CRED-009: rolling hash of the previous audit row, lazily seeded from the
+   * last line on disk. `undefined` means "not yet loaded"; the empty string is
+   * the genesis value for an empty/absent log.
+   */
+  private prevHash: string | undefined;
 
   constructor(args: { personalAccessToken: string; cliPath?: string; auditLogPath: string }) {
     this.pat = args.personalAccessToken;
@@ -137,6 +147,11 @@ export class PassService {
         // SimpleLogin keys in tests, etc.).
         child = spawn(this.cliPath, ["--json", ...args], {
           stdio: ["ignore", "pipe", "pipe"],
+          // CRED-013: pin cwd to the user's home rather than inheriting
+          // process.cwd(). If mailpouch was launched from an attacker-writable
+          // directory (e.g. /tmp), pass-cli could drop session-state files
+          // there. homedir() is the same trust domain that holds the audit log.
+          cwd: homedir(),
           env: {
             PATH: process.env.PATH ?? "",
             HOME: process.env.HOME ?? "",
@@ -187,14 +202,52 @@ export class PassService {
     });
   }
 
-  /** Append one line to the audit log. Never includes secret values. */
+  /**
+   * Lazily recover the `hash` of the last row on disk so a chain survives
+   * process restarts. Best-effort: a missing/empty/corrupt file restarts the
+   * chain from genesis ("").
+   */
+  private loadPrevHash(): string {
+    if (this.prevHash !== undefined) return this.prevHash;
+    let last = "";
+    try {
+      if (existsSync(this.auditPath)) {
+        const lines = readFileSync(this.auditPath, "utf-8").split("\n").filter((l) => l.trim() !== "");
+        const tail = lines[lines.length - 1];
+        if (tail) {
+          const parsed = JSON.parse(tail) as { hash?: unknown };
+          if (typeof parsed.hash === "string") last = parsed.hash;
+        }
+      }
+    } catch {
+      last = "";
+    }
+    this.prevHash = last;
+    return last;
+  }
+
+  /**
+   * Append one line to the audit log. Never includes secret values.
+   *
+   * CRED-009: each row is hash-chained — `hash = sha256(prevHash || canonical)`,
+   * where `canonical` is the row JSON without the `hash` field. A reviewer can
+   * recompute the chain to detect deletion or in-place edits. This is
+   * tamper-EVIDENT, not tamper-PROOF: an attacker with write access can rewrite
+   * the whole file and recompute every hash. The log is best-effort (no fsync,
+   * no rotation lock); treat a broken chain as "investigate", not "trusted".
+   */
   private audit(event: { tool: string; itemId?: string; vault?: string; ok: boolean; error?: string }): void {
     try {
-      const row = {
+      const prevHash = this.loadPrevHash();
+      const base = {
         ts: new Date().toISOString(),
         ...event,
+        prevHash,
       };
+      const hash = createHash("sha256").update(prevHash).update(JSON.stringify(base)).digest("hex");
+      const row = { ...base, hash };
       appendFileSync(this.auditPath, JSON.stringify(row) + "\n", { encoding: "utf-8", mode: 0o600 });
+      this.prevHash = hash;
     } catch (err) {
       logger.warn(`Pass: could not write audit log at ${this.auditPath}`, "PassService", err);
     }

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1680,8 +1680,9 @@ export class SimpleIMAPService {
       // VALID-013: inReplyTo and references are sibling Message-ID header
       // fields and must share ONE sanitiser. The reference list historically
       // stripped the full C0/C1+DEL range; inReplyTo only stripped CR/LF/NUL.
-      // Unify on the broader mask (strictly safer than CRLF-only) for both.
-      const stripHeaderField = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, "");
+      // Unify on the broader mask (strictly safer than CRLF-only) for both —
+      // C0 (0x00–0x1f), DEL and C1 (0x7f–0x9f).
+      const stripHeaderField = (s: string) => s.replace(/[\x00-\x1f\x7f-\x9f]/g, "");
 
       // Build the raw MIME message using nodemailer's buffer transport
       const transport = nodemailer.createTransport({ streamTransport: true, buffer: true, newline: 'crlf' });

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1677,6 +1677,11 @@ export class SimpleIMAPService {
       // flowed through raw, so "Hello\r\nBcc: leak@evil.com" could inject a
       // header line into the appended MIME.
       const stripCrlf = (s: string) => s.replace(/[\r\n\x00]/g, "");
+      // VALID-013: inReplyTo and references are sibling Message-ID header
+      // fields and must share ONE sanitiser. The reference list historically
+      // stripped the full C0/C1+DEL range; inReplyTo only stripped CR/LF/NUL.
+      // Unify on the broader mask (strictly safer than CRLF-only) for both.
+      const stripHeaderField = (s: string) => s.replace(/[\x00-\x1f\x7f]/g, "");
 
       // Build the raw MIME message using nodemailer's buffer transport
       const transport = nodemailer.createTransport({ streamTransport: true, buffer: true, newline: 'crlf' });
@@ -1694,11 +1699,9 @@ export class SimpleIMAPService {
         subject: stripCrlf(options.subject || '(No Subject)'),
         text: options.isHtml ? undefined : (options.body || ''),
         html: options.isHtml ? (options.body || '') : undefined,
-        // Strip CRLF and NUL from inReplyTo to prevent Message-ID header injection
-        // (e.g. a crafted value like "<id>\r\nBcc: evil@x.com" would inject a raw
-        // MIME header line).  Mirrors the stripHeaderInjection() call in smtp-service.ts.
-        inReplyTo: options.inReplyTo ? stripCrlf(options.inReplyTo) : undefined,
-        references: options.references?.map(r => r.replace(/[\x00-\x1f\x7f]/g, "")).join(' '),
+        // VALID-013: both Message-ID header fields use the same broad mask.
+        inReplyTo: options.inReplyTo ? stripHeaderField(options.inReplyTo) : undefined,
+        references: options.references?.map(stripHeaderField).join(' '),
       };
 
       if (options.attachments && options.attachments.length > 0) {

--- a/src/services/simplelogin-service.test.ts
+++ b/src/services/simplelogin-service.test.ts
@@ -73,6 +73,25 @@ describe("SimpleLoginService", () => {
       const svc = new SimpleLoginService("sl-key");
       await expect(svc.listAliases()).rejects.toThrow(/500/);
     });
+
+    // ── CRED-012 — secret-shaped substrings are scrubbed from error bodies ──
+    it("redacts the configured API key if it appears in an upstream error", async () => {
+      const apiKey = "sl_super_secret_api_key_value_1234567890";
+      globalThis.fetch = mockFetch(() => ({ status: 400, body: { error: `invalid key '${apiKey}'` } })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService(apiKey);
+      const err = await svc.listAliases().catch((e: Error) => e);
+      expect((err as Error).message).not.toContain(apiKey);
+      expect((err as Error).message).toContain("[redacted]");
+    });
+
+    it("redacts opaque token-shaped substrings even when not the configured key", async () => {
+      const leaked = "abcdef0123456789ABCDEFghij";  // 26-char opaque blob
+      globalThis.fetch = mockFetch(() => ({ status: 400, body: { error: `token ${leaked} rejected` } })) as unknown as typeof globalThis.fetch;
+      const svc = new SimpleLoginService("sl-key");
+      const err = await svc.listAliases().catch((e: Error) => e);
+      expect((err as Error).message).not.toContain(leaked);
+      expect((err as Error).message).toContain("[redacted]");
+    });
   });
 
   describe("listAliases", () => {

--- a/src/services/simplelogin-service.ts
+++ b/src/services/simplelogin-service.ts
@@ -71,6 +71,24 @@ export class SimpleLoginService {
     return !!this.apiKey;
   }
 
+  /**
+   * CRED-012: strip secret-shaped substrings from a server-controlled error
+   * string. Replaces (a) the exact configured API key and (b) any long
+   * opaque token (SimpleLogin keys are ~40+ char base62/hex blobs) with a
+   * `[redacted]` placeholder so they never reach the log or the MCP response.
+   */
+  private redactSecrets(message: string): string {
+    let out = message;
+    if (this.apiKey) {
+      out = out.split(this.apiKey).join("[redacted]");
+    }
+    // Generic catch-all for opaque tokens: 24+ chars of base62/_- with no
+    // whitespace. Errs toward over-redaction; human-readable messages rarely
+    // contain unbroken 24-char alphanumeric runs.
+    out = out.replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]");
+    return out;
+  }
+
   private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
     if (!this.apiKey) {
       throw new Error(
@@ -98,6 +116,12 @@ export class SimpleLoginService {
           const parsed = JSON.parse(text) as { error?: string };
           if (parsed.error) message = parsed.error;
         } catch { /* non-JSON body — use status text */ }
+        // CRED-012: the upstream `error` body is server-controlled and reaches
+        // the MCP response + the JSONL log, whose redaction is key-based (not
+        // value-pattern). Defensively scrub our own API key and any
+        // token-shaped substrings before raising so a hostile error string
+        // can't smuggle a secret into ~/.mailpouch.log.
+        message = this.redactSecrets(message);
         throw new Error(`SimpleLogin ${init.method ?? "GET"} ${path} → ${message}`);
       }
       if (!text) return undefined as T;

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -7,6 +7,7 @@
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import {
+  optionalSourceFolder,
   requireNumericEmailId,
   validateFolderName,
   validateLabelName,
@@ -293,20 +294,6 @@ export const defs: ToolDef[] = [
     outputSchema: BULK_RESULT_SCHEMA,
   },
 ];
-
-/** Validate and extract an optional sourceFolder argument. Uses the
- *  full-path validator (validateTargetFolder) since sourceFolder is a
- *  complete IMAP path like `Folders/Work` or `Labels/Priority` — the
- *  leaf-only validateFolderName would reject the embedded `/`. */
-function optionalSourceFolder(raw: unknown): string | undefined {
-  if (raw === undefined || raw === null || raw === "") return undefined;
-  if (typeof raw !== "string") {
-    throw new McpError(ErrorCode.InvalidParams, "'sourceFolder' must be a string when provided.");
-  }
-  const err = validateTargetFolder(raw);
-  if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid sourceFolder: ${err}`);
-  return raw;
-}
 
 export const handlers: Record<string, ToolHandler> = {
   mark_email_read: async (ctx) => {

--- a/src/tools/bridge.ts
+++ b/src/tools/bridge.ts
@@ -56,10 +56,15 @@ export const handlers: Record<string, ToolHandler> = {
       state.bridgeAutoStarted = true;
       return ok({ success: true }, "Proton Bridge is running and reachable.");
     }
-    return ok(
-      { success: false, reason: "Bridge launch command sent but ports are not yet reachable. Bridge may still be starting." },
-      "Bridge launch command sent — ports not yet reachable.",
-    );
+    // TOOL-014: the ports never came up. Flag isError so an agent that only
+    // checks result.isError doesn't read this failure as success. The
+    // structured `success: false` + reason are still carried for richer
+    // consumers that unpack structuredContent.
+    return {
+      structuredContent: { success: false, reason: "Bridge launch command sent but ports are not yet reachable. Bridge may still be starting." },
+      content: [{ type: "text" as const, text: "Bridge launch command sent — ports not yet reachable." }],
+      isError: true,
+    };
   },
 
   shutdown_server: async (ctx) => {

--- a/src/tools/deletion.ts
+++ b/src/tools/deletion.ts
@@ -7,7 +7,7 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { requireNumericEmailId, validateTargetFolder } from "../utils/helpers.js";
+import { optionalSourceFolder, requireNumericEmailId } from "../utils/helpers.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const SOURCE_FOLDER_SCHEMA = {
@@ -15,19 +15,6 @@ const SOURCE_FOLDER_SCHEMA = {
   description:
     "Folder the UID(s) live in (e.g. INBOX, Folders/Work, Labels/Foo). Strongly recommended whenever the UIDs came from a folder other than INBOX — IMAP UIDs are folder-scoped, so without this the wrong folder may be selected.",
 };
-
-/** Validate the optional sourceFolder arg. Uses validateTargetFolder so
- *  full-path strings like `Folders/Work` aren't rejected by the leaf-only
- *  validator. */
-function optionalSourceFolder(raw: unknown): string | undefined {
-  if (raw === undefined || raw === null || raw === "") return undefined;
-  if (typeof raw !== "string") {
-    throw new McpError(ErrorCode.InvalidParams, "'sourceFolder' must be a string when provided.");
-  }
-  const err = validateTargetFolder(raw);
-  if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid sourceFolder: ${err}`);
-  return raw;
-}
 
 const ACTION_RESULT_SCHEMA = {
   type: "object",

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -4,7 +4,7 @@
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
-import { validateTargetFolder } from "../utils/helpers.js";
+import { validateRequiredTargetFolder } from "../utils/helpers.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const ACTION_RESULT_SCHEMA = {
@@ -121,42 +121,28 @@ export const handlers: Record<string, ToolHandler> = {
 
   create_folder: async (ctx) => {
     const { args, imapService, actionOk } = ctx;
-    const cfValidErr = validateTargetFolder(args.folderName);
-    if (cfValidErr) throw new McpError(ErrorCode.InvalidParams, cfValidErr);
-    if (!args.folderName || typeof args.folderName !== "string" || !(args.folderName as string).trim()) {
-      throw new McpError(ErrorCode.InvalidParams, "folderName must be a non-empty string.");
-    }
-    await imapService.createFolder(args.folderName as string);
+    // VALID-011: single required-name gate (rejects empty/whitespace + invalid
+    // chars in one McpError shape).
+    const folderName = validateRequiredTargetFolder(args.folderName, "folderName");
+    await imapService.createFolder(folderName);
     return actionOk();
   },
 
   delete_folder: async (ctx) => {
     const { args, imapService, actionOk } = ctx;
-    const dfValidErr = validateTargetFolder(args.folderName);
-    if (dfValidErr) throw new McpError(ErrorCode.InvalidParams, dfValidErr);
-    if (!args.folderName || typeof args.folderName !== "string" || !(args.folderName as string).trim()) {
-      throw new McpError(ErrorCode.InvalidParams, "folderName must be a non-empty string.");
-    }
-    await imapService.deleteFolder(args.folderName as string);
+    const folderName = validateRequiredTargetFolder(args.folderName, "folderName");
+    await imapService.deleteFolder(folderName);
     return actionOk();
   },
 
   rename_folder: async (ctx) => {
     const { args, imapService, actionOk } = ctx;
-    const rfOldErr = validateTargetFolder(args.oldName);
-    if (rfOldErr) throw new McpError(ErrorCode.InvalidParams, `oldName: ${rfOldErr}`);
-    if (!args.oldName || typeof args.oldName !== "string" || !(args.oldName as string).trim()) {
-      throw new McpError(ErrorCode.InvalidParams, "oldName must be a non-empty string.");
-    }
-    const rfNewErr = validateTargetFolder(args.newName);
-    if (rfNewErr) throw new McpError(ErrorCode.InvalidParams, `newName: ${rfNewErr}`);
-    if (!args.newName || typeof args.newName !== "string" || !(args.newName as string).trim()) {
-      throw new McpError(ErrorCode.InvalidParams, "newName must be a non-empty string.");
-    }
-    if ((args.oldName as string) === (args.newName as string)) {
+    const oldName = validateRequiredTargetFolder(args.oldName, "oldName");
+    const newName = validateRequiredTargetFolder(args.newName, "newName");
+    if (oldName === newName) {
       throw new McpError(ErrorCode.InvalidParams, "'newName' must be different from 'oldName'.");
     }
-    await imapService.renameFolder(args.oldName as string, args.newName as string);
+    await imapService.renameFolder(oldName, newName);
     return actionOk();
   },
 };

--- a/src/tools/input-hygiene.test.ts
+++ b/src/tools/input-hygiene.test.ts
@@ -14,10 +14,11 @@ import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolCallContext, ToolResult } from "./types.js";
 
 import { handlers as readingHandlers } from "./reading.js";
+import { handlers as sendingHandlers } from "./sending.js";
+import { handlers as bridgeHandlers } from "./bridge.js";
 import { handlers as analyticsHandlers } from "./analytics.js";
 import { handlers as aliasHandlers } from "./aliases.js";
 import { handlers as systemHandlers } from "./system.js";
-import { handlers as sendingHandlers } from "./sending.js";
 import { handlers as escalationHandlers, type EscalationContext } from "./escalation.js";
 
 const DEFAULT_LIMITS = {
@@ -312,7 +313,6 @@ describe("tool input hygiene (v3.0.53)", () => {
     });
   });
 
-  // ── SMTP-009/010/013 — sending-tool validation parity ─────────────────────
   describe("sending tool hardening (SMTP-009/010/013)", () => {
     const sendOk = { success: true as const, messageId: "msg-1" };
     function sendCtx(overrides: Partial<ToolCallContext>): ToolCallContext {
@@ -385,6 +385,117 @@ describe("tool input hygiene (v3.0.53)", () => {
       await sendingHandlers.forward_email(ctx);
       const sent = sendEmail.mock.calls[0][0] as { body: string };
       expect(sent.body).toContain("see < below");
+    });
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // v3.0.62 low-severity sweep
+  // ════════════════════════════════════════════════════════════════════════
+
+  // ── TOOL-016 — search_emails larger/smaller must be non-negative finite ──
+  describe("TOOL-016 search_emails larger/smaller", () => {
+    for (const field of ["larger", "smaller"] as const) {
+      it(`rejects a negative '${field}'`, async () => {
+        const ctx = makeCtx({ args: { [field]: -1 }, imapService: { searchEmails: vi.fn() } as never });
+        await expect(readingHandlers.search_emails(ctx)).rejects.toBeInstanceOf(McpError);
+      });
+      it(`rejects a NaN '${field}'`, async () => {
+        const ctx = makeCtx({ args: { [field]: Number.NaN }, imapService: { searchEmails: vi.fn() } as never });
+        await expect(readingHandlers.search_emails(ctx)).rejects.toBeInstanceOf(McpError);
+      });
+    }
+    it("accepts a non-negative larger/smaller", async () => {
+      const searchEmails = vi.fn().mockResolvedValue([]);
+      const ctx = makeCtx({ args: { larger: 0, smaller: 1024 }, imapService: { searchEmails } as never });
+      await expect(readingHandlers.search_emails(ctx)).resolves.toBeDefined();
+    });
+  });
+
+  // ── TOOL-017 — sentBefore/sentSince require parseable date strings ───────
+  describe("TOOL-017 search_emails sentBefore/sentSince", () => {
+    for (const field of ["sentBefore", "sentSince"] as const) {
+      it(`rejects a non-string '${field}'`, async () => {
+        const ctx = makeCtx({ args: { [field]: 1234 }, imapService: { searchEmails: vi.fn() } as never });
+        await expect(readingHandlers.search_emails(ctx)).rejects.toBeInstanceOf(McpError);
+      });
+      it(`rejects an unparseable '${field}'`, async () => {
+        const ctx = makeCtx({ args: { [field]: "not-a-date" }, imapService: { searchEmails: vi.fn() } as never });
+        await expect(readingHandlers.search_emails(ctx)).rejects.toBeInstanceOf(McpError);
+      });
+    }
+    it("accepts an ISO date string", async () => {
+      const searchEmails = vi.fn().mockResolvedValue([]);
+      const ctx = makeCtx({ args: { sentBefore: "2026-01-01T00:00:00Z" }, imapService: { searchEmails } as never });
+      await expect(readingHandlers.search_emails(ctx)).resolves.toBeDefined();
+      expect((searchEmails.mock.calls[0][0] as { sentBefore: Date }).sentBefore).toBeInstanceOf(Date);
+    });
+  });
+
+  // ── VALID-016 — fts_search validates the folder filter ───────────────────
+  describe("VALID-016 fts_search folder validation", () => {
+    const ftsCtx = (args: Record<string, unknown>, search = vi.fn().mockReturnValue([])) =>
+      makeCtx({ args, getFts: () => ({ search }) as never, getCallerAllowedFolders: () => undefined });
+
+    it("rejects a traversal in the folder filter", async () => {
+      await expect(readingHandlers.fts_search(ftsCtx({ query: "x", folder: "../etc" }))).rejects.toBeInstanceOf(McpError);
+    });
+    it("accepts a clean folder filter", async () => {
+      await expect(readingHandlers.fts_search(ftsCtx({ query: "x", folder: "Folders/Work" }))).resolves.toBeDefined();
+    });
+  });
+
+  // ── TOOL-013 — fts_rebuild in-progress flag is keyed per DB path ─────────
+  describe("TOOL-013 fts_rebuild per-DB in-progress flag", () => {
+    it("allows concurrent rebuilds against different DB paths", async () => {
+      // Two FTS handles with distinct dbPaths. A blocking rebuild on the first
+      // must not reject a rebuild on the second.
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const ftsA = { stats: vi.fn().mockReturnValue({ messageCount: 0, dbPath: "/tmp/a.db" }), rebuild: vi.fn(async () => { await gate; return 0; }) };
+      const ftsB = { stats: vi.fn().mockReturnValue({ messageCount: 0, dbPath: "/tmp/b.db" }), rebuild: vi.fn().mockReturnValue(0) };
+      const ctxA = makeCtx({ args: {}, getFts: () => ftsA as never, recordFromEmail: ((e: unknown) => e) as never });
+      const ctxB = makeCtx({ args: {}, getFts: () => ftsB as never, recordFromEmail: ((e: unknown) => e) as never });
+      const pA = readingHandlers.fts_rebuild(ctxA);
+      const resB = await readingHandlers.fts_rebuild(ctxB);
+      expect(resB.isError).toBeFalsy();
+      release();
+      await pA;
+    });
+
+    it("rejects a second concurrent rebuild against the SAME DB path", async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((r) => { release = r; });
+      const stats = vi.fn().mockReturnValue({ messageCount: 0, dbPath: "/tmp/same.db" });
+      const fts = { stats, rebuild: vi.fn(async () => { await gate; return 0; }) };
+      const mk = () => makeCtx({ args: {}, getFts: () => fts as never, recordFromEmail: ((e: unknown) => e) as never });
+      const p1 = readingHandlers.fts_rebuild(mk());
+      const res2 = await readingHandlers.fts_rebuild(mk());
+      expect(res2.isError).toBe(true);
+      release();
+      await p1;
+    });
+  });
+
+  // ── TOOL-014 — start_bridge flags isError when ports stay down ───────────
+  describe("TOOL-014 start_bridge port-failure result", () => {
+    const bridgeCtx = (smtpUp: boolean, imapUp: boolean) =>
+      makeCtx({
+        args: {},
+        config: { smtp: { host: "h", port: 1 }, imap: { host: "h", port: 2 } } as never,
+        launchProtonBridge: vi.fn().mockResolvedValue(undefined) as never,
+        isBridgeReachable: vi.fn().mockImplementation((_h: string, p: number) => Promise.resolve(p === 1 ? smtpUp : imapUp)) as never,
+        state: {} as never,
+      });
+
+    it("sets isError when ports never come up", async () => {
+      const res = await bridgeHandlers.start_bridge(bridgeCtx(false, false));
+      expect(res.isError).toBe(true);
+      expect((res.structuredContent as { success: boolean }).success).toBe(false);
+    });
+    it("does not set isError when both ports are reachable", async () => {
+      const res = await bridgeHandlers.start_bridge(bridgeCtx(true, true));
+      expect(res.isError).toBeFalsy();
+      expect((res.structuredContent as { success: boolean }).success).toBe(true);
     });
   });
 });

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -21,6 +21,7 @@ import {
   isValidEmail,
   optionalFolderHint,
   requireNumericEmailId,
+  truncate,
   validateLabelName,
   validateTargetFolder,
 } from "../utils/helpers.js";
@@ -28,7 +29,11 @@ import { extractActionItems, parseIcs } from "../services/content-parser.js";
 import { FtsUnavailableError } from "../services/fts-service.js";
 import type { FtsIndexService } from "../services/fts-service.js";
 
-let _ftsRebuilding = false;
+// TOOL-013: track in-progress rebuilds per resolved DB path rather than a
+// single module-global boolean. Per-account routing means two concurrent
+// fts_rebuild calls can target different index files; a shared flag wrongly
+// rejected the second even when its target was a different DB.
+const _ftsRebuilding = new Set<string>();
 import type { EmailMessage, EmailFolder } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
@@ -246,11 +251,14 @@ export const defsEarly: ToolDef[] = [
     outputSchema: {
       type: "object",
       properties: {
-        emails: { type: "array", items: { type: "object" } },
+        // TOOL-011: advertise the same item shape as get_emails (was a bare
+        // `object` with no properties) and declare required keys.
+        emails: { type: "array", items: EMAIL_SUMMARY_SCHEMA },
         count: { type: "number" },
         folder: { type: "string" },
         nextCursor: { type: "string" },
       },
+      required: ["emails", "folder", "count"],
     },
   },
 ];
@@ -620,10 +628,30 @@ export const handlers: Record<string, ToolHandler> = {
     }
     const answered = typeof args.answered === 'boolean' ? args.answered : undefined;
     const isDraft  = typeof args.isDraft === 'boolean' ? args.isDraft : undefined;
+    // TOOL-016: byte-size predicates are non-negative integers; reject negatives
+    // and non-finite (NaN/Infinity) instead of forwarding them to the IMAP wire.
+    if (args.larger !== undefined &&
+        (typeof args.larger !== 'number' || !Number.isFinite(args.larger) || args.larger < 0)) {
+      throw new McpError(ErrorCode.InvalidParams, "'larger' must be a non-negative finite number (bytes) when provided.");
+    }
+    if (args.smaller !== undefined &&
+        (typeof args.smaller !== 'number' || !Number.isFinite(args.smaller) || args.smaller < 0)) {
+      throw new McpError(ErrorCode.InvalidParams, "'smaller' must be a non-negative finite number (bytes) when provided.");
+    }
     const larger   = typeof args.larger === 'number' ? args.larger : undefined;
     const smaller  = typeof args.smaller === 'number' ? args.smaller : undefined;
-    const sentBefore = args.sentBefore ? new Date(args.sentBefore as string) : undefined;
-    const sentSince  = args.sentSince  ? new Date(args.sentSince  as string) : undefined;
+    // TOOL-017: require a string + a parseable date. The old truthy-check let
+    // numbers/objects through — `new Date(null)` → 1970, `new Date({})` →
+    // Invalid Date — silently corrupting the search window.
+    const parseSentDate = (raw: unknown, field: string): Date | undefined => {
+      if (raw === undefined || raw === null) return undefined;
+      if (typeof raw !== 'string' || Number.isNaN(Date.parse(raw))) {
+        throw new McpError(ErrorCode.InvalidParams, `'${field}' must be a parseable date string when provided.`);
+      }
+      return new Date(raw);
+    };
+    const sentBefore = parseSentDate(args.sentBefore, 'sentBefore');
+    const sentSince  = parseSentDate(args.sentSince, 'sentSince');
 
     const results = await imapService.searchEmails({
       folder: folders ? undefined : folder,
@@ -767,9 +795,26 @@ export const handlers: Record<string, ToolHandler> = {
       if (normSubj !== normalized) continue;
       byId.set(m.id, m);
     }
+    // TOOL-010: the outputSchema advertises EMAIL_SUMMARY_SCHEMA, but the
+    // handler used to return full EmailMessage objects (entire body per
+    // message), so a long thread could blow the 1 MB response budget and the
+    // shape didn't match the schema. Narrow to the summary fields, deriving a
+    // bounded bodyPreview from the body when absent.
     const messages = Array.from(byId.values())
       .sort((a, b) => (a.date?.getTime?.() ?? 0) - (b.date?.getTime?.() ?? 0))
-      .slice(0, maxMsgs);
+      .slice(0, maxMsgs)
+      .map((m) => ({
+        id: m.id,
+        from: m.from,
+        to: m.to,
+        subject: m.subject,
+        bodyPreview: m.bodyPreview ?? (m.body ? truncate(m.body, 300) : ""),
+        date: m.date?.toISOString?.() ?? null,
+        folder: m.folder,
+        isRead: m.isRead,
+        isStarred: m.isStarred,
+        hasAttachment: m.hasAttachment,
+      }));
     return ok({ subject: normalized, messages });
   },
 
@@ -840,10 +885,18 @@ export const handlers: Record<string, ToolHandler> = {
       throw new McpError(ErrorCode.InvalidParams, "'sinceEpoch' must be a non-negative finite number (epoch seconds) when provided.");
     }
     const sinceEpoch = typeof args.sinceEpoch === "number" ? args.sinceEpoch : undefined;
+    // VALID-016: validate the folder filter for parity with search_emails;
+    // previously it was forwarded raw, so fts_search admitted folders its IMAP
+    // twin would reject.
+    const ftsFolder = typeof args.folder === "string" ? args.folder : undefined;
+    if (ftsFolder !== undefined) {
+      const ftsFolderErr = validateTargetFolder(ftsFolder);
+      if (ftsFolderErr) throw new McpError(ErrorCode.InvalidParams, `folder: ${ftsFolderErr}`);
+    }
     const hits = fts.search({
       query: q,
       limit,
-      folder: typeof args.folder === "string" ? args.folder : undefined,
+      folder: ftsFolder,
       sinceEpoch,
       allowedFolders,
     }).map(h => ({
@@ -861,12 +914,15 @@ export const handlers: Record<string, ToolHandler> = {
 
   fts_rebuild: async (ctx) => {
     const { ok, getFts, getAnalyticsEmails, recordFromEmail } = ctx;
-    if (_ftsRebuilding) {
+    const fts = getFts();
+    // Resolve the target DB path so the in-progress guard is scoped to this
+    // account's index, not all accounts (TOOL-013).
+    const dbPath = fts.stats().dbPath;
+    if (_ftsRebuilding.has(dbPath)) {
       return { content: [{ type: "text" as const, text: "FTS rebuild already in progress — try again in a moment." }], isError: true };
     }
-    _ftsRebuilding = true;
+    _ftsRebuilding.add(dbPath);
     try {
-      const fts = getFts();
       const { inbox, sent } = await getAnalyticsEmails();
       // PARSE-003: atomic clear+repopulate in one transaction. A bare
       // clear()+upsertMany() committed the DELETE immediately, so a throw mid-map
@@ -876,7 +932,7 @@ export const handlers: Record<string, ToolHandler> = {
       const stats = fts.stats();
       return ok({ indexed, messageCount: stats.messageCount, dbPath: stats.dbPath });
     } finally {
-      _ftsRebuilding = false;
+      _ftsRebuilding.delete(dbPath);
     }
   },
 

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1132,6 +1132,14 @@ describe('helpers', () => {
       expect(() => requireNumericEmailId('3.14')).toThrow(McpError);
     });
 
+    it('accepts the 32-bit unsigned max (4294967295)', () => {
+      expect(requireNumericEmailId('4294967295')).toBe('4294967295');
+    });
+
+    it('throws for a 10-digit value above the 32-bit max ("9999999999")', () => {
+      expect(() => requireNumericEmailId('9999999999')).toThrow(McpError);
+    });
+
     it('throws for null', () => {
       expect(() => requireNumericEmailId(null)).toThrow(McpError);
     });
@@ -3958,6 +3966,12 @@ describe('helpers', () => {
     it('throws on non-string and invalid path', () => {
       expect(() => optionalSourceFolder(42)).toThrow(McpError);
       expect(() => optionalSourceFolder('a..b')).toThrow(McpError);
+    });
+    it('rejects leading/trailing whitespace so the gate matches the service', () => {
+      // validateImapPath (what the service uses) rejects " INBOX"; the tool gate
+      // must agree and throw a clean McpError rather than passing it through.
+      expect(() => optionalSourceFolder(' INBOX')).toThrow(McpError);
+      expect(() => optionalSourceFolder('INBOX ')).toThrow(McpError);
     });
   });
 

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -27,6 +27,9 @@ import {
   sleep,
   clampOptionalInt,
   requireNonEmptyString,
+  validateLeafName,
+  validateRequiredTargetFolder,
+  optionalSourceFolder,
 } from './helpers.js';
 
 describe('helpers', () => {
@@ -3851,6 +3854,122 @@ describe('helpers', () => {
       expect(() => requireNonEmptyString('   ', 'reason')).toThrow(McpError);
       expect(() => requireNonEmptyString(undefined, 'reason')).toThrow(McpError);
       expect(() => requireNonEmptyString(42, 'reason')).toThrow(McpError);
+    });
+  });
+
+  // ── v3.0.62 low-severity validator sweep ───────────────────────────────────
+
+  describe('validateLeafName (VALID-004 shared core)', () => {
+    it('uses the provided field name in the error', () => {
+      expect(validateLeafName('', 'widget')).toMatch(/widget must be a non-empty/i);
+    });
+    it('rejects slash, traversal and control chars', () => {
+      expect(validateLeafName('a/b', 'x')).toMatch(/invalid characters/i);
+      expect(validateLeafName('..', 'x')).toMatch(/invalid characters/i);
+      expect(validateLeafName('a\x00b', 'x')).toMatch(/invalid characters/i);
+    });
+    it('accepts a plain leaf', () => {
+      expect(validateLeafName('Work', 'x')).toBeNull();
+    });
+  });
+
+  describe('VALID-007 — leaf/path validators reject DEL and C1 controls', () => {
+    it('validateLabelName rejects DEL (0x7f) and C1 (0x80-0x9f)', () => {
+      expect(validateLabelName('a\x7fb')).toMatch(/invalid characters/i);
+      expect(validateLabelName('a\x85b')).toMatch(/invalid characters/i);
+    });
+    it('validateFolderName rejects DEL and C1', () => {
+      expect(validateFolderName('a\x7fb')).toMatch(/invalid characters/i);
+      expect(validateFolderName('a\x9fb')).toMatch(/invalid characters/i);
+    });
+    it('validateTargetFolder and validateImapPath reject DEL', () => {
+      expect(validateTargetFolder('Folders/a\x7fb')).toMatch(/invalid characters/i);
+      expect(validateImapPath('Folders/a\x7fb')).toMatch(/invalid characters/i);
+    });
+  });
+
+  describe('VALID-008 — requireNumericEmailId bounds', () => {
+    it('accepts a normal UID', () => {
+      expect(requireNumericEmailId('12345')).toBe('12345');
+    });
+    it('accepts the literal "0"', () => {
+      expect(requireNumericEmailId('0')).toBe('0');
+    });
+    it('rejects leading zeros', () => {
+      expect(() => requireNumericEmailId('0000001')).toThrow(McpError);
+    });
+    it('rejects over-length numeric strings (>10 digits)', () => {
+      expect(() => requireNumericEmailId('123456789012345')).toThrow(McpError);
+    });
+  });
+
+  describe('VALID-010 — parseEmails per-token cap', () => {
+    it('drops a pathologically long token but keeps valid neighbours', () => {
+      const huge = 'x'.repeat(5000) + '@example.com';
+      expect(parseEmails(`good@example.com, ${huge}`)).toEqual(['good@example.com']);
+    });
+  });
+
+  describe('VALID-011 — validateRequiredTargetFolder', () => {
+    it('returns the trimmed name', () => {
+      expect(validateRequiredTargetFolder('  Folders/Work  ', 'folderName')).toBe('Folders/Work');
+    });
+    it('throws on empty/whitespace/non-string', () => {
+      expect(() => validateRequiredTargetFolder('', 'folderName')).toThrow(McpError);
+      expect(() => validateRequiredTargetFolder('   ', 'folderName')).toThrow(McpError);
+      expect(() => validateRequiredTargetFolder(undefined, 'folderName')).toThrow(McpError);
+    });
+    it('throws on invalid chars', () => {
+      expect(() => validateRequiredTargetFolder('a..b', 'folderName')).toThrow(McpError);
+    });
+  });
+
+  describe('VALID-012 — validateImapPath rejects edge whitespace', () => {
+    it('rejects leading/trailing whitespace', () => {
+      expect(validateImapPath(' INBOX')).toMatch(/whitespace/i);
+      expect(validateImapPath('INBOX ')).toMatch(/whitespace/i);
+    });
+    it('accepts a clean path', () => {
+      expect(validateImapPath('Folders/Work')).toBeNull();
+    });
+  });
+
+  describe('VALID-018 — validateAttachments filename hardening', () => {
+    it('rejects path separators and traversal in filename', () => {
+      expect(validateAttachments([{ filename: '../../etc/passwd', content: 'aGk=' }])).toMatch(/path separators/i);
+      expect(validateAttachments([{ filename: 'a\\b', content: 'aGk=' }])).toMatch(/path separators/i);
+    });
+    it('rejects an over-length filename', () => {
+      expect(validateAttachments([{ filename: 'x'.repeat(300), content: 'aGk=' }])).toMatch(/maximum length/i);
+    });
+    it('accepts a clean filename', () => {
+      expect(validateAttachments([{ filename: 'report.pdf', content: 'aGk=' }])).toBeNull();
+    });
+  });
+
+  describe('VALID-021 — optionalSourceFolder (shared)', () => {
+    it('returns undefined for omitted/empty', () => {
+      expect(optionalSourceFolder(undefined)).toBeUndefined();
+      expect(optionalSourceFolder('')).toBeUndefined();
+    });
+    it('returns a valid full path', () => {
+      expect(optionalSourceFolder('Folders/Work')).toBe('Folders/Work');
+    });
+    it('throws on non-string and invalid path', () => {
+      expect(() => optionalSourceFolder(42)).toThrow(McpError);
+      expect(() => optionalSourceFolder('a..b')).toThrow(McpError);
+    });
+  });
+
+  describe('PARSE-020 — extractEmailAddress anchoring', () => {
+    it('extracts the trailing address, not the first bracket pair', () => {
+      expect(extractEmailAddress('<bogus> "Alice" <real@x.com>')).toBe('real@x.com');
+    });
+    it('still handles a normal display-name form', () => {
+      expect(extractEmailAddress('Alice <alice@x.com>')).toBe('alice@x.com');
+    });
+    it('falls back to the trimmed input when no bracket pair matches', () => {
+      expect(extractEmailAddress('  plain@x.com  ')).toBe('plain@x.com');
     });
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -18,6 +18,13 @@ export const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 export const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
 /**
+ * Per-token cap for `parseEmails` (VALID-010). RFC 5321 caps a full address at
+ * 320 chars; 1024 leaves generous room for a `Display Name <addr>` token while
+ * keeping the regex off multi-kilobyte inputs.
+ */
+export const MAX_ADDRESS_TOKEN = 1024;
+
+/**
  * Best-effort decoded byte size of an attachment `content` value.
  * base64 strings decode to ~3/4 of their character length; Buffers are exact.
  * Returns `null` for anything that is neither (e.g. a Readable stream), which
@@ -78,6 +85,13 @@ export function parseEmailsDetailed(emailString: string): { valid: string[]; dro
   for (const raw of emailString.split(",")) {
     const trimmed = raw.trim();
     if (trimmed.length === 0) continue;
+    // VALID-010: reject pathologically long tokens before running the regex.
+    // RFC 5321 caps a full address at 320 chars; allow generous room for a
+    // display name but cap so a multi-MB token can't be fed to the matcher.
+    if (trimmed.length > MAX_ADDRESS_TOKEN) {
+      logger.warn("parseEmails: dropping over-length address token", "helpers", { length: trimmed.length });
+      continue;
+    }
     // Support "Display Name <email@domain.com>" format by extracting the angle-bracket part.
     // Anchored to reject multiple/nested brackets: "Name <<x>>" or "a> <b".
     const angleMatch = trimmed.match(/^[^<>]*<([^<>]+)>$/);
@@ -161,8 +175,19 @@ export function sanitizeForLog(str: string, maxLength: number = 100): string {
  * Extract email address from "Name <email@domain.com>" format
  */
 export function extractEmailAddress(emailString: string): string {
-  const match = emailString.match(/<([^>]+)>/);
-  return match ? match[1] : emailString.trim();
+  // PARSE-020: take the LAST angle-bracket pair, not the first one found
+  // anywhere. A hostile header like `<bogus> "Alice" <real@x.com>` previously
+  // returned `bogus` (first `<...>`) and poisoned the contact map; the real
+  // address is conventionally the trailing `<addr>` segment.
+  const lastOpen = emailString.lastIndexOf("<");
+  if (lastOpen !== -1) {
+    const close = emailString.indexOf(">", lastOpen + 1);
+    if (close !== -1) {
+      const inner = emailString.slice(lastOpen + 1, close).trim();
+      if (inner) return inner;
+    }
+  }
+  return emailString.trim();
 }
 
 /**
@@ -212,46 +237,59 @@ export function generateId(): string {
 }
 
 /**
- * Validate a label name before constructing an IMAP path (e.g. `Labels/<name>`).
+ * Control-character class rejected by every text-shape validator: the full
+ * C0 range (U+0000–U+001F), DEL (U+007F), and the C1 range (U+0080–U+009F).
+ * VALID-007: the old `/[\x00-\x1f]/` let DEL and C1 through; this matches the
+ * CONTROL_CHARS_RE documented in settings/security.ts sanitizeText.
+ */
+const CONTROL_CHARS_RE = /[\x00-\x1f\x7f\x80-\x9f]/;
+
+/**
+ * Validate a single IMAP name segment (a "leaf") before it is composed into a
+ * path such as `Labels/<name>` or `Folders/<name>`. Shared by
+ * `validateLabelName` and `validateFolderName` so the rules can't drift
+ * (VALID-004 — the two were byte-identical duplicates).
  *
- * Returns `null` on success or an error message string on failure.
- * Rules mirror those used in `move_to_label`:
+ * Returns `null` on success or an error message string on failure. Rules:
  *   - Must be a non-empty string after trimming
  *   - Must not contain `/` (path separator) or `..` (traversal)
- *   - Must not contain C0 control characters (U+0000–U+001F)
+ *   - Must not contain C0/C1 control characters or DEL
  *   - Must not exceed 255 characters
  */
-export function validateLabelName(label: unknown): string | null {
-  if (!label || typeof label !== "string" || !label.trim()) {
-    return "label must be a non-empty string.";
+export function validateLeafName(value: unknown, fieldName: string): string | null {
+  if (!value || typeof value !== "string" || !value.trim()) {
+    return `${fieldName} must be a non-empty string.`;
   }
-  if (label.includes("/") || label.includes("..") || /[\x00-\x1f]/.test(label)) {
-    return "label contains invalid characters (/, .., or control characters).";
+  if (value.includes("/") || value.includes("..") || CONTROL_CHARS_RE.test(value)) {
+    return `${fieldName} contains invalid characters (/, .., or control characters).`;
   }
-  if (label.length > 255) {
-    return "label exceeds maximum length of 255 characters.";
+  if (value.length > 255) {
+    return `${fieldName} exceeds maximum length of 255 characters.`;
   }
   return null;
 }
 
 /**
- * Validate a folder name before constructing an IMAP path (e.g. `Folders/<name>`).
- *
+ * Validate a label name before constructing an IMAP path (e.g. `Labels/<name>`).
  * Returns `null` on success or an error message string on failure.
- * Same rules as validateLabelName — the folder name is the leaf segment only;
- * the `Folders/` prefix is added by the caller.
+ *
+ * Note (VALID-019): a non-ASCII leaf like `Wörk` is accepted here but imapflow
+ * encodes it to modified UTF-7 (`W&APY-rk`) on the wire, so the IMAP-stored
+ * name differs from the in-memory key. Callers that use the label as a map key
+ * must re-list to learn the encoded name.
+ */
+export function validateLabelName(label: unknown): string | null {
+  return validateLeafName(label, "label");
+}
+
+/**
+ * Validate a folder name before constructing an IMAP path (e.g. `Folders/<name>`).
+ * Returns `null` on success or an error message string on failure.
+ * The folder name is the leaf segment only; the `Folders/` prefix is added by
+ * the caller.
  */
 export function validateFolderName(folder: unknown): string | null {
-  if (!folder || typeof folder !== "string" || !folder.trim()) {
-    return "folder must be a non-empty string.";
-  }
-  if (folder.includes("/") || folder.includes("..") || /[\x00-\x1f]/.test(folder)) {
-    return "folder contains invalid characters (/, .., or control characters).";
-  }
-  if (folder.length > 255) {
-    return "folder exceeds maximum length of 255 characters.";
-  }
-  return null;
+  return validateLeafName(folder, "folder");
 }
 
 /**
@@ -264,19 +302,50 @@ export function validateFolderName(folder: unknown): string | null {
  * Max length 1000 characters.
  */
 export function validateTargetFolder(targetFolder: unknown): string | null {
+  // VALID-017: empty/omitted is intentionally NOT an error here — it signals
+  // "caller falls back to a default (e.g. INBOX)". Folder-MUTATING tools that
+  // require a concrete name must use `validateRequiredTargetFolder` instead, or
+  // an empty string would silently reach imapflow.
   if (targetFolder === undefined || targetFolder === null || targetFolder === "") {
     return null; // omitted/empty — caller uses a default (e.g. INBOX)
   }
   if (typeof targetFolder !== "string") {
     return "targetFolder must be a string.";
   }
-  if (/[\x00-\x1f]/.test(targetFolder) || targetFolder.includes("..")) {
+  // VALID-007: reject the full C0/C1+DEL control range, not just C0.
+  if (CONTROL_CHARS_RE.test(targetFolder) || targetFolder.includes("..")) {
     return "targetFolder contains invalid characters (.. or control characters).";
   }
+  // VALID-014: 1000 is the single full-path bound. A multi-segment path may
+  // exceed any single 255-char leaf cap; the per-leaf validators enforce 255
+  // on the segments that callers compose, this caps the assembled path.
   if (targetFolder.length > 1000) {
     return "targetFolder exceeds maximum length of 1000 characters.";
   }
   return null;
+}
+
+/**
+ * Like `validateTargetFolder` but REQUIRES a non-empty (after trim) name.
+ *
+ * VALID-011: folder-mutating tools (`create_folder`/`delete_folder`/
+ * `rename_folder`) always need a concrete name, so the empty-string fall-back
+ * semantics of `validateTargetFolder` are wrong for them. Each handler used to
+ * repeat its own `!args.folderName || ...trim()` guard with subtly different
+ * shapes; this centralises it. Returns the trimmed value on success or throws
+ * `McpError(InvalidParams, …)`.
+ */
+export function validateRequiredTargetFolder(raw: unknown, fieldName: string = "folderName"): string {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw new McpError(ErrorCode.InvalidParams, `${fieldName} is required and must be a non-empty string.`);
+  }
+  const trimmed = raw.trim();
+  const err = validateTargetFolder(trimmed);
+  if (err) {
+    const cleaned = err.replace(/^targetFolder\s*/, "");
+    throw new McpError(ErrorCode.InvalidParams, `Invalid ${fieldName}: ${cleaned}`);
+  }
+  return trimmed;
 }
 
 /**
@@ -299,7 +368,15 @@ export function validateImapPath(path: unknown): string | null {
   if (!path || typeof path !== "string" || !path.trim()) {
     return "folder path must be a non-empty string.";
   }
-  if (path.includes("..") || /[\x00-\x1f]/.test(path)) {
+  // VALID-012: reject leading/trailing whitespace rather than silently
+  // accepting a path that selects a different mailbox than the visible name
+  // (e.g. " INBOX" vs "INBOX"). The IMAP modified-UTF-7 `&` escape is left
+  // intact since legitimate encoded folder names contain it.
+  if (path !== path.trim()) {
+    return "folder path must not have leading or trailing whitespace.";
+  }
+  // VALID-007: reject the full C0/C1+DEL control range, not just C0.
+  if (path.includes("..") || CONTROL_CHARS_RE.test(path)) {
     return "folder path contains invalid characters (.. or control characters).";
   }
   if (path.length > 1000) {
@@ -341,7 +418,11 @@ export function truncate(text: string, maxLength: number): string {
  * @throws {McpError} with `ErrorCode.InvalidParams` when validation fails.
  */
 export function requireNumericEmailId(raw: unknown, fieldName: string = "emailId"): string {
-  if (!raw || typeof raw !== "string" || !/^\d+$/.test(raw)) {
+  // VALID-008: IMAP UIDs are 32-bit unsigned (max 4294967295 = 10 digits).
+  // Reject leading zeros (except the literal "0") and over-length strings so a
+  // thousand-digit "UID" can't burn log space / Bridge round-trips. `^\d+$`
+  // alone admitted "0000001" and arbitrarily long numeric strings.
+  if (!raw || typeof raw !== "string" || !/^(0|[1-9]\d{0,9})$/.test(raw)) {
     throw new McpError(ErrorCode.InvalidParams, `${fieldName} must be a non-empty numeric UID string.`);
   }
   return raw;
@@ -378,6 +459,26 @@ export function optionalFolderHint(raw: unknown, fieldName: string = "folder"): 
     throw new McpError(ErrorCode.InvalidParams, `Invalid ${fieldName}: ${cleaned}`);
   }
   return trimmed;
+}
+
+/**
+ * Validate an optional `sourceFolder` argument — the full IMAP path the
+ * UID(s) live in (e.g. `Folders/Work`, `Labels/Foo`). Uses the full-path
+ * validator (`validateTargetFolder`) so embedded `/` is allowed. Returns the
+ * value when present, `undefined` for omitted/empty/null, and throws
+ * `McpError(InvalidParams, …)` otherwise.
+ *
+ * VALID-021: previously defined byte-for-byte in both `tools/actions.ts` and
+ * `tools/deletion.ts`; consolidated here so the two can't drift.
+ */
+export function optionalSourceFolder(raw: unknown): string | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  if (typeof raw !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'sourceFolder' must be a string when provided.");
+  }
+  const err = validateTargetFolder(raw);
+  if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid sourceFolder: ${err}`);
+  return raw;
 }
 
 /**
@@ -458,6 +559,15 @@ export function validateAttachments(attachments: unknown): string | null {
     const { filename, content, contentType } = att as Record<string, unknown>;
     if (!filename || typeof filename !== "string") {
       return `attachments[${i}].filename must be a non-empty string.`;
+    }
+    // VALID-018: the SMTP/IMAP layers scrub CRLF/traversal later, but reject
+    // path separators and control chars here so `../../../etc/passwd` and the
+    // like never reach a layer that might interpret them.
+    if (filename.includes("/") || filename.includes("\\") || filename.includes("..") || CONTROL_CHARS_RE.test(filename)) {
+      return `attachments[${i}].filename must not contain path separators, '..', or control characters.`;
+    }
+    if (filename.length > 255) {
+      return `attachments[${i}].filename exceeds maximum length of 255 characters.`;
     }
     if (content === undefined || content === null || (typeof content !== "string" && !Buffer.isBuffer(content))) {
       return `attachments[${i}].content must be a base64 string or Buffer.`;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -425,6 +425,11 @@ export function requireNumericEmailId(raw: unknown, fieldName: string = "emailId
   if (!raw || typeof raw !== "string" || !/^(0|[1-9]\d{0,9})$/.test(raw)) {
     throw new McpError(ErrorCode.InvalidParams, `${fieldName} must be a non-empty numeric UID string.`);
   }
+  // 10 digits still admits up to 9999999999, beyond the 32-bit unsigned max.
+  // Enforce the real ceiling so an out-of-range "UID" can't reach the Bridge.
+  if (Number(raw) > 4294967295) {
+    throw new McpError(ErrorCode.InvalidParams, `${fieldName} exceeds the maximum IMAP UID (4294967295).`);
+  }
   return raw;
 }
 
@@ -476,7 +481,11 @@ export function optionalSourceFolder(raw: unknown): string | undefined {
   if (typeof raw !== "string") {
     throw new McpError(ErrorCode.InvalidParams, "'sourceFolder' must be a string when provided.");
   }
-  const err = validateTargetFolder(raw);
+  // Validate with the same validator the service layer uses (validateFolderName
+  // delegates to validateImapPath) so the tool gate and the service agree —
+  // e.g. " INBOX" is rejected here with a clean McpError instead of passing the
+  // gate and failing later with a non-McpError shape.
+  const err = validateImapPath(raw);
   if (err) throw new McpError(ErrorCode.InvalidParams, `Invalid sourceFolder: ${err}`);
   return raw;
 }


### PR DESCRIPTION
Batch **P2-B** of the 2026-05-28 audit Low-severity sweep — tools, validators, parsers, credentials. Ships as **v3.0.62**. DO NOT MERGE per batch instructions.

## Findings closed (code fix)
**Validators (`src/utils/helpers.ts`)**
- VALID-004 shared `validateLeafName(value, fieldName)` core for label/folder
- VALID-007 full C0/C1+DEL control mask in every text validator
- VALID-008 `requireNumericEmailId` bounded (10 digits, no leading zeros)
- VALID-010 `parseEmails` per-token cap (`MAX_ADDRESS_TOKEN`)
- VALID-011 `validateRequiredTargetFolder` wired into create/delete/rename folder
- VALID-012 `validateImapPath` rejects leading/trailing whitespace
- VALID-013 `saveDraft` `inReplyTo`/`references` share one sanitiser
- VALID-016 `fts_search` validates its `folder` filter
- VALID-018 `validateAttachments` filename hardening (separators/traversal/control/255)
- VALID-021 `optionalSourceFolder` consolidated into helpers

**Tools (`src/tools/*`)**
- TOOL-010 `get_thread` narrows to summary shape (bounded body)
- TOOL-011 `get_emails_by_label` outputSchema items + required
- TOOL-013 `fts_rebuild` in-progress guard keyed per DB path
- TOOL-014 `start_bridge` flags `isError` on port failure
- TOOL-016 `search_emails` rejects negative/NaN `larger`/`smaller`
- TOOL-017 `search_emails` requires parseable `sentBefore`/`sentSince`
- TOOL-015 closed via the shared `optionalFolderHint` gate (also VALID-001/009)

**Parsers**
- PARSE-020 `extractEmailAddress` takes the last bracket pair

**Credentials**
- CRED-005 single keychain fetch per account
- CRED-009 hash-chained Pass audit log (best-effort tamper-evident)
- CRED-011 atomic v1→v2 re-encrypt (stage both, save once)
- CRED-012 redact API key + token-shaped substrings from SimpleLogin errors
- CRED-013 pin pass-cli `cwd` to `homedir()`
- CRED-015 `migrateCredentials` under write lock on a deep clone

## Annotation-only reconciliation
- VALID-001 / VALID-009 — verified closed by the v3.0.44 #131 `optionalFolderHint` work and annotated.

## Acknowledged (won't-fix, by design)
- TOOL-012 — two `email_id`/`emailId` spellings are a frozen part of the published schema; shared validator already gives both identical behavior.
- TOOL-020 — `agentAudit.write()` is a sync `appendFileSync` in the dispatcher `finally`, which always completes before the `setImmediate(gracefulShutdown)` callback can run.

## Documentation-only (per audit suggestion)
- VALID-014 (single full-path cap documented), VALID-017 (empty-as-default contract documented), VALID-019 (UTF-7 expansion documented).

## Validation
- `tsc --noEmit` clean
- `npm test` — 1883 passed (53 files)
- `PRESHIP_NO_BRIDGE=1 npm run preship:fast` — PASS (typecheck, version-sync, secrets, npm-audit, license-inv, build, unit, tarball-smoke)
- New regression tests across helpers, input-hygiene, pass-service, simplelogin-service, registry, loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)