### PR TITLE
fix(startup): instance singleton lock + bind settings UI before backend checks (v3.0.69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.69] — 2026-05-31
+
+### Fixed — instance singleton lock (consolidated report cluster 2 follow-up)
+
+- **Multiple `claude --continue` sessions each spawned their own mailpouch MCP**, and each one opened a separate IMAP IDLE/auth loop against the *same* mailbox — a compounded version of the connection leak addressed in 3.0.68. Nothing prevented N concurrent instances from N-multiplying the Bridge session load.
+- **Fix:** on startup, after config load and before any IMAP/SMTP connectivity, each instance acquires a **per-account PID lock** under `$HOME` (`~/.mailpouch-<accounthash>.lock`). If another **live** instance for the same account already holds it (the recorded PID is verified alive), the new instance logs a clear message and **exits 0** instead of starting a second connection. **Stale locks** from crashed/killed processes (dead PID, or garbage contents) are reclaimed automatically, so a legitimate restart after a clean *or* crashed shutdown is never blocked. The lock is released on `gracefulShutdown` (and on the hard-exit path). Always on; set `MAILPOUCH_NO_SINGLETON=1` to allow intentional multi-instance setups. Fail-safe: if the lock mechanism itself errors, the instance logs and continues rather than blocking a legitimate start. New `src/utils/singleton-lock.ts` helper with unit tests (acquire-when-free, live-holder signal, stale/garbage reclaim, ownership-checked release).
+
+### Fixed — settings-UI bind race (consolidated report cluster 4)
+
+- **The settings HTTP server bind was sequenced *after* the IMAP/SMTP connectivity check in `main()`.** When a backend probe/verify hung (observed after ~3-day uptime), the settings server never bound — port stayed unbound, HTTP probes got connection-refused — leaving the UI unreachable *precisely* when the operator needed it to fix the backend misconfiguration.
+- **Fix:** the settings server (and system tray) now **bind before** the Bridge reachability probe and backend connect, so the UI is reachable independent of backend state. Added a **watchdog log line** every 15 s while the bind is still pending, naming what it is waiting on, so a stuck bind is visible in `~/.mailpouch.log`.
+
 ## [3.0.68] — 2026-05-31
 
 ### Fixed — IMAP connection leak / auth-retry storm (consolidated report cluster 2)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.68-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.69-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.68",
+  "version": "3.0.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.68",
+      "version": "3.0.69",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.68",
+  "version": "3.0.69",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import { AccountManager, registerAccountManager } from "./accounts/manager.js";
 import { DesktopNotifier } from "./notifications/desktop.js";
 import { WebhookDispatcher } from "./notifications/webhooks.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
+import { acquireSingletonLock, releaseSingletonLock } from "./utils/singleton-lock.js";
 import { isValidEmail, validateTargetFolder, requireNumericEmailId } from "./utils/helpers.js";
 import { permissions } from "./permissions/manager.js";
 import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain, loadAuxiliaryCredentialsFromKeychain } from "./config/loader.js";
@@ -260,6 +261,8 @@ let bridgeWatchdogTimer: ReturnType<typeof setInterval> | null = null;
 let launchedBridgePid: number | null = null;
 /** Prevents concurrent gracefulShutdown invocations (SIGINT + tray quit race, etc.). */
 let _shutdownInProgress = false;
+/** Path of the per-account singleton lock this process holds (null if none/disabled). */
+let _singletonLockPath: string | null = null;
 
 // ─── Shared mutable state ────────────────────────────────────────────────────
 // Referenced by both the tool handlers (via ToolCallContext.state) and
@@ -2008,6 +2011,37 @@ async function main() {
     logger.warn("No password configured — run 'npm run settings' to set up credentials", "MCPServer");
   }
 
