### PR TITLE
feat(tray): mirror Enable/Disable Settings UI toggle onto launcher tray (v3.0.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.67] — 2026-05-31
+
+### Added — Enable/Disable Settings UI toggle on the standalone launcher tray
+
+- The standalone `mailpouch-settings` tray now mirrors the MCP server's tray: an **"Enable Settings UI" ↔ "Disable Settings UI"** toggle, with **"Open Settings" shown only when the UI is enabled**. "Disable" stops the HTTP server while keeping the tray and process alive (so the icon stays an always-available control point); "Enable" brings the server back up on the same port. Previously the launcher tray had only Open Settings / Quit, so the only way to stop serving was to quit entirely. Menu construction is the pure, unit-tested `buildLauncherTrayMenu()` (`src/utils/tray-menu.ts`).
+
 ## [3.0.66] — 2026-05-31
 
 ### Changed — tray Settings-UI toggle made testable (no behavior change)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.66-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.67-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.66",
+  "version": "3.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.66",
+      "version": "3.0.67",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.66",
+  "version": "3.0.67",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -37,6 +37,7 @@ import {
 import { startSettingsServer } from "./settings/server.js";
 import { loadConfig } from "./config/loader.js";
 import { createTray, trayPreconditionSkip, inheritDisplayFromParent, type TrayHandle } from "./utils/tray.js";
+import { buildLauncherTrayMenu } from "./utils/tray-menu.js";
 import { makeIconPng, makeTrayIconBytes } from "./utils/icon.js";
 
 const _pkgVersion = (() => {
@@ -152,21 +153,54 @@ function _onShutdownRequested(): void {
 
 // ─── Helper: persistent tray icon ────────────────────────────────────────────
 // When `mailpouch-settings` is the user's always-on background process (their
-// autostart entry), the tray icon is how they get back to the settings UI.
-// The menu is intentionally spartan — this entry point doesn't have agent
-// grants / escalation queue state to surface, unlike the MCP's embedded
-// tray. Just the three things the user actually needs:
+// autostart entry), the tray icon is how they control the settings UI:
 //
 //   mailpouch                — header label (disabled)
-//   Open Settings            — re-opens the browser at the live URL
-//   Quit                     — stops the HTTP server and exits cleanly
+//   Open Settings            — re-opens the browser at the live URL (UI on only)
+//   Enable/Disable Settings UI — toggles the HTTP server WITHOUT killing the
+//                              tray, mirroring the MCP-server tray. "Disable"
+//                              stops serving; "Enable" brings it back up.
+//   Quit                     — stops the server and exits cleanly
 //
-// Backend selection (native tray-icon vs systray2 fallback) lives in
-// utils/tray.ts; we just call createTray() and let it pick. Skips
-// silently on headless/arm64 hosts; the HTTP server still runs so
-// browser access keeps working from a different machine on the LAN.
+// Spartan vs. the MCP tray (no agent/connection state here). Backend selection
+// (native vs systray2 fallback) lives in utils/tray.ts. Skips silently on
+// headless/arm64 hosts.
 let _activeTray: TrayHandle | null = null;
-function _startTrayIcon(url: string): void {
+let _uiStop: (() => Promise<void>) | null = null; // stop fn for the running server
+let _uiEnabled = false;
+let _uiUrl = "";
+
+function _rebuildLauncherTray(): void {
+  if (!_activeTray) return;
+  try {
+    _activeTray.setMenu(buildLauncherTrayMenu({
+      version: _pkgVersion,
+      settingsEnabled: _uiEnabled,
+      settingsUrl: _uiUrl,
+    }));
+  } catch { /* tray backend may not support live updates — non-fatal */ }
+}
+
+/** Bring the HTTP server back up on the original port (tray "Enable"). */
+async function _enableUi(): Promise<void> {
+  if (_uiEnabled) return;
+  const { scheme, stop } = await startSettingsServer(port, lan, false, {
+    onRestartRequested: _onRestartRequested,
+    onShutdownRequested: _onShutdownRequested,
+  });
+  _uiStop = stop;
+  _uiUrl = `${scheme}://localhost:${port}`;
+  _uiEnabled = true;
+}
+
+/** Stop serving but keep the tray + process alive (tray "Disable"). */
+async function _disableUi(): Promise<void> {
+  if (!_uiEnabled) return;
+  try { if (_uiStop) await _uiStop(); }
+  finally { _uiStop = null; _uiUrl = ""; _uiEnabled = false; }
+}
+
+function _startTrayIcon(): void {
   if (noTray) return;
   // GUI MCP clients (Claude Desktop, VS Code) strip DISPLAY from
   // stdio-spawned children; copy it from the parent's environ on Linux
@@ -186,18 +220,19 @@ function _startTrayIcon(url: string): void {
       // scaling. Native backend ignores this.
       iconLegacyOverride: process.platform === "win32" ? makeTrayIconBytes("win32") : undefined,
       tooltip: "mailpouch — Proton Mail via Bridge",
-      items: [
-        { id: "header",   label: "mailpouch", enabled: false },
-        { id: "version",  label: `v${_pkgVersion}`, enabled: false },
-        { id: "sep1",     label: "",          separator: true },
-        { id: "open",     label: "Open Settings" },
-        { id: "sep2",     label: "",          separator: true },
-        { id: "quit",     label: "Quit" },
-      ],
+      items: buildLauncherTrayMenu({ version: _pkgVersion, settingsEnabled: _uiEnabled, settingsUrl: _uiUrl }),
       onClick: (id) => {
         switch (id) {
           case "open":
-            openBrowser(url);
+            if (_uiUrl) openBrowser(_uiUrl);
+            break;
+          case "disable":
+            _disableUi().then(_rebuildLauncherTray).catch((e) =>
+              process.stderr.write(`Disable Settings UI failed: ${e instanceof Error ? e.message : String(e)}\n`));
+            break;
+          case "enable":
+            _enableUi().then(_rebuildLauncherTray).catch((e) =>
+              process.stderr.write(`Enable Settings UI failed: ${e instanceof Error ? e.message : String(e)}\n`));
             break;
           case "quit":
             try { _activeTray?.destroy(); } catch { /* already gone */ }
@@ -222,9 +257,12 @@ switch (mode) {
     // Start server first (async), then open browser once it's listening.
     // startSettingsServer returns the actual scheme (http/https) so we open
     // the correct URL regardless of whether openssl was available.
-    startSettingsServer(port, lan, false, { onRestartRequested: _onRestartRequested, onShutdownRequested: _onShutdownRequested }).then(({ scheme }) => {
+    startSettingsServer(port, lan, false, { onRestartRequested: _onRestartRequested, onShutdownRequested: _onShutdownRequested }).then(({ scheme, stop }) => {
       const url = `${scheme}://localhost:${port}`;
       serverStarted = true;
+      _uiStop = stop;
+      _uiUrl = url;
+      _uiEnabled = true;
 
       if (!noOpen) {
         const opened = openBrowser(url);
@@ -238,8 +276,8 @@ switch (mode) {
       // Fire the tray in the background — user wanted an always-available
       // control point. Start it AFTER openBrowser so the browser opens
       // immediately even if tray init takes a moment. Fire-and-forget; the
-      // HTTP server is the process's anchor either way.
-      void _startTrayIcon(url);
+      // tray stays alive across enable/disable so it's always reachable.
+      void _startTrayIcon();
     }).catch((err: Error) => {
       process.stderr.write(`Settings server error: ${err?.message ?? err}\n`);
       process.exit(1);

--- a/src/utils/tray-menu.test.ts
+++ b/src/utils/tray-menu.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildSettingsTrayMenu, type TrayMenuState } from "./tray-menu.js";
+import { buildSettingsTrayMenu, buildLauncherTrayMenu, type TrayMenuState } from "./tray-menu.js";
 
 const base: TrayMenuState = {
   version: "9.9.9",
@@ -74,5 +74,36 @@ describe("buildSettingsTrayMenu — Settings-UI enable/disable toggle", () => {
     expect(byId(some.items, "pending")?.label).toContain("2 agent(s) pending");
     expect(byId(some.items, "active")?.label).toContain("1 agent(s) active");
     expect(some.tooltip).toContain("2 agent(s) awaiting approval");
+  });
+});
+
+describe("buildLauncherTrayMenu — standalone mailpouch-settings tray (toggle parity)", () => {
+  it("off: 'Enable Settings UI' (id=enable), no 'Open Settings'", () => {
+    const items = buildLauncherTrayMenu({ version: "1.2.3", settingsEnabled: false, settingsUrl: "" });
+    expect(byId(items, "enable")?.label).toBe("Enable Settings UI");
+    expect(byId(items, "disable")).toBeUndefined();
+    expect(byId(items, "open")).toBeUndefined();
+    expect(byId(items, "quit")?.label).toBe("Quit");
+    expect(byId(items, "version")?.label).toBe("v1.2.3");
+  });
+
+  it("on: 'Disable Settings UI' (id=disable) + 'Open Settings'", () => {
+    const items = buildLauncherTrayMenu({ version: "1.2.3", settingsEnabled: true, settingsUrl: "http://localhost:8766" });
+    expect(byId(items, "disable")?.label).toBe("Disable Settings UI");
+    expect(byId(items, "enable")).toBeUndefined();
+    expect(byId(items, "open")?.label).toBe("Open Settings");
+  });
+
+  it("fails safe: enabled-but-urlless never offers 'Open Settings'", () => {
+    const items = buildLauncherTrayMenu({ version: "1.2.3", settingsEnabled: true, settingsUrl: "" });
+    expect(byId(items, "open")).toBeUndefined();
+    expect(byId(items, "disable")?.label).toBe("Disable Settings UI");
+  });
+
+  it("has no MCP-only items (status/account/agent badges)", () => {
+    const items = buildLauncherTrayMenu({ version: "1.2.3", settingsEnabled: true, settingsUrl: "http://x" });
+    expect(byId(items, "status")).toBeUndefined();
+    expect(byId(items, "account")).toBeUndefined();
+    expect(byId(items, "pending")).toBeUndefined();
   });
 });

--- a/src/utils/tray-menu.ts
+++ b/src/utils/tray-menu.ts
@@ -58,3 +58,34 @@ export function buildSettingsTrayMenu(s: TrayMenuState): { items: TrayItem[]; to
   ];
   return { items, tooltip };
 }
+
+export interface LauncherTrayState {
+  version: string;
+  settingsEnabled: boolean;
+  settingsUrl: string;
+}
+
+/**
+ * Menu for the standalone `mailpouch-settings` launcher tray. Spartan vs. the
+ * MCP tray (no agent/connection state to surface), but mirrors the same
+ * enable/disable-Settings-UI toggle and "Open Settings" gating: on the launcher
+ * "disable" stops the HTTP server while keeping the tray alive, and "enable"
+ * brings it back — so the icon stays an always-available control point.
+ */
+export function buildLauncherTrayMenu(s: LauncherTrayState): TrayItem[] {
+  return [
+    { id: "header",  label: "mailpouch", enabled: false },
+    { id: "version", label: `v${s.version}`, enabled: false },
+    { id: "sep1",    label: "", separator: true },
+    ...(s.settingsEnabled && s.settingsUrl
+      ? [{ id: "open", label: "Open Settings" }]
+      : []),
+    { id: "sep2",    label: "", separator: true },
+    {
+      id:    s.settingsEnabled ? "disable" : "enable",
+      label: s.settingsEnabled ? "Disable Settings UI" : "Enable Settings UI",
+    },
+    { id: "sep3",    label: "", separator: true },
+    { id: "quit",    label: "Quit" },
+  ];
+}


### PR DESCRIPTION
Mirrors the MCP server's tray onto the standalone `mailpouch-settings` launcher: an **Enable/Disable Settings UI** toggle (stops the HTTP server while keeping the tray + process alive; re-enables on the same port), with **Open Settings** gated on the UI being up. Previously the launcher tray had only Open Settings / Quit.

Pure menu builder `buildLauncherTrayMenu()` in `tray-menu.ts`, unit-tested (4 new tests; suite 1932 green; preship green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)