### PR TITLE
fix(imap): stop connection leak + IDLE auth-failure backoff (v3.0.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.68] — 2026-05-31
+
+### Fixed — IMAP connection leak / auth-retry storm (consolidated report cluster 2)
+
+- **`connect()` and the IDLE reconnect loop never closed the previous IMAP client before creating a new one**, so every reconnect (or half-open drop) orphaned a socket. Over a long-running process this leaked one Bridge IMAP session per reconnect; once Proton Bridge hit its per-user session cap and began rejecting auth (`454 too many login attempts`), the IDLE loop — retrying at a **flat 30 s with no backoff** — turned a single auth failure into thousands of leaked sockets and failed-auth attempts per day, eventually saturating Bridge. A reporter observed ~44,000 ESTABLISHED sockets across three orphaned instances.
+- **Fix:** `connect()` now reaps any existing client (`logout()`, falling back to `close()`) before assigning a new one. `runIdleLoop()` reaps the failed client on every iteration (so a dropped/failed connection's socket is never orphaned) and applies **exponential backoff** (30 s → cap 5 min), resetting to 30 s only after a clean connect — so a session-capped Bridge is no longer hammered. Regression test asserts a reconnect logs out the stale client before creating the new one.
+- **Note (report cluster 3, folder/label loss):** a read-only audit of every IMAP `STORE`/`COPY`/`MOVE`/`DELETE`/`mailboxDelete` call site found **no path that targets a wildcard, empty, or all-folders UID set** — all mutations are scoped to explicit, validated UIDs (empty sets short-circuit) and `delete_folder` deletes a single gated folder name. mailpouch could not have mass-unlabelled or mass-deleted folders directly; the loss correlates with the cluster-2 connection storm exhausting/corrupting Bridge, which this fix removes the trigger for.
+
 ## [3.0.67] — 2026-05-31
 
 ### Added — Enable/Disable Settings UI toggle on the standalone launcher tray

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.67-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.68-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.67",
+  "version": "3.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.67",
+      "version": "3.0.68",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.67",
+  "version": "3.0.68",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/services/connect-tls.test.ts
+++ b/src/services/connect-tls.test.ts
@@ -62,6 +62,24 @@ describe("SimpleIMAPService.connect() bridgeCertPath handling", () => {
     expect((svc as any).isConnected).toBe(true);
   });
 
+  it("Cluster-2 leak: a reconnect tears down the previous client before creating a new one", async () => {
+    statSync.mockReturnValue({ isDirectory: () => false });
+    readFileSync.mockReturnValue(Buffer.from("CERT_DATA"));
+    const { ImapFlow } = await import("imapflow");
+    const ctor = ImapFlow as unknown as ReturnType<typeof vi.fn>;
+    ctor.mockClear();
+
+    const svc = new SimpleIMAPService();
+    await svc.connect("localhost", 1143, "user", "pass", "/path/to/cert.pem");
+    const first = ctor.mock.results[0].value as { logout: ReturnType<typeof vi.fn> };
+    expect(first.logout).not.toHaveBeenCalled(); // first connect: nothing to reap
+
+    // Reconnecting must logout() the stale client so its socket isn't orphaned.
+    await svc.connect("localhost", 1143, "user", "pass", "/path/to/cert.pem");
+    expect(first.logout).toHaveBeenCalledTimes(1);
+    expect(ctor.mock.results.length).toBe(2); // a fresh client was created after reaping
+  });
+
   it("resolves cert.pem inside a directory when statSync says it is a directory (lines 317-319)", async () => {
     statSync.mockReturnValue({ isDirectory: () => true });
     readFileSync.mockReturnValue(Buffer.from("CERT_DATA"));

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -3283,6 +3283,16 @@ export class SimpleIMAPService {
       catch { try { (stale as unknown as { close?: () => void }).close?.(); } catch { /* already gone */ } }
     };
 
+    // Sleep in short chunks so stopIdle() (which flips idleActive) interrupts the
+    // backoff promptly even at the 5-min cap, and no long pending timer keeps the
+    // Node event loop alive during shutdown.
+    const interruptibleSleep = async (ms: number): Promise<void> => {
+      const STEP = 1000;
+      for (let waited = 0; waited < ms && this.idleActive; waited += STEP) {
+        await new Promise(resolve => setTimeout(resolve, Math.min(STEP, ms - waited)));
+      }
+    };
+
     while (this.idleActive) {
       try {
         await reapIdleClient(); // never leak a prior socket
@@ -3326,7 +3336,7 @@ export class SimpleIMAPService {
       }
 
       if (this.idleActive) {
-        await new Promise(resolve => setTimeout(resolve, backoff));
+        await interruptibleSleep(backoff);
         backoff = Math.min(backoff * 2, MAX_BACKOFF_MS); // escalate while failing
       }
     }

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -745,6 +745,19 @@ export class SimpleIMAPService {
       // localhost (Bridge uses STARTTLS on 1143) and true for non-localhost connections.
       const useSecure = secure !== undefined ? secure : !isLocalhost;
 
+      // Cluster-2 connection leak: tear down any existing client BEFORE we
+      // replace the reference. A reconnect() (or a re-connect after a half-open
+      // drop) used to overwrite `this.client` and orphan the previous socket —
+      // over a long-running process that leaks one FD per reconnect, eventually
+      // exhausting Bridge's per-user IMAP session limit.
+      if (this.client) {
+        const stale = this.client;
+        this.client = null;
+        this.isConnected = false;
+        try { await stale.logout(); }
+        catch { try { (stale as unknown as { close?: () => void }).close?.(); } catch { /* already gone */ } }
+      }
+
       this.client = new ImapFlow({
         host,
         port,
@@ -3252,8 +3265,27 @@ export class SimpleIMAPService {
       tlsOptions = { minVersion: 'TLSv1.2' };
     }
 
+    // Cluster-2 connection leak: a failed connect()/idle() must NOT leave its
+    // socket dangling for the next iteration to overwrite. Always reap the
+    // previous idle client before creating a new one, and back off
+    // exponentially on repeated failures so a session-capped Bridge (which
+    // answers "454 too many login attempts") isn't hammered every 30s — which
+    // previously turned one auth failure into thousands of leaked sockets/day.
+    const BASE_BACKOFF_MS = 30_000;
+    const MAX_BACKOFF_MS = 5 * 60_000;
+    let backoff = BASE_BACKOFF_MS;
+
+    const reapIdleClient = async (): Promise<void> => {
+      if (!this.idleClient) return;
+      const stale = this.idleClient;
+      this.idleClient = null;
+      try { await stale.logout(); }
+      catch { try { (stale as unknown as { close?: () => void }).close?.(); } catch { /* already gone */ } }
+    };
+
     while (this.idleActive) {
       try {
+        await reapIdleClient(); // never leak a prior socket
         this.idleClient = new ImapFlow({
           host: cfg.host,
           port: cfg.port,
@@ -3265,6 +3297,7 @@ export class SimpleIMAPService {
         });
 
         await this.idleClient.connect();
+        backoff = BASE_BACKOFF_MS; // connected cleanly — reset the failure backoff
         const lock = await this.idleClient.getMailboxLock('INBOX');
 
         try {
@@ -3287,17 +3320,18 @@ export class SimpleIMAPService {
           lock.release();
         }
       } catch (err) {
-        logger.debug('IDLE connection dropped, will retry in 30s', 'IMAPService', err);
+        // Close the failed client so its socket is reaped, not orphaned.
+        await reapIdleClient();
+        logger.debug(`IDLE connection dropped, will retry in ${Math.round(backoff / 1000)}s`, 'IMAPService', err);
       }
 
       if (this.idleActive) {
-        // Wait 30s before reconnecting
-        await new Promise(resolve => setTimeout(resolve, 30_000));
+        await new Promise(resolve => setTimeout(resolve, backoff));
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS); // escalate while failing
       }
     }
 
-    try { this.idleClient?.logout().catch(() => {}); } catch {}
-    this.idleClient = null;
+    await reapIdleClient();
   }
 
   /** Stop the background IDLE connection. */


### PR DESCRIPTION
**Consolidated report cluster 2 (critical, data-risk).** `connect()` and the IDLE reconnect loop overwrote `this.client`/`this.idleClient` **without closing the previous one**, orphaning a socket per reconnect. Once Bridge hit its per-user session cap and rejected auth (`454 too many login attempts`), the IDLE loop retried at a **flat 30 s with no backoff** — turning one auth failure into thousands of leaked sockets/day (reporter saw ~44k).

**Fix:** `connect()` reaps any existing client before creating a new one; `runIdleLoop()` reaps the failed client every iteration and backs off exponentially (30 s → 5 min cap, reset on clean connect). Regression test asserts a reconnect logs out the stale client first. Suite 1933 green.

**Cluster 3 (folder/label loss) — audit result:** read-only audit of every IMAP `STORE`/`COPY`/`MOVE`/`DELETE`/`mailboxDelete` call site found **no path targeting a wildcard, empty, or all-folders UID set**; all mutations are UID-scoped with empty sets short-circuited. mailpouch could not have mass-mutated — the loss correlates with the cluster-2 storm exhausting Bridge, which this removes the trigger for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)