+  // ── Instance singleton guard (Cluster 2, 2026-05-31 report) ───────────────
+  // The MCP is launched per client (Claude Desktop, VS Code, every
+  // `claude --continue` session). Each instance otherwise opens its OWN IMAP
+  // IDLE/auth loop against the same mailbox — a compounded connection leak.
+  // Hold a per-account PID lock; if another LIVE instance already owns it,
+  // exit 0 instead of starting a second connection. Stale locks (dead PID)
+  // are reclaimed so a legitimate restart after a clean OR crashed shutdown is
+  // never blocked. MAILPOUCH_NO_SINGLETON=1 is the escape hatch for power
+  // users running intentional multi-instance setups.
+  if (process.env.MAILPOUCH_NO_SINGLETON !== "1") {
+    try {
+      const outcome = acquireSingletonLock(config.smtp.username);
+      if (outcome.status === "held-by-live-instance") {
+        logger.info(
+          `Another mailpouch instance for this account is already running (pid ${outcome.pid}); ` +
+          `exiting so we don't open a second IMAP connection. ` +
+          `Set MAILPOUCH_NO_SINGLETON=1 to allow multiple instances.`,
+          "MCPServer",
+        );
+        process.exit(0);
+      }
+      _singletonLockPath = outcome.path;
+      if (outcome.reclaimed) {
+        logger.debug("Reclaimed a stale singleton lock from a previous (crashed) instance", "MCPServer");
+      }
+    } catch (e: unknown) {
+      // Fail-safe: a broken lock mechanism must NEVER block a legitimate start.
+      logger.debug("Singleton lock check failed; continuing without it", "MCPServer", e);
+    }
+  }
+
   // Rebuild the SMTP transporter now that credentials and cert path are loaded.
   // SMTPService is constructed at module load time (before config is read), so
   // its initial transporter has an empty password and no Bridge cert.
@@ -2025,6 +2059,37 @@ async function main() {
     logger.warn("Async registry rebuild failed (falling back to sync view)", "MCPServer", e);
   }
   smtpService.reinitialize();
+
+  // ── Settings UI: bind BEFORE any backend connectivity (Cluster 4) ─────────
+  // The bind used to be sequenced after the IMAP/SMTP connect block below.
+  // When a backend probe/verify hung (observed after 3-day uptime), the
+  // settings HTTP server NEVER bound — leaving the UI unreachable precisely
+  // when the operator needed it to fix the misconfiguration. Bind first so the
+  // UI is up whether or not Bridge is reachable. A watchdog logs every 15s
+  // while the bind is still pending, naming what it's waiting on.
+  if (!noSettingsUi) {
+    const bindWatchdog = setInterval(() => {
+      if (!_settingsEnabled) {
+        logger.warn(
+          `Settings UI not yet bound on port ${config.settingsPort ?? 8765} — still waiting on the HTTP server bind. ` +
+          `The UI should be reachable independent of Bridge connectivity; if this repeats, the port may be occupied.`,
+          "MCPServer",
+        );
+      }
+    }, 15_000);
+    bindWatchdog.unref();
+    try {
+      await _startSettingsServerDaemon();
+    } finally {
+      clearInterval(bindWatchdog);
+    }
+  }
+  // Only the process that owns the settings server gets a tray. If another MCP
+  // already holds the port, _settingsExternal is true and that process already
+  // has the tray — skip to avoid duplicates.
+  if (!noTray && !_settingsExternal) {
+    _initTray().catch((err: unknown) => logger.warn("Tray init error", "MCPServer", err));
+  }
 
   // ── Bridge reachability probe + optional auto-start ───────────────────────
   let [smtpReachable, imapReachable] = await Promise.all([
@@ -2195,19 +2260,9 @@ async function main() {
       });
     }
 
