### PR TITLE
fix(ci): --ignore-scripts on publish (unblock v3.0.64 release)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,7 +56,15 @@ jobs:
         if npm view "${NAME}@${VERSION}" version --registry https://registry.npmjs.org 2>/dev/null | grep -q "${VERSION}"; then
           echo "Version ${VERSION} already published to npm — skipping"
         else
-          npm publish --provenance --access public
+          # --ignore-scripts: this job already ran typecheck/lint/test/build as
+          # explicit steps, and CI gated the commit (incl. the Greenmail E2E). A
+          # bare `npm publish` would fire the `prepublishOnly` hook
+          # (`preship:release`), whose release tier runs e2e:greenmail (Docker)
+          # and e2e:bridge — neither exists in this job, so it hangs. Skipping
+          # lifecycle scripts here is also consistent with the BUILD-011
+          # supply-chain rationale above (no untrusted script runs with the
+          # publish token in scope). dist/ is already built by the step above.
+          npm publish --provenance --access public --ignore-scripts
         fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -115,7 +123,10 @@ jobs:
             p.publishConfig = { registry: 'https://npm.pkg.github.com', access: 'public' };
             fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
           "
-          npm publish
+          # --ignore-scripts: same rationale as the npm job — build already ran,
+          # and a bare publish would fire prepublishOnly → preship:release (E2E)
+          # which can't run in this job.
+          npm publish --ignore-scripts
           mv /tmp/pkg.bak package.json
         fi
       env:


### PR DESCRIPTION
The publish workflow hangs because `npm publish` (no `--ignore-scripts`) fires `prepublishOnly` → `preship:release`, whose release tier runs the Greenmail + Bridge E2E that can't run in the publish job. v3.0.64 is the first real publish to hit this (prior runs skipped as 'already published').

Adds `--ignore-scripts` to both publish commands. The job already runs typecheck/lint/test/build explicitly and CI gates each commit, so the publish lifecycle gate is redundant; this also aligns with the BUILD-011 `--ignore-scripts` hardening already in this workflow. No version bump (`.github/` isn't in the published tarball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)