### PR TITLE
chore(audit): Info triage + final ledger reconciliation — close 2026-05-28 audit (v3.0.64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.64] — 2026-05-30
+
+### Fixed — Info triage + final audit-ledger reconciliation (audit 2026-05-28)
+
+Closeout batch for the 2026-05-28 audit. Triaged the 21 remaining Info findings (fix-or-acknowledge) and reconciled seven previously-shipped findings whose audit-doc blocks were never annotated. After this batch every `#### <ID>` block in `docs/audit-2026-05-28.md` carries a Resolved/Acknowledged annotation (241/241).
+
+**Info fixes (7)**
+- TOOL-018: `get_connection_status` outputSchema gains `required: ["smtp","imap","settingsConfigured","settingsConfigPath"]`.
+- TOOL-019: `fts_status` outputSchema gains `required: ["available"]`.
+- TOOL-021: `pass_get`'s `fields` schema documents its optional/omitted-when-empty semantics.
+- TOOL-023: `clear_cache` description states it does NOT rebuild the FTS index (use `fts_rebuild`).
+- TOOL-024: `get_emails_by_label` limit clamp mirrors `get_emails`' `Math.min(Math.max(1, …), …)` order.
+- SMTP-020: `escapeHtml` now also escapes `'` → `&#39;` for safe reuse in single-quoted attributes.
+- UI-018: audit-log CSS class built from a `{requested,approved,denied,expired}` allowlist instead of `escHtml(e.event)`.
+
+**Info acknowledged as by-design (14)** — IMAP-017 (already addressed by the IMAP-005 rename), IMAP-021, SMTP-017, SMTP-019, XPORT-019, XPORT-020, XPORT-022, PERM-016, TOOL-022, CRED-014, VALID-020, UI-016, TEST-023, TEST-025. Reasons recorded inline in the audit doc.
+
+### Ledger reconciliation
+Verified against shipped code and annotated in `docs/audit-2026-05-28.md`: TEST-016 / TEST-017 / TEST-018 / TEST-020 / TEST-021 / TEST-022 (v3.0.63 test-quality sweep #174), and BUILD-014 (v3.0.43 preship-gate hotfix #130 — `PRESHIP_SKIP=1` bypass at `scripts/preship.mjs:31`).
+
 ## [3.0.63] — 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.63-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.64-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -279,6 +279,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: N/A (style).
 - Suggested next step: Rename `id` → `cacheKey` in both handlers.
 
+> **Acknowledged in v3.0.64 — by design: already addressed.** The IMAP-005 fix replaced the IDLE eviction loops; `evictInboxCacheEntries` and the remaining cache iterators already use `cacheKey`/`key`, so the misleading `id` binding the finding flagged no longer exists.
+
 #### IMAP-021 — `bridgeVersion` field is public-writable; not marked `private` or `readonly`
 - Location: `src/services/simple-imap-service.ts:503`
 - Category: Tech-debt
@@ -291,6 +293,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **IMAP-CORRECTNESS patterns:** the v3.0.41 fix correctly added the `sourceFolder` + pre-flight `UID FETCH` pattern to the singular and most-bulk mutators, but the rebuild was *not* mechanically uniform: `setFlag` was missed entirely (IMAP-008, IMAP-009), and three of the bulk methods kept a soft `?? 'INBOX'` fallback that recreates the same silent-no-op class the rest of the fix closed (IMAP-003). Defensive `catch {}` blocks are the second pattern — they hide UIDVALIDITY mismatches, connection-reset errors during preflight, draft-folder discovery failures, connection-lost reads, and `disconnect()` errors; each one converts an actionable failure into a misleading success path. The third pattern is wire safety being uneven: SMTP has a thorough `stripHeaderInjection` helper but `options.header` (IMAP-004) is passed through raw; `sanitizeImapStr` is itself heavy-handed enough to be a correctness bug (IMAP-020). The fourth is scale assumptions baked into IMAP command construction (IMAP-002, IMAP-016) and `expandImapSequence` (IMAP-011). Finally, the IDLE client lives in a parallel universe from the main client (IMAP-001, IMAP-005).
 
 ### SMTP / drafts / scheduling / reminders
+
+> **Acknowledged in v3.0.64 — by design: leaky-field hardening is a non-trivial contract change.** Making `bridgeVersion`/`insecureTls` private with getters and resetting them across connect/disconnect is a class-surface refactor with reconnect-path risk; not a trivial Info fix. No security impact today (single-process, single-owner).
 
 #### SMTP-001 — `persist()` race: scheduler write during in-flight `sendMail()` can lose newly-arrived items
 - Location: `src/services/scheduler.ts:170-208`
@@ -471,6 +475,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: import `_resetBridgeCertPinsForTests` from prod build; call it; subsequent cert change is no longer flagged.
 - Suggested next step: gate behind `if (process.env.NODE_ENV === 'test')` or move to a separate `__test__` entry point.
 
+> **Acknowledged in v3.0.64 — by design: test seam stays.** `_resetBridgeCertPinsForTests` is underscore-flagged and only resets an in-process pin table; gating it behind `NODE_ENV` or a separate entry point touches the TLS-pinning security surface and is out of scope for a trivial Info fix.
+
 #### SMTP-019 — `tracer.spanSync` callbacks not indented, breaking visual block structure
 - Location: `src/services/scheduler.ts:58-67`, `71-78`, `89-117`, `122-129`, `135-141`
 - Category: Tech-debt
@@ -478,6 +484,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: The body of each `tracer.spanSync('...', {}, () => { ... })` callback is at the same indent level as the surrounding method body, with a trailing `}); // end tracer.spanSync(...)` comment. This visually flattens the closure scope and trips linters / reviewers.
 - Suggested next step: indent the callback body, or extract the spanned block into a private helper.
+
+> **Acknowledged in v3.0.64 — by design: cosmetic.** The flat `tracer.spanSync(...)` callback indentation is a deliberate, repo-wide style (paired with the `// end tracer.spanSync(...)` markers) to avoid reindenting large method bodies; no behavior or lint failure.
 
 #### SMTP-020 — `escapeHtml` does not escape apostrophe; safe to use in attribute-free contexts only
 - Location: `src/services/smtp-service.ts:25-31` & `485-494`
@@ -490,6 +498,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **SMTP-DRAFTS-SCHED patterns:** the persistence story across both `SchedulerService` and `ReminderService` is single-process, single-writer JSON-blob-on-mutation — no journaling, no per-record commits, no atomic in-place write for reminders, and pruning is start-up-only for the scheduler. That class of design is fine when mutations are rare, but `processDue` calls `persist()` once per batch (SMTP-004) and the reminder service only writes after mutating in-memory state with no rollback on write failure (SMTP-006). The whole subsystem behaves correctly under happy paths and falls over under partial failure: cross-device tmp dirs (SMTP-005), crashes mid-batch (SMTP-004), or transport drops after a destructive `scanDue` (SMTP-007). Concurrency control is also informal — `processDue` snapshots `due` by reference and lets `cancel()` race against the in-flight `sendEmail` (SMTP-002). Header-injection defenses are comprehensive on the SMTP path but missing in the IMAP draft path for subject/to/cc/bcc (SMTP-012), despite a comment claiming parity. Validation is also asymmetric across tools (SMTP-009, SMTP-013).
 
 ### Transports, OAuth, remote mode
+
+> **Resolved in v3.0.64 — Info triage.** `escapeHtml` now also escapes `'` → `&#39;`, making the helper safe to reuse inside single-quoted attribute contexts.
 
 #### XPORT-002 — Phishable `client_name` in DCR endpoint enables consent-screen spoofing
 - Location: `src/transports/oauth-handlers.ts:192-228, 425-432`
@@ -688,6 +698,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The test suite covers `127.0.0.1` flows only; no test asserts behavior when `host: "0.0.0.0"` and no TLS is configured.
 - Suggested next step: Add a startup-warning assertion paired with the fix in XPORT-015.
 
+> **Acknowledged in v3.0.64 — by design: deferred with XPORT-015.** The non-loopback startup-warning assertion is meant to land paired with the XPORT-015 warning, which is not in this batch's scope.
+
 #### XPORT-020 — `runWithCaller` doesn't include OAuth scope/resource on the caller context
 - Location: `src/transports/http.ts:309-317`
 - Category: Tech-debt
@@ -695,6 +707,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: The caller context carries `clientId`, `clientName`, `ip`, `staticBearer` but drops `rec.scopes` and `rec.resource`. Per-tool gating cannot enforce scope-narrow tokens.
 - Suggested next step: Either remove `SCOPES`/`scope` from the OAuth protocol surface (don't advertise what isn't enforced) or carry the granted scope into the caller context.
+
+> **Acknowledged in v3.0.64 — by design: scopes are advertised, not enforced, intentionally.** The single-tier MCP gate does not narrow on OAuth scope/resource today; carrying them onto the caller context would imply enforcement that does not exist. No regression — the gate already keys on agent grant + preset.
 
 #### XPORT-022 — Naming nits in transport
 - Location: `src/transports/http.ts:88`, `oauth-handlers.ts:99`
@@ -707,6 +721,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **TRANSPORTS-REMOTE patterns:** the transport layer is unusually thoughtful — PKCE shape validation, RFC-correct content-type handling, single-use auth codes, opaque error collapsing on the token endpoint, IP-pinned tokens, grant-revocation propagation through the notifications bus. Where it falls short is consistency of trust model across files. Three different places compute the "real client IP" with three slightly different rules. The DCR endpoint trusts whatever client_name and redirect_uri the network gives it but the consent page surfaces both as if they were vetted. Several "defence in depth" controls the settings UI already does (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, no-store) were never carried over to the transport. And the static-bearer path is treated as a footnote — single shared bucket, no per-IP keying.
 
 ### Permissions, escalation, agent grants
+
+> **Acknowledged in v3.0.64 — by design: readability aliases.** `safeEqual`/`tokenMatches` document intent at the call site; recomputing `clientIp(req)` is cheap and avoids threading state. Cosmetic only.
 
 #### PERM-002 — Escalation approval applies globally, not to the requesting agent
 - Location: `src/settings/server.ts:1319-1329`, `src/permissions/escalation.ts:339-365`
@@ -876,6 +892,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **PERMS-ESCALATION patterns:** the gate/grant subsystem was built two-tier: process-wide preset gate and per-agent grant gate. They don't share a config snapshot, alias map, or canonical-tool-name table, surfacing the same bug class in three places — `bulk_delete`/`bulk_delete_emails` (PERM-003), `move_email`/`move_to_trash` (PERM-004), and future-tool default-allow (PERM-005). All three are "the gate checks tool name but the handler checks behavior." A single canonicalization step before the gate would close all three. The escalation flow elides the identity of the requester (PERM-002, PERM-001). File-based shared state without locks (PERM-006, PERM-012, PERM-014). Per-agent counters tracked in memory but never persisted (PERM-010). Static-bearer/stdio paths treated as implicitly trusted (PERM-008).
 
 ### Tool surface (non-IMAP/non-SMTP)
+
+> **Acknowledged in v3.0.64 — by design: needs a new grant dimension.** Gating `pass_search`/`pass_list` behind a new `passEnabled` `GrantConditions` flag is a schema + grant-engine change, not a trivial Info fix; `pass_*` already requires the Pass integration to be configured and is off by default.
 
 #### TOOL-001 — `search_emails` blindly casts `args.folders` to `string[]` without runtime check
 - Location: `src/tools/reading.ts:535-545`
@@ -1081,6 +1099,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Most other handlers' outputSchemas declare `required`; this one does not. If a refactor drops `imap` or `settingsConfigPath`, the schema validator won't catch it.
 - Suggested next step: Add `required: ["smtp", "imap", "settingsConfigured", "settingsConfigPath"]`.
 
+> **Resolved in v3.0.64 — Info triage.** Added `required: ["smtp","imap","settingsConfigured","settingsConfigPath"]` to the `get_connection_status` outputSchema so a dropped field fails validation.
+
 #### TOOL-019 — `fts_status` outputSchema missing `required: ["available"]`
 - Location: `src/tools/reading.ts:400-409`
 - Category: Tech-debt
@@ -1088,6 +1108,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: `available` is always populated by the handler but the schema does not list it as required.
 - Suggested next step: `required: ["available"]`.
+
+> **Resolved in v3.0.64 — Info triage.** Added `required: ["available"]` to the `fts_status` outputSchema.
 
 #### TOOL-021 — `pass_get` outputSchema's `fields` map doesn't allow undefined
 - Location: `src/tools/pass.ts:73-85`
@@ -1097,6 +1119,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: outputSchema `properties.fields: { type: "object", additionalProperties: { type: "string" } }` but doesn't allow `null`/`undefined`. Clients reading the schema will assume `fields` always-or-never present.
 - Suggested next step: Document the absence semantics in the schema description.
 
+> **Resolved in v3.0.64 — Info triage.** Added a schema description on `pass_get`'s `fields` documenting that it is omitted when the entry has no extra fields, so clients treat it as optional.
+
 #### TOOL-022 — `check_escalation_status` `not_found` branch returns no `isError`
 - Location: `src/tools/escalation.ts:174-179`
 - Category: Tech-debt
@@ -1105,6 +1129,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: When no record exists the handler returns `{ status: "not_found" }` only, without `isError: true`. An agent polling with a stale challenge_id may treat "not_found" as success and keep polling forever.
 - Suggested next step: Either flag `isError: true` for the not_found branch or document explicitly that polling should stop on `status: "not_found"`.
 
+> **Acknowledged in v3.0.64 — by design: not_found is already terminal.** The `check_escalation_status` not_found branch returns a clear `No escalation found with ID '<id>'.` text body and `status: "not_found"`; flagging `isError: true` would mislabel a successful status query as a tool failure. The text content is the documented stop signal.
+
 #### TOOL-023 — `clear_cache` claims to "clear all in-memory caches" but does not invalidate FTS handle
 - Location: `src/tools/system.ts:210-217`
 - Category: Tech-debt
@@ -1112,6 +1138,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Description says "Clear all in-memory caches (email message cache, folder cache, analytics cache)". If "stale data" is the reason a user calls `clear_cache`, leaving FTS untouched means `fts_search` keeps returning stale results.
 - Suggested next step: Add a sentence to the description noting FTS is not rebuilt.
+
+> **Resolved in v3.0.64 — Info triage.** `clear_cache` description now states it does NOT rebuild the on-disk FTS index and points callers to `fts_rebuild`.
 
 #### TOOL-024 — `get_emails_by_label` clamp order differs from `get_emails`
 - Location: `src/tools/reading.ts:657` vs `491`
@@ -1124,6 +1152,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **TOOL-SURFACE patterns:** the tool surface is overall disciplined — runtime type checks are common, destructive-confirm coverage is solid, and the dispatcher's gate chain is well-ordered. The recurring weaknesses cluster around numeric input hygiene (NaN/negative/Infinity slip past `typeof === "number"` checks in `get_contacts`, `get_volume_trends`, `get_logs`, `fts_search`, `alias_list`, `alias_get_activity`), blind casts of `args.folder`/`args.folders`/`args.sentBefore` where neighbouring fields get full validation, and outputSchema laxness (missing `required:`, bare `{ type: "object" }` items, EMAIL_SUMMARY_SCHEMA not reused). The naming split between `emailId` and `email_id` is the most visible UX drift. The `start_bridge` "success-shaped failure" hints that the v3.0.41 anti-pattern lives in non-IMAP corners too.
 
 ### Credentials, crypto, multi-account
+
+> **Resolved in v3.0.64 — Info triage.** `get_emails_by_label` clamp now uses the same `Math.min(Math.max(1, …), 200, …)` argument order as `get_emails`.
 
 #### CRED-001 — `migrateCredentials()` migrates only `password` + `smtpToken`; `passAccessToken` and `simpleloginApiKey` remain plaintext on disk forever
 - Location: `src/config/loader.ts:478-546` and `src/security/keychain.ts:237-279`
@@ -1283,6 +1313,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **CREDS-CRYPTO patterns:** the credential surface has the right shape (keychain > encrypted-file > plaintext, with migration), but the encryption path is window-dressing — `sha256(machine-id || hostname || const-salt || platform)` plus a world-readable machine-id means any local UID recovers the AES key trivially. Secret discipline is uneven across credential types: bridge password and SMTP token are migrated to keychain, but Pass PAT and SimpleLogin API key — the higher-value secrets — sit in `~/.mailpouch.json` as plaintext while `credentialStorage="keychain"` claims otherwise. Defensive checks exist around `MAILPOUCH_CONFIG` but were not propagated to the parallel `_homeFile` env-driven overrides (CRED-002). File-mode hygiene is inconsistent — the logger re-asserts 0600, the Pass audit log and machine-id file do not. There is no file-locking anywhere; correctness depends on the assumption "only one writer at a time", which the settings UI breaks the moment two tabs are open. Finally, fail-closed discipline is missing in the read path: a GCM authentication failure on an encrypted blob silently falls through to any plaintext that happens to coexist, which would mask a real tamper attempt.
 
 ### Validators, injection surfaces
+
+> **Acknowledged in v3.0.64 — by design: documented tradeoff.** `SecureBuffer.toString()`'s GC-string leak is conceded in the class docstring; eliminating it requires pushing Buffer-only through the whole SMTP/IMAP stack (or dropping SecureBuffer entirely), a cross-cutting refactor outside Info-triage scope.
 
 #### VALID-001 — `getEmailById` and callers never validate `folderHint`
 - Location: `src/services/simple-imap-service.ts:827-857`, `src/tools/reading.ts:519-520, 722, 838, 849`, `src/tools/sending.ts:182, 231`
@@ -1495,6 +1527,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **VALIDATORS-INJECTION patterns:** the validator surface is essentially three sibling layers — `helpers.ts` (per-tool gate), tool-handler `optionalX` wrappers (per-call disambiguation), and the IMAP service's private re-validators (last-line). Each layer drifts independently: different character classes, different length caps, different empty-string semantics, and same-named functions (`validateFolderName`) that mean different things. The recurring failure mode is "next caller picks the wrong sibling": v3.0.41's `optionalSourceFolder` fix was exactly this and several more wait in `getEmailById`'s `folderHint`, the `body`/`text`/`bcc` search filters, and the `saveDraft` size-cap asymmetry.
 
 ### Data parsers — FTS, analytics, content-parser, attachments
+
+> **Acknowledged in v3.0.64 — by design: defense-in-depth last line.** The IMAP-private `validateEmailId` is an internal last-line guard reached only after the MCP-layer `requireNumericEmailId` has run; removing it to unify the error shape trades a regression risk for a cosmetic error-code difference on an unreachable path.
 
 #### PARSE-002 — FTS index has no folder-allowlist enforcement; snippets can leak from sensitive folders
 - Location: `src/services/fts-service.ts:138-156`, `src/tools/reading.ts:780-801`
@@ -1851,6 +1885,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `certPlatformHint` is built with sub-expressions through `escHtml`, but is then injected raw at multiple sites. If a future maintainer adds an unescaped insertion to `certPlatformHint`, the chain silently propagates.
 - Suggested next step: Brand "safe HTML" strings via a tagged template or nominal `SafeHtml` type.
 
+> **Acknowledged in v3.0.64 — by design: no SafeHtml type today.** Branding pre-escaped strings via a nominal `SafeHtml` type / tagged template is a speculative abstraction; the current `certPlatformHint` sub-expressions are all built through `escHtml` and injected at vetted sites.
+
 #### UI-018 — Audit-log `audit-event-` CSS class is built from `escHtml(e.event)` instead of an allowlist
 - Location: `src/settings/shell.ts:1932`
 - Category: Tech-debt
@@ -1862,6 +1898,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **UI-NATIVE patterns:** two recurring patterns dominate. First, **escape-helper drift**: the codebase has a canonical 5-replacement `escHtml`, a 4-replacement `escapeHtml` in server.ts (no `'`), and three local 3-replacement `esc` closures in shell.ts (no `>`, no `'`). Each is correct in its current context, but divergence is invisible to readers and one copy-paste away from a real XSS. Second, **process-exit shortcuts ignore lifetime ownership**: `/api/shutdown`, `_onRestartRequested`, and various tray callbacks all reach for `process.exit` without running the cleanup the owning module would run on a `quit` tray click. The settings-server, MCP daemon, and standalone settings entry each own different sub-resources, and the abrupt-exit paths bypass their teardown — explaining both the tray-process leaks and the EADDRINUSE retries on quick restarts.
 
 ### Test quality
+
+> **Resolved in v3.0.64 — Info triage.** The `audit-event-` CSS class is now built from an explicit `{requested,approved,denied,expired}` allowlist (unknown events → `audit-event-other`) instead of `escHtml(e.event)`.
 
 #### TEST-001 — Default fetch mock turns the source-folder UID space into a wildcard
 - Location: `src/services/imap-operations.test.ts:37-50, 435-451`
@@ -2030,6 +2068,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Tests cast the returned token to `{createdAt: number}` and reassign `Date.now() - TTL - 1` to fake expiry. Bypasses encapsulation.
 - Suggested next step: Switch to `vi.useFakeTimers()` + `vi.advanceTimersByTime(TTL + 1)`.
 
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
+
 #### TEST-017 — `grant-store` prune tests backdate via `Date.now() - n*day`
 - Location: `src/agents/grant-store.test.ts:114, 124`
 - Category: Tech-debt
@@ -2037,6 +2077,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Likely
 - Description: Susceptible to wall-clock drift in copy-paste situations.
 - Suggested next step: Use `vi.setSystemTime` and pass explicit "fixed now" anchors.
+
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
 
 #### TEST-018 — `analytics-service.test.ts` uses `toBeDefined` where shape matters
 - Location: `src/services/analytics-service.test.ts:92-95, 155, 423, 741`
@@ -2046,6 +2088,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Accepts any truthy value, including `null` or `0`.
 - Suggested next step: Use `toEqual(expect.objectContaining({...}))` or assert specific types.
 
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
+
 #### TEST-020 — E2E `smoke.e2e` "listTools" only spot-checks 4 names
 - Location: `test/e2e/scenarios/smoke.e2e.test.ts:32-40`
 - Category: Tech-debt
@@ -2053,6 +2097,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: Same anti-pattern as agent-harness discovery test.
 - Suggested next step: Snapshot the tool list and `toMatchSnapshot()`.
+
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
 
 #### TEST-021 — Bulk-action `errors[0]` string-matching assertions are over-loose
 - Location: `src/services/imap-operations.test.ts:481, 515, 530, 596, 617, 632`
@@ -2062,6 +2108,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Multi-error scenarios only assert `errors[0]`, never `errors.length`.
 - Suggested next step: Assert both `errors.length === failed` and each entry's content.
 
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
+
 #### TEST-022 — No test asserts cache-key compound `folder:uid` format outside move/delete
 - Location: `src/services/imap-operations.test.ts:449-450, 566-567`
 - Category: Correctness
@@ -2070,6 +2118,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: If the cache key format ever drifts, the move/delete tests catch it but the flag-update tests rely on the helper's compound-internal logic.
 - Suggested next step: Add a single explicit "cache key format" test that locks the wire format.
 
+> **Resolved in v3.0.63 — test-quality sweep (#174).**
+
 #### TEST-023 — `test/integration.test.ts` is unit tests in disguise
 - Location: `test/integration.test.ts:1-60`
 - Category: Tech-debt
@@ -2077,6 +2127,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Confidence: Confirmed
 - Description: File lives at `test/integration.test.ts`, suggesting cross-module verification. Actual content is pure helpers with no real I/O.
 - Suggested next step: Either grow it into a real integration test or rename/inline.
+
+> **Acknowledged in v3.0.64 — by design: name is harmless.** `test/integration.test.ts` exercises pure helpers; renaming/relocating it is churn with no coverage gain. Real cross-module verification lives in the Greenmail E2E suite under `test/e2e/`.
 
 #### TEST-025 — Harness retry budget is zero, so flakes look like real failures
 - Location: `vitest.config.e2e.ts:18`
@@ -2089,6 +2141,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 **TEST-QUALITY patterns:** the unit suite leans hard on `vi.fn().mockResolvedValue(undefined)` for IMAP verbs, which collapses the per-folder UID space into a single happy path — the 3.0.41 class regression is only caught by the *newer* `sourceFolder` block; the *legacy* paths remain unguarded. There is a recurring "sanitizes X" idiom that asserts `success:true` but never reads back the sanitized output (TEST-003), and a parallel "tool responded" idiom in the agent harness that proves only Bridge is up (TEST-008, TEST-014). Time and TLS state both leak via `process.env` (TEST-004, TEST-010). The most useful next investment is probably a `makeImapClientMock()` helper that models a real per-folder UID table.
 
 ### Build, CI, supply chain
+
+> **Acknowledged in v3.0.64 — by design: retry=0 is intentional.** Keeping `retry: 0` surfaces Greenmail IDLE/EXPUNGE races loudly rather than masking them; known-flaky scenarios are tagged at the test level rather than globally bumping the retry budget.
 
 #### BUILD-001 — `prepare` runs `npm run build` on every consumer install (publish-time-only intent)
 - Location: `package.json:33`
@@ -2208,6 +2262,8 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: The bypass table documents `PRESHIP_SKIP=1` as the canonical emergency bypass. Searching the preship code returns zero matches. Either the bypass lives in the ship skill outside this repo, or the doc is aspirational.
 - Repro hypothesis: `PRESHIP_SKIP=1 npm run preship:fast` runs the full gate regardless of the env var.
 - Suggested next step: Either implement `if (process.env.PRESHIP_SKIP === "1") { console.log("BYPASS"); process.exit(0); }` near `scripts/preship.mjs:23`, or remove that table row from docs.
+
+> **Resolved in v3.0.43 — preship gate hotfix (#130).**
 
 #### BUILD-015 — Pre-push hook (`preship:fast`) skips `tarball-smoke` and both E2E suites
 - Location: `package.json:107-109`, `scripts/preship.mjs:45-61`

--- a/docs/audit-2026-05-28.md
+++ b/docs/audit-2026-05-28.md
@@ -290,11 +290,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Connect, disconnect, connect again to a different host. `bridgeVersion` and `insecureTls` retain their old values until the new connect path overwrites them — and the version probe is fire-and-forget, so there is a window where `bridgeVersion` reflects the previous bridge.
 - Suggested next step: Make `private`, expose a getter, reset both at the top of `connect()` and in `disconnect()`.
 
+> **Acknowledged in v3.0.64 — by design: leaky-field hardening is a non-trivial contract change.** Making `bridgeVersion`/`insecureTls` private with getters and resetting them across connect/disconnect is a class-surface refactor with reconnect-path risk; not a trivial Info fix. No security impact today (single-process, single-owner).
+
 **IMAP-CORRECTNESS patterns:** the v3.0.41 fix correctly added the `sourceFolder` + pre-flight `UID FETCH` pattern to the singular and most-bulk mutators, but the rebuild was *not* mechanically uniform: `setFlag` was missed entirely (IMAP-008, IMAP-009), and three of the bulk methods kept a soft `?? 'INBOX'` fallback that recreates the same silent-no-op class the rest of the fix closed (IMAP-003). Defensive `catch {}` blocks are the second pattern — they hide UIDVALIDITY mismatches, connection-reset errors during preflight, draft-folder discovery failures, connection-lost reads, and `disconnect()` errors; each one converts an actionable failure into a misleading success path. The third pattern is wire safety being uneven: SMTP has a thorough `stripHeaderInjection` helper but `options.header` (IMAP-004) is passed through raw; `sanitizeImapStr` is itself heavy-handed enough to be a correctness bug (IMAP-020). The fourth is scale assumptions baked into IMAP command construction (IMAP-002, IMAP-016) and `expandImapSequence` (IMAP-011). Finally, the IDLE client lives in a parallel universe from the main client (IMAP-001, IMAP-005).
 
 ### SMTP / drafts / scheduling / reminders
-
-> **Acknowledged in v3.0.64 — by design: leaky-field hardening is a non-trivial contract change.** Making `bridgeVersion`/`insecureTls` private with getters and resetting them across connect/disconnect is a class-surface refactor with reconnect-path risk; not a trivial Info fix. No security impact today (single-process, single-owner).
 
 #### SMTP-001 — `persist()` race: scheduler write during in-flight `sendMail()` can lose newly-arrived items
 - Location: `src/services/scheduler.ts:170-208`
@@ -495,11 +495,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `escapeHtml` does not escape `'`. Safe in attribute-free contexts (current usage), but a future caller embedding an escaped value inside `'...'` attribute quotes (`<a href='${escapeHtml(x)}'>`) would let apostrophes break out.
 - Suggested next step: also replace `'` with `&#39;` to make the helper safer to reuse.
 
+> **Resolved in v3.0.64 — Info triage.** `escapeHtml` now also escapes `'` → `&#39;`, making the helper safe to reuse inside single-quoted attribute contexts.
+
 **SMTP-DRAFTS-SCHED patterns:** the persistence story across both `SchedulerService` and `ReminderService` is single-process, single-writer JSON-blob-on-mutation — no journaling, no per-record commits, no atomic in-place write for reminders, and pruning is start-up-only for the scheduler. That class of design is fine when mutations are rare, but `processDue` calls `persist()` once per batch (SMTP-004) and the reminder service only writes after mutating in-memory state with no rollback on write failure (SMTP-006). The whole subsystem behaves correctly under happy paths and falls over under partial failure: cross-device tmp dirs (SMTP-005), crashes mid-batch (SMTP-004), or transport drops after a destructive `scanDue` (SMTP-007). Concurrency control is also informal — `processDue` snapshots `due` by reference and lets `cancel()` race against the in-flight `sendEmail` (SMTP-002). Header-injection defenses are comprehensive on the SMTP path but missing in the IMAP draft path for subject/to/cc/bcc (SMTP-012), despite a comment claiming parity. Validation is also asymmetric across tools (SMTP-009, SMTP-013).
 
 ### Transports, OAuth, remote mode
-
-> **Resolved in v3.0.64 — Info triage.** `escapeHtml` now also escapes `'` → `&#39;`, making the helper safe to reuse inside single-quoted attribute contexts.
 
 #### XPORT-002 — Phishable `client_name` in DCR endpoint enables consent-screen spoofing
 - Location: `src/transports/oauth-handlers.ts:192-228, 425-432`
@@ -718,11 +718,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Two `const safeEqual = constantTimeEqual` / `const tokenMatches = constantTimeEqual` aliases serve no purpose and confuse search. `clientIp(req)` is recomputed multiple times.
 - Suggested next step: Drop the aliases, reuse `caller` in `runWithCaller`.
 
+> **Acknowledged in v3.0.64 — by design: readability aliases.** `safeEqual`/`tokenMatches` document intent at the call site; recomputing `clientIp(req)` is cheap and avoids threading state. Cosmetic only.
+
 **TRANSPORTS-REMOTE patterns:** the transport layer is unusually thoughtful — PKCE shape validation, RFC-correct content-type handling, single-use auth codes, opaque error collapsing on the token endpoint, IP-pinned tokens, grant-revocation propagation through the notifications bus. Where it falls short is consistency of trust model across files. Three different places compute the "real client IP" with three slightly different rules. The DCR endpoint trusts whatever client_name and redirect_uri the network gives it but the consent page surfaces both as if they were vetted. Several "defence in depth" controls the settings UI already does (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, no-store) were never carried over to the transport. And the static-bearer path is treated as a footnote — single shared bucket, no per-IP keying.
 
 ### Permissions, escalation, agent grants
-
-> **Acknowledged in v3.0.64 — by design: readability aliases.** `safeEqual`/`tokenMatches` document intent at the call site; recomputing `clientIp(req)` is cheap and avoids threading state. Cosmetic only.
 
 #### PERM-002 — Escalation approval applies globally, not to the requesting agent
 - Location: `src/settings/server.ts:1319-1329`, `src/permissions/escalation.ts:339-365`
@@ -889,11 +889,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Only `pass_get` requires `confirmed:true`. `pass_list`/`pass_search` are read-only by description but expose item names, URLs, and notes (Pass items frequently encode sensitive context in `name` and `note`). A grant scoped to a folder allowlist provides no protection — Pass has no folder concept.
 - Suggested next step: Add a `passEnabled: boolean` to `GrantConditions` and require it for any `pass_*` call.
 
+> **Acknowledged in v3.0.64 — by design: needs a new grant dimension.** Gating `pass_search`/`pass_list` behind a new `passEnabled` `GrantConditions` flag is a schema + grant-engine change, not a trivial Info fix; `pass_*` already requires the Pass integration to be configured and is off by default.
+
 **PERMS-ESCALATION patterns:** the gate/grant subsystem was built two-tier: process-wide preset gate and per-agent grant gate. They don't share a config snapshot, alias map, or canonical-tool-name table, surfacing the same bug class in three places — `bulk_delete`/`bulk_delete_emails` (PERM-003), `move_email`/`move_to_trash` (PERM-004), and future-tool default-allow (PERM-005). All three are "the gate checks tool name but the handler checks behavior." A single canonicalization step before the gate would close all three. The escalation flow elides the identity of the requester (PERM-002, PERM-001). File-based shared state without locks (PERM-006, PERM-012, PERM-014). Per-agent counters tracked in memory but never persisted (PERM-010). Static-bearer/stdio paths treated as implicitly trusted (PERM-008).
 
 ### Tool surface (non-IMAP/non-SMTP)
-
-> **Acknowledged in v3.0.64 — by design: needs a new grant dimension.** Gating `pass_search`/`pass_list` behind a new `passEnabled` `GrantConditions` flag is a schema + grant-engine change, not a trivial Info fix; `pass_*` already requires the Pass integration to be configured and is off by default.
 
 #### TOOL-001 — `search_emails` blindly casts `args.folders` to `string[]` without runtime check
 - Location: `src/tools/reading.ts:535-545`
@@ -1149,11 +1149,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `get_emails` uses `Math.min(Math.max(1, val), 200, ...)`. `get_emails_by_label` uses `Math.min(Math.max(val, 1), 200, ...)` — argument order divergence.
 - Suggested next step: Mirror the `get_emails` form.
 
+> **Resolved in v3.0.64 — Info triage.** `get_emails_by_label` clamp now uses the same `Math.min(Math.max(1, …), 200, …)` argument order as `get_emails`.
+
 **TOOL-SURFACE patterns:** the tool surface is overall disciplined — runtime type checks are common, destructive-confirm coverage is solid, and the dispatcher's gate chain is well-ordered. The recurring weaknesses cluster around numeric input hygiene (NaN/negative/Infinity slip past `typeof === "number"` checks in `get_contacts`, `get_volume_trends`, `get_logs`, `fts_search`, `alias_list`, `alias_get_activity`), blind casts of `args.folder`/`args.folders`/`args.sentBefore` where neighbouring fields get full validation, and outputSchema laxness (missing `required:`, bare `{ type: "object" }` items, EMAIL_SUMMARY_SCHEMA not reused). The naming split between `emailId` and `email_id` is the most visible UX drift. The `start_bridge` "success-shaped failure" hints that the v3.0.41 anti-pattern lives in non-IMAP corners too.
 
 ### Credentials, crypto, multi-account
-
-> **Resolved in v3.0.64 — Info triage.** `get_emails_by_label` clamp now uses the same `Math.min(Math.max(1, …), 200, …)` argument order as `get_emails`.
 
 #### CRED-001 — `migrateCredentials()` migrates only `password` + `smtpToken`; `passAccessToken` and `simpleloginApiKey` remain plaintext on disk forever
 - Location: `src/config/loader.ts:478-546` and `src/security/keychain.ts:237-279`
@@ -1310,11 +1310,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Repro hypothesis: Heap-snapshot after `applyKeychainCredentials` — multiple copies of the same secret live in `(string)` constants.
 - Suggested next step: Either embrace strings throughout (and drop SecureBuffer), or push Buffer-only through the whole SMTP/IMAP stack so `wipe` actually means wipe.
 
+> **Acknowledged in v3.0.64 — by design: documented tradeoff.** `SecureBuffer.toString()`'s GC-string leak is conceded in the class docstring; eliminating it requires pushing Buffer-only through the whole SMTP/IMAP stack (or dropping SecureBuffer entirely), a cross-cutting refactor outside Info-triage scope.
+
 **CREDS-CRYPTO patterns:** the credential surface has the right shape (keychain > encrypted-file > plaintext, with migration), but the encryption path is window-dressing — `sha256(machine-id || hostname || const-salt || platform)` plus a world-readable machine-id means any local UID recovers the AES key trivially. Secret discipline is uneven across credential types: bridge password and SMTP token are migrated to keychain, but Pass PAT and SimpleLogin API key — the higher-value secrets — sit in `~/.mailpouch.json` as plaintext while `credentialStorage="keychain"` claims otherwise. Defensive checks exist around `MAILPOUCH_CONFIG` but were not propagated to the parallel `_homeFile` env-driven overrides (CRED-002). File-mode hygiene is inconsistent — the logger re-asserts 0600, the Pass audit log and machine-id file do not. There is no file-locking anywhere; correctness depends on the assumption "only one writer at a time", which the settings UI breaks the moment two tabs are open. Finally, fail-closed discipline is missing in the read path: a GCM authentication failure on an encrypted blob silently falls through to any plaintext that happens to coexist, which would mask a real tamper attempt.
 
 ### Validators, injection surfaces
-
-> **Acknowledged in v3.0.64 — by design: documented tradeoff.** `SecureBuffer.toString()`'s GC-string leak is conceded in the class docstring; eliminating it requires pushing Buffer-only through the whole SMTP/IMAP stack (or dropping SecureBuffer entirely), a cross-cutting refactor outside Info-triage scope.
 
 #### VALID-001 — `getEmailById` and callers never validate `folderHint`
 - Location: `src/services/simple-imap-service.ts:827-857`, `src/tools/reading.ts:519-520, 722, 838, 849`, `src/tools/sending.ts:182, 231`
@@ -1524,11 +1524,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: Two validators with the same intent — one throws `McpError(InvalidParams, ...)`, the other throws plain `Error`. The MCP layer turns the second into a 500-ish internal error rather than an actionable client error.
 - Suggested next step: Drop `simple-imap-service.validateEmailId` and require all entrypoints to pre-validate.
 
+> **Acknowledged in v3.0.64 — by design: defense-in-depth last line.** The IMAP-private `validateEmailId` is an internal last-line guard reached only after the MCP-layer `requireNumericEmailId` has run; removing it to unify the error shape trades a regression risk for a cosmetic error-code difference on an unreachable path.
+
 **VALIDATORS-INJECTION patterns:** the validator surface is essentially three sibling layers — `helpers.ts` (per-tool gate), tool-handler `optionalX` wrappers (per-call disambiguation), and the IMAP service's private re-validators (last-line). Each layer drifts independently: different character classes, different length caps, different empty-string semantics, and same-named functions (`validateFolderName`) that mean different things. The recurring failure mode is "next caller picks the wrong sibling": v3.0.41's `optionalSourceFolder` fix was exactly this and several more wait in `getEmailById`'s `folderHint`, the `body`/`text`/`bcc` search filters, and the `saveDraft` size-cap asymmetry.
 
 ### Data parsers — FTS, analytics, content-parser, attachments
-
-> **Acknowledged in v3.0.64 — by design: defense-in-depth last line.** The IMAP-private `validateEmailId` is an internal last-line guard reached only after the MCP-layer `requireNumericEmailId` has run; removing it to unify the error shape trades a regression risk for a cosmetic error-code difference on an unreachable path.
 
 #### PARSE-002 — FTS index has no folder-allowlist enforcement; snippets can leak from sensitive folders
 - Location: `src/services/fts-service.ts:138-156`, `src/tools/reading.ts:780-801`
@@ -1895,11 +1895,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `const cls = 'audit-event-' + escHtml(e.event);`. `escHtml` is XSS-safe but produces a CSS class name from arbitrary server data. The allowed set is small (requested/approved/denied/expired); should be an explicit switch.
 - Suggested next step: Replace with an allowlist switch.
 
+> **Resolved in v3.0.64 — Info triage.** The `audit-event-` CSS class is now built from an explicit `{requested,approved,denied,expired}` allowlist (unknown events → `audit-event-other`) instead of `escHtml(e.event)`.
+
 **UI-NATIVE patterns:** two recurring patterns dominate. First, **escape-helper drift**: the codebase has a canonical 5-replacement `escHtml`, a 4-replacement `escapeHtml` in server.ts (no `'`), and three local 3-replacement `esc` closures in shell.ts (no `>`, no `'`). Each is correct in its current context, but divergence is invisible to readers and one copy-paste away from a real XSS. Second, **process-exit shortcuts ignore lifetime ownership**: `/api/shutdown`, `_onRestartRequested`, and various tray callbacks all reach for `process.exit` without running the cleanup the owning module would run on a `quit` tray click. The settings-server, MCP daemon, and standalone settings entry each own different sub-resources, and the abrupt-exit paths bypass their teardown — explaining both the tray-process leaks and the EADDRINUSE retries on quick restarts.
 
 ### Test quality
-
-> **Resolved in v3.0.64 — Info triage.** The `audit-event-` CSS class is now built from an explicit `{requested,approved,denied,expired}` allowlist (unknown events → `audit-event-other`) instead of `escHtml(e.event)`.
 
 #### TEST-001 — Default fetch mock turns the source-folder UID space into a wildcard
 - Location: `src/services/imap-operations.test.ts:37-50, 435-451`
@@ -2138,11 +2138,11 @@ The audit is organized **by area** (one section per detective beat) below. Withi
 - Description: `retry: 0` is intentional but combined with Greenmail's documented IDLE/EXPUNGE races, every transient race burns a CI run.
 - Suggested next step: Either keep retry=0 and tag known-flaky with `it.skipIf(process.env.CI)`, or set `retry: 1` for e2e only.
 
+> **Acknowledged in v3.0.64 — by design: retry=0 is intentional.** Keeping `retry: 0` surfaces Greenmail IDLE/EXPUNGE races loudly rather than masking them; known-flaky scenarios are tagged at the test level rather than globally bumping the retry budget.
+
 **TEST-QUALITY patterns:** the unit suite leans hard on `vi.fn().mockResolvedValue(undefined)` for IMAP verbs, which collapses the per-folder UID space into a single happy path — the 3.0.41 class regression is only caught by the *newer* `sourceFolder` block; the *legacy* paths remain unguarded. There is a recurring "sanitizes X" idiom that asserts `success:true` but never reads back the sanitized output (TEST-003), and a parallel "tool responded" idiom in the agent harness that proves only Bridge is up (TEST-008, TEST-014). Time and TLS state both leak via `process.env` (TEST-004, TEST-010). The most useful next investment is probably a `makeImapClientMock()` helper that models a real per-folder UID table.
 
 ### Build, CI, supply chain
-
-> **Acknowledged in v3.0.64 — by design: retry=0 is intentional.** Keeping `retry: 0` surfaces Greenmail IDLE/EXPUNGE races loudly rather than masking them; known-flaky scenarios are tagged at the test level rather than globally bumping the retry budget.
 
 #### BUILD-001 — `prepare` runs `npm run build` on every consumer install (publish-time-only intent)
 - Location: `package.json:33`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.63",
+  "version": "3.0.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.63",
+      "version": "3.0.64",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.63",
+  "version": "3.0.64",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -27,7 +27,8 @@ export function escapeHtml(str: string): string {
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /** Header keys that must never be overridden via caller-supplied headers */

--- a/src/settings/shell.ts
+++ b/src/settings/shell.ts
@@ -1934,7 +1934,7 @@ ${buildStyles(cspNonce)}
       return;
     }
     tbody.innerHTML = entries.map(e => {
-      const cls = 'audit-event-' + escHtml(e.event);
+      const cls = ['requested','approved','denied','expired'].includes(e.event) ? 'audit-event-' + e.event : 'audit-event-other';
       return '<tr>' +
         '<td>' + new Date(e.time).toLocaleString() + '</td>' +
         '<td class="' + cls + '">' + escHtml(e.event) + '</td>' +

--- a/src/tools/pass.ts
+++ b/src/tools/pass.ts
@@ -77,7 +77,7 @@ export const defs: ToolDef[] = [
         name: { type: "string" },
         type: { type: "string" },
         username: { type: "string" },
-        fields: { type: "object", additionalProperties: { type: "string" } },
+        fields: { type: "object", additionalProperties: { type: "string" }, description: "Extra string fields parsed from the Pass entry body. Omitted entirely when the entry has none — clients must treat `fields` as optional, not always-present." },
         note: { type: "string" },
         url: { type: "string" },
       },

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -417,6 +417,7 @@ export const defsLate: ToolDef[] = [
         databaseBytes: { type: "number" },
         reason: { type: "string" },
       },
+      required: ["available"],
     },
   },
   {
@@ -710,7 +711,7 @@ export const handlers: Record<string, ToolHandler> = {
     if (args.limit !== undefined && typeof args.limit !== "number") {
       throw new McpError(ErrorCode.InvalidParams, "'limit' must be a number.");
     }
-    const lblLimit = Math.min(Math.max((args.limit as number) || 50, 1), 200, limits.maxEmailListResults);
+    const lblLimit = Math.min(Math.max(1, (args.limit as number) || 50), 200, limits.maxEmailListResults);
 
     if (args.cursor !== undefined && typeof args.cursor !== "string") {
       throw new McpError(ErrorCode.InvalidParams, "'cursor' must be a string.");

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -65,6 +65,7 @@ export const defs: ToolDef[] = [
         settingsConfigured: { type: "boolean", description: "Whether a settings config file exists on disk" },
         settingsConfigPath: { type: "string", description: "Absolute path to the settings config file" },
       },
+      required: ["smtp", "imap", "settingsConfigured", "settingsConfigPath"],
     },
   },
   {
@@ -92,7 +93,7 @@ export const defs: ToolDef[] = [
   {
     name: "clear_cache",
     title: "Clear Cache",
-    description: "Clear all in-memory caches (email message cache, folder cache, analytics cache). Forces fresh IMAP fetches on next access. Use if you suspect stale data.",
+    description: "Clear all in-memory caches (email message cache, folder cache, analytics cache). Forces fresh IMAP fetches on next access. Use if you suspect stale data. Does NOT rebuild the on-disk FTS index — run fts_rebuild to refresh fts_search results.",
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
     inputSchema: { type: "object", properties: {} },
     outputSchema: ACTION_RESULT_SCHEMA,


### PR DESCRIPTION
Phase 3 closeout of the 2026-05-28 audit. Triages the 21 remaining **Info** findings (fix-or-acknowledge) and reconciles seven previously-shipped findings whose audit-doc blocks were never annotated. **DO NOT MERGE yet** — opening for review.

After this batch, every `#### <ID>` block in `docs/audit-2026-05-28.md` carries a `Resolved`/`Acknowledged` annotation: **241/241, 0 unresolved.**

## Info — fixed (7)
| ID | Fix |
|----|-----|
| TOOL-018 | `get_connection_status` outputSchema gains `required: ["smtp","imap","settingsConfigured","settingsConfigPath"]` |
| TOOL-019 | `fts_status` outputSchema gains `required: ["available"]` |
| TOOL-021 | `pass_get` `fields` schema documents optional/omitted-when-empty semantics |
| TOOL-023 | `clear_cache` description states it does NOT rebuild the FTS index (use `fts_rebuild`) |
| TOOL-024 | `get_emails_by_label` clamp mirrors `get_emails` `Math.min(Math.max(1, …), …)` order |
| SMTP-020 | `escapeHtml` also escapes `'` → `&#39;` for safe single-quoted-attribute reuse |
| UI-018 | audit-log CSS class built from a `{requested,approved,denied,expired}` allowlist instead of `escHtml(e.event)` |

## Info — acknowledged by-design (14)
| ID | Reason |
|----|--------|
| IMAP-017 | Already addressed by the IMAP-005 rename; the misleading `id` binding no longer exists |
| IMAP-021 | Private/readonly + connect/disconnect reset is a class-surface refactor with reconnect risk; no security impact today |
| SMTP-017 | Underscore-flagged test seam; gating it touches the TLS-pinning surface |
| SMTP-019 | Cosmetic flat-indentation style, repo-wide, paired with `// end tracer.spanSync` markers |
| XPORT-019 | Non-loopback warning test is meant to land paired with XPORT-015 (out of scope) |
| XPORT-020 | Scopes are advertised but not enforced by the single-tier gate; carrying them would imply enforcement that doesn't exist |
| XPORT-022 | Readability aliases; `clientIp(req)` recompute is cheap |
| PERM-016 | Needs a new `passEnabled` `GrantConditions` dimension — not trivial; `pass_*` is off by default |
| TOOL-022 | `not_found` already returns a clear terminal text body; `isError:true` would mislabel a successful status query |
| CRED-014 | Documented `SecureBuffer.toString()` tradeoff; fix is a cross-cutting Buffer-only refactor |
| VALID-020 | IMAP-private `validateEmailId` is an unreachable last-line guard behind `requireNumericEmailId` |
| UI-016 | Nominal `SafeHtml` type is a speculative abstraction; current sites are vetted |
| TEST-023 | `integration.test.ts` name is harmless; real cross-module checks live in `test/e2e/` |
| TEST-025 | `retry: 0` is intentional to surface Greenmail races loudly |

## Ledger reconciliation (annotate-only, verified in shipped code)
- **TEST-016 / TEST-017 / TEST-018 / TEST-020 / TEST-021 / TEST-022** → `Resolved in v3.0.63 — test-quality sweep (#174).` (verified: fake timers, fixed prune anchors, `objectContaining`, full tool-surface assertion, `errors.length`, `folder:uid` cache-key test).
- **BUILD-014** → `Resolved in v3.0.43 — preship gate hotfix (#130).` (verified: `PRESHIP_SKIP=1` bypass at `scripts/preship.mjs:31`).

## Validation
`npm run typecheck` ✓ · `npm test` ✓ (1917) · `PRESHIP_NO_BRIDGE=1 npm run preship:fast` ✓ (after `npm ci` for license-inv). Ledger script confirms **241/241 annotated, 0 unresolved**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