-    // ── Daemon: start settings HTTP server + system tray ───────────────────
-    // Both run alongside the MCP transport. stdout is now owned by the
-    // MCP protocol, so startSettingsServer is called with quiet=true.
-    // Suppressed in headless environments via --no-settings-ui / --no-tray.
-    if (!noSettingsUi) {
-      await _startSettingsServerDaemon();
-    }
-    // Only the process that owns the settings server gets a tray.
-    // If another MCP already holds the port, _settingsExternal is true
-    // and that process already has the tray — skip to avoid duplicates.
-    if (!noTray && !_settingsExternal) {
-      _initTray().catch((err: unknown) => logger.warn("Tray init error", "MCPServer", err));
-    }
+    // NOTE: the settings HTTP server + system tray are now started ABOVE,
+    // before the Bridge reachability probe and backend connect (Cluster 4),
+    // so the UI is reachable even when a backend hangs. Nothing to do here.
   } catch (error) {
     logger.error("Server startup failed", "MCPServer", error);
     process.exit(1);
@@ -2247,6 +2302,13 @@ async function gracefulShutdown(signal: string): Promise<void> {
 
     // 0b. Stop settings server
     await _stopSettingsServerDaemon();
+
+    // 0c. Release the per-account singleton lock so a legitimate restart can
+    // re-acquire it immediately (no stale-lock wait needed on the happy path).
+    if (_singletonLockPath) {
+      try { releaseSingletonLock(_singletonLockPath); } catch { /* best-effort */ }
+      _singletonLockPath = null;
+    }
 
     // 1. Stop bridge watchdog
     if (bridgeWatchdogTimer) { clearInterval(bridgeWatchdogTimer); bridgeWatchdogTimer = null; }
@@ -2307,6 +2369,12 @@ process.on("exit", () => {
     analyticsService.wipeData();
     smtpService.wipeCredentials();
   } catch { /* best-effort */ }
+  // Release the singleton lock even on the hard-exit timeout path, so a stale
+  // lock never outlives the process when gracefulShutdown's body didn't finish.
+  if (_singletonLockPath) {
+    try { releaseSingletonLock(_singletonLockPath); } catch { /* best-effort */ }
+    _singletonLockPath = null;
+  }
 });
 
 process.on("SIGINT", () => gracefulShutdown("SIGINT"));

--- a/src/utils/singleton-lock.test.ts
+++ b/src/utils/singleton-lock.test.ts
@@ -13,24 +13,29 @@ import {
 // HOME instead of the real ~/.mailpouch-*.lock.
 describe("singleton-lock", () => {
   const ENV = "MAILPOUCH_LOCK_PATH";
-  const HOME = "HOME";
+  // os.homedir() (which homeFile uses) reads HOME on POSIX but USERPROFILE on
+  // Windows — override BOTH so the temp dir is "home" on every platform.
+  const HOME_VARS = ["HOME", "USERPROFILE"] as const;
   const origEnv = process.env[ENV];
-  const origHome = process.env[HOME];
+  const origHome: Record<string, string | undefined> = {};
+  for (const v of HOME_VARS) origHome[v] = process.env[v];
   let dir: string;
   let lockFile: string;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "mp-lock-"));
-    // homeFile validates against homedir(); point HOME at our temp dir so the
-    // override is considered "inside HOME".
-    process.env[HOME] = dir;
+    // Point homedir() at our temp dir (HOME on POSIX, USERPROFILE on Windows)
+    // so homeFile considers the MAILPOUCH_LOCK_PATH override "inside HOME".
+    for (const v of HOME_VARS) process.env[v] = dir;
     lockFile = join(dir, "test.lock");
     process.env[ENV] = lockFile;
   });
 
   afterEach(() => {
     if (origEnv === undefined) delete process.env[ENV]; else process.env[ENV] = origEnv;
-    if (origHome === undefined) delete process.env[HOME]; else process.env[HOME] = origHome;
+    for (const v of HOME_VARS) {
+      if (origHome[v] === undefined) delete process.env[v]; else process.env[v] = origHome[v];
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/src/utils/singleton-lock.test.ts
+++ b/src/utils/singleton-lock.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, sep } from "path";
+import {
+  acquireSingletonLock,
+  releaseSingletonLock,
+  lockPathForAccount,
+} from "./singleton-lock.js";
+
+// Drive the lock path through the MAILPOUCH_LOCK_PATH override (homeFile
+// requires it stay within $HOME) so the suite writes into a temp dir under
+// HOME instead of the real ~/.mailpouch-*.lock.
+describe("singleton-lock", () => {
+  const ENV = "MAILPOUCH_LOCK_PATH";
+  const HOME = "HOME";
+  const origEnv = process.env[ENV];
+  const origHome = process.env[HOME];
+  let dir: string;
+  let lockFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mp-lock-"));
+    // homeFile validates against homedir(); point HOME at our temp dir so the
+    // override is considered "inside HOME".
+    process.env[HOME] = dir;
+    lockFile = join(dir, "test.lock");
+    process.env[ENV] = lockFile;
+  });
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env[ENV]; else process.env[ENV] = origEnv;
+    if (origHome === undefined) delete process.env[HOME]; else process.env[HOME] = origHome;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("acquires when the lock is free and records our pid", () => {
+    const r = acquireSingletonLock("user@proton.me", 4321);
+    expect(r.status).toBe("acquired");
+    if (r.status === "acquired") expect(r.reclaimed).toBe(false);
+    expect(readFileSync(lockFile, "utf8")).toBe("4321");
+  });
+
+  it("signals held-by-live-instance when a LIVE pid holds the lock", () => {
+    // process.pid is, by definition, alive.
+    writeFileSync(lockFile, String(process.pid));
+    const r = acquireSingletonLock("user@proton.me", process.pid + 1);
+    expect(r.status).toBe("held-by-live-instance");
+    if (r.status === "held-by-live-instance") expect(r.pid).toBe(process.pid);
+  });
+
+  it("reclaims a stale lock whose recorded pid is dead", () => {
+    // PID 2^31-1 is effectively never a live process.
+    writeFileSync(lockFile, "2147483646");
+    const r = acquireSingletonLock("user@proton.me", 777);
+    expect(r.status).toBe("acquired");
+    if (r.status === "acquired") expect(r.reclaimed).toBe(true);
+    expect(readFileSync(lockFile, "utf8")).toBe("777");
+  });
+
+  it("reclaims a garbage/non-numeric lock file", () => {
+    writeFileSync(lockFile, "not-a-pid");
+    const r = acquireSingletonLock("user@proton.me", 999);
+    expect(r.status).toBe("acquired");
+    expect(readFileSync(lockFile, "utf8")).toBe("999");
+  });
+
+  it("release removes the lock when we still own it", () => {
+    const r = acquireSingletonLock("user@proton.me", 4321);
+    expect(r.status).toBe("acquired");
+    if (r.status !== "acquired") throw new Error("unexpected");
+    releaseSingletonLock(r.path, 4321);
+    expect(existsSync(lockFile)).toBe(false);
+  });
+
+  it("release does NOT remove a lock another pid re-took", () => {
+    const r = acquireSingletonLock("user@proton.me", 4321);
+    if (r.status !== "acquired") throw new Error("unexpected");
+    // Simulate another instance re-acquiring after we were considered stale.
+    writeFileSync(lockFile, "5555");
+    releaseSingletonLock(r.path, 4321);
+    expect(existsSync(lockFile)).toBe(true);
+    expect(readFileSync(lockFile, "utf8")).toBe("5555");
+  });
+
+  it("release is a no-op when the lock is already gone", () => {
+    expect(() => releaseSingletonLock(lockFile, 4321)).not.toThrow();
+  });
+
+  describe("lockPathForAccount", () => {
+    it("derives a stable, hashed, HOME-relative path per identity", () => {
+      delete process.env[ENV]; // exercise the non-override branch
+      const a = lockPathForAccount("user@proton.me");
+      const b = lockPathForAccount("user@proton.me");
+      const c = lockPathForAccount("other@proton.me");
+      expect(a).toBe(b);
+      expect(a).not.toBe(c);
+      expect(a.startsWith(dir + sep)).toBe(true);
+      expect(a).not.toContain("user@proton.me"); // identity is hashed, not leaked
+    });
+
+    it("normalizes case/whitespace and buckets empty identity to default", () => {
+      delete process.env[ENV];
+      expect(lockPathForAccount("  User@Proton.ME ")).toBe(lockPathForAccount("user@proton.me"));
+      expect(lockPathForAccount("")).toBe(lockPathForAccount(null));
+      expect(lockPathForAccount(undefined)).toBe(lockPathForAccount(""));
+    });
+  });
+});

--- a/src/utils/singleton-lock.ts
+++ b/src/utils/singleton-lock.ts
@@ -1,0 +1,127 @@
+/**
+ * Per-account instance singleton guard (Cluster 2, 2026-05-31 report).
+ *
+ * Multiple `claude --continue` sessions each spawn a mailpouch MCP, and each
+ * one runs its own IMAP IDLE/auth loop against the SAME mailbox — a compounded
+ * connection leak. This guard lets the FIRST live instance for an account hold
+ * a PID lock file under $HOME; a later instance that finds a *live* holder
+ * exits cleanly (the caller logs and `process.exit(0)`s) instead of opening a
+ * second IMAP connection.
+ *
+ * Design notes:
+ *  - The lock is a plain file containing the holder's PID (decimal). We write
+ *    it with `wx` (O_EXCL) so creation is atomic — only one process can win.
+ *  - A *stale* lock (holder crashed without releasing) is reclaimed: if the
+ *    recorded PID is not a live process, we delete the file and retry once.
+ *    This is what allows a legitimate restart after a clean OR crashed shutdown
+ *    to proceed — we never block on a dead PID.
+ *  - Fail-safe: any unexpected error in the mechanism itself resolves to
+ *    `acquired` so a broken lock can never block a legitimate start.
+ *
+ * No external dependency and no new runtime deps — `fs` + `process.kill(pid, 0)`
+ * is sufficient for the single-host, cooperating-Node-process case.
+ */
+
+import { writeFileSync, readFileSync, unlinkSync } from "fs";
+import { createHash } from "crypto";
+import { homeFile } from "./home-path.js";
+
+export type LockOutcome =
+  | { status: "acquired"; path: string; reclaimed: boolean }
+  | { status: "held-by-live-instance"; path: string; pid: number };
+
+/**
+ * Derive the per-account lock file path. The account identity (typically the
+ * username/email) is hashed so the filename never leaks the address and stays
+ * filesystem-safe. Empty/undefined identity collapses to a stable "default"
+ * bucket so a not-yet-configured install still gets a singleton guard.
+ */
+export function lockPathForAccount(accountIdentity: string | undefined | null): string {
+  const id = (accountIdentity ?? "").trim().toLowerCase() || "default";
+  const hash = createHash("sha256").update(id).digest("hex").slice(0, 16);
+  // Env override resolved + $HOME-contained by homeFile (CRED-002).
+  return homeFile("MAILPOUCH_LOCK_PATH", `.mailpouch-${hash}.lock`);
+}
+
+/** True if `pid` is a live process this user can signal. */
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs error checking without sending a signal.
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    // EPERM means the process exists but is owned by another user — still alive.
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Attempt to acquire the singleton lock for `accountIdentity`.
+ *
+ * Returns `held-by-live-instance` when another live mailpouch already owns it
+ * (caller should log + exit 0). Returns `acquired` when we now own the lock —
+ * `reclaimed` is true if we broke a stale (dead-PID) lock to do so.
+ *
+ * Fail-safe: on any unexpected error, resolves to `acquired` so the start is
+ * never blocked by a malfunctioning lock.
+ *
+ * @param pid the PID to record as the holder (defaults to this process).
+ */
+export function acquireSingletonLock(
+  accountIdentity: string | undefined | null,
+  pid: number = process.pid,
+): LockOutcome {
+  const path = lockPathForAccount(accountIdentity);
+  // Two passes at most: first attempt, then one retry after reclaiming a stale
+  // lock. A second EEXIST after reclaim means another process won the race —
+  // treat it as a live holder rather than spinning.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      writeFileSync(path, String(pid), { flag: "wx", mode: 0o600 });
+      return { status: "acquired", path, reclaimed: attempt > 0 };
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        // Unexpected FS error — fail safe: let the instance start.
+        return { status: "acquired", path, reclaimed: false };
+      }
+    }
+
+    // The lock exists. Read the holder PID and decide live vs stale.
+    let holderPid = NaN;
+    try {
+      holderPid = parseInt(readFileSync(path, "utf8").trim(), 10);
+    } catch {
+      // Vanished between EEXIST and read — retry the create.
+      continue;
+    }
+
+    if (isPidAlive(holderPid) && holderPid !== pid) {
+      return { status: "held-by-live-instance", path, pid: holderPid };
+    }
+
+    // Stale (dead PID) or our own PID — reclaim and retry the create once.
+    try { unlinkSync(path); } catch { /* another process won the break — retry */ }
+  }
+
+  // Lost the reclaim race to another starting instance: it now holds the lock.
+  let holderPid = NaN;
+  try { holderPid = parseInt(readFileSync(path, "utf8").trim(), 10); } catch { /* gone */ }
+  if (isPidAlive(holderPid) && holderPid !== pid) {
+    return { status: "held-by-live-instance", path, pid: holderPid };
+  }
+  // Couldn't confirm a live holder — fail safe and start.
+  return { status: "acquired", path, reclaimed: true };
+}
+
+/**
+ * Release a previously-acquired lock. Only removes the file if it still records
+ * OUR pid, so we never delete a lock another instance legitimately re-took
+ * after we (e.g.) were considered stale. Best-effort; never throws.
+ */
+export function releaseSingletonLock(path: string, pid: number = process.pid): void {
+  try {
+    const holderPid = parseInt(readFileSync(path, "utf8").trim(), 10);
+    if (holderPid === pid) unlinkSync(path);
+  } catch { /* already gone or unreadable — nothing to do */ }
+}


### PR DESCRIPTION
Two startup fixes from the 2026-05-31 consolidated report, shipping together as **v3.0.69**.

## Cluster 2 follow-up — instance singleton lock
Multiple `claude --continue` sessions each spawn a mailpouch MCP, each running its own IMAP IDLE/auth loop against the **same** mailbox — a compounded version of the 3.0.68 connection leak.

**What changed:** new `src/utils/singleton-lock.ts` acquires a per-account PID lock under `$HOME` (`~/.mailpouch-<accounthash>.lock`) on startup, after config load and **before** any IMAP/SMTP connectivity. If another **live** instance for the same account holds the lock (the recorded PID is verified alive), the new instance logs a clear message and **exits 0** instead of opening a second connection. Stale locks (dead PID / garbage contents) are reclaimed automatically, so a legitimate restart after a clean **or** crashed shutdown is never blocked. The lock is released on `gracefulShutdown` and on the hard-exit `process.on("exit")` path (ownership-checked, so it never deletes a lock another instance legitimately re-took).

- Always on; escape hatch `MAILPOUCH_NO_SINGLETON=1` for intentional multi-instance setups.
- **Fail-safe:** if the lock mechanism itself errors, the instance logs and **continues** — a broken lock can never block a legitimate start.

## Cluster 4 — settings-UI bind race
The settings HTTP server bind was sequenced **after** the IMAP/SMTP connect block in `main()`. When a backend probe/verify hung (observed after ~3-day uptime), the settings server **never bound** (port stayed unbound, HTTP probe → connection-refused), leaving the UI unreachable precisely when the operator needed it to fix the misconfiguration.

**What changed:** the settings server (and system tray) now **bind before** the Bridge reachability probe and backend connect, so the UI is reachable independent of backend state. Added a **watchdog log line** every 15 s while the bind is still pending, naming what it is waiting on, so a stuck bind is visible in `~/.mailpouch.log`.

## Verification
- `npm run typecheck` — clean
- New `src/utils/singleton-lock.test.ts` — 9 cases (acquire-when-free, live-holder signal, stale/garbage reclaim, ownership-checked release, path derivation)
- Full suite — **1942 passing**
- `PRESHIP_NO_BRIDGE=1 npm run preship:fast` — green (after `npm ci` on fresh worktree); pre-push hook re-ran it green
- CI runs the Greenmail E2E

## Rollback
Both fixes are isolated to startup ordering + a new helper. To roll back, revert this commit (or the merge). The singleton can also be disabled at runtime without a revert via `MAILPOUCH_NO_SINGLETON=1`. No schema/config changes, no new runtime deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)