### PR TITLE
fix(errors): actionable error classification (folder-not-found/auth/conn-lost/timeout) (v3.0.70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.70] — 2026-05-31
+
+### Fixed — actionable error classification (consolidated report cluster 6)
+
+- **Many tools collapsed every failure into the opaque string `"An error occurred"`**, giving users and agents nothing to act on. In particular, `get_emails({ folder: "Labels/X" })`, `get_emails_by_label({ label: "X" })`, and `sync_emails({ folder: "Labels/X" })` against a non-existent folder/label returned the generic message instead of saying what was wrong.
+- Added a focused error-classification helper (`src/utils/error-classify.ts`) that maps a thrown error — including imapflow rejections that expose `responseText` / `responseStatus` / `code` — into stable, actionable categories: **folder/label not found**, **IMAP auth failed**, **IMAP connection lost**, **timeout**, and **internal error**. Internal stack detail is kept out of the user-facing string (still logged by the dispatcher).
+- The three cited read tools now detect a missing-mailbox SELECT rejection (imapflow `NONEXISTENT` / "Mailbox doesn't exist") and return a precise `McpError(InvalidParams)` naming the resource, e.g. `Folder/label 'Labels/X' not found.`, rather than the generic message.
+- The MCP dispatcher's `safeErrorMessage()` now routes previously-opaque IMAP/connection/auth/timeout failures through the classifier for distinguishable, actionable messages.
+
 ## [3.0.69] — 2026-05-31
 
 ### Fixed — instance singleton lock (consolidated report cluster 2 follow-up)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, or a static bearer token if you'd rather. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.69-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.70-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.69",
+  "version": "3.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.69",
+      "version": "3.0.70",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.69",
+  "version": "3.0.70",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ import { WebhookDispatcher } from "./notifications/webhooks.js";
 import { logger, getLogFilePath } from "./utils/logger.js";
 import { acquireSingletonLock, releaseSingletonLock } from "./utils/singleton-lock.js";
 import { isValidEmail, validateTargetFolder, requireNumericEmailId } from "./utils/helpers.js";
+import { classifyError } from "./utils/error-classify.js";
 import { permissions } from "./permissions/manager.js";
 import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain, loadAuxiliaryCredentialsFromKeychain } from "./config/loader.js";
 import type { ToolName } from "./config/schema.js";
@@ -371,13 +372,6 @@ function safeErrorMessage(error: unknown): string {
   if (msg.includes("smtp") || msg.includes("send") || msg.includes("delivery"))
     return "Email delivery failed";
   if (
-    msg.includes("imap") ||
-    msg.includes("connect") ||
-    msg.includes("mailbox") ||
-    msg.includes("login")
-  )
-    return "IMAP operation failed";
-  if (
     msg.includes("protected folder") ||
     msg.includes("already exists") ||
     msg.includes("not empty") ||
@@ -385,7 +379,19 @@ function safeErrorMessage(error: unknown): string {
   )
     return error.message;
   if (msg.includes("at least one recipient") || msg.includes("required")) return error.message;
-  return "An error occurred";
+  // Cluster 6: classify the remaining IMAP/connection/auth/timeout failures into
+  // actionable categories instead of the opaque "IMAP operation failed" /
+  // "An error occurred". The raw error (with stack) is logged by the dispatcher.
+  const classified = classifyError(error);
+  if (classified.category !== "internal") return classified.message;
+  if (
+    msg.includes("imap") ||
+    msg.includes("connect") ||
+    msg.includes("mailbox") ||
+    msg.includes("login")
+  )
+    return "IMAP operation failed";
+  return classified.message;
 }
 
 /**

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -36,6 +36,7 @@ import type { FtsIndexService } from "../services/fts-service.js";
 const _ftsRebuilding = new Set<string>();
 import type { EmailMessage, EmailFolder } from "../types/index.js";
 import { logger } from "../utils/logger.js";
+import { isFolderNotFoundError } from "../utils/error-classify.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const EMAIL_SUMMARY_SCHEMA = {
@@ -514,7 +515,17 @@ export const handlers: Record<string, ToolHandler> = {
       offset = decoded.offset;
     }
 
-    const emails = await imapService.getEmails(folder, limit, offset);
+    let emails;
+    try {
+      emails = await imapService.getEmails(folder, limit, offset);
+    } catch (err) {
+      // Cluster 6: a SELECT of a missing mailbox surfaces as an opaque imapflow
+      // rejection. Convert it to a precise, actionable not-found error.
+      if (isFolderNotFoundError(err)) {
+        throw new McpError(ErrorCode.InvalidParams, `Folder/label '${folder}' not found.`);
+      }
+      throw err;
+    }
 
     let nextCursor: string | undefined;
     if (emails.length === limit) {
@@ -725,7 +736,17 @@ export const handlers: Record<string, ToolHandler> = {
       lblOffset = decoded.offset;
     }
 
-    const lblEmails = await imapService.getEmails(lblFolder, lblLimit, lblOffset);
+    let lblEmails;
+    try {
+      lblEmails = await imapService.getEmails(lblFolder, lblLimit, lblOffset);
+    } catch (err) {
+      // Cluster 6: a missing label folder maps to a precise not-found message
+      // naming the label, rather than the opaque "An error occurred".
+      if (isFolderNotFoundError(err)) {
+        throw new McpError(ErrorCode.InvalidParams, `Folder/label '${lblFolder}' not found.`);
+      }
+      throw err;
+    }
     let lblNextCursor: string | undefined;
     if (lblEmails.length === lblLimit) {
       lblNextCursor = encodeCursor({ folder: lblFolder, offset: lblOffset + lblLimit, limit: lblLimit });

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -9,6 +9,7 @@ import { fileURLToPath as _fileURLToPath } from "url";
 import nodePath from "path";
 import { validateTargetFolder, clampOptionalInt } from "../utils/helpers.js";
 import { logger } from "../utils/logger.js";
+import { isFolderNotFoundError } from "../utils/error-classify.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
 const ACTION_RESULT_SCHEMA = {
@@ -202,7 +203,16 @@ export const handlers: Record<string, ToolHandler> = {
       throw new McpError(ErrorCode.InvalidParams, "'limit' must be a number.");
     }
     const limit = Math.min(Math.max(1, (args.limit as number) || 100), 500);
-    const emails = await imapService.getEmails(folder, limit);
+    let emails;
+    try {
+      emails = await imapService.getEmails(folder, limit);
+    } catch (err) {
+      // Cluster 6: surface a missing folder as a precise not-found error.
+      if (isFolderNotFoundError(err)) {
+        throw new McpError(ErrorCode.InvalidParams, `Folder/label '${folder}' not found.`);
+      }
+      throw err;
+    }
     state.analyticsCache = null;
     state.analyticsCacheInflight = null;
     return ok({ success: true, folder, count: emails.length });

--- a/src/utils/error-classify.test.ts
+++ b/src/utils/error-classify.test.ts
@@ -67,7 +67,7 @@ describe("classifyError", () => {
       err.name = "IMAPNotConnectedError";
       const c = classifyError(err);
       expect(c.category).toBe("connection");
-      expect(c.message).toMatch(/connection to the imap server/i);
+      expect(c.message).toMatch(/connection to the mail server/i);
     });
 
     it("classifies ECONNRESET code", () => {

--- a/src/utils/error-classify.test.ts
+++ b/src/utils/error-classify.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { classifyError, isFolderNotFoundError } from "./error-classify.js";
+
+describe("classifyError", () => {
+  describe("not_found", () => {
+    it("classifies imapflow NONEXISTENT responseText", () => {
+      const err = Object.assign(new Error("Command failed"), {
+        responseText: "NONEXISTENT Mailbox doesn't exist",
+        responseStatus: "NO",
+      });
+      const c = classifyError(err, { folder: "Labels/X" });
+      expect(c.category).toBe("not_found");
+      expect(c.message).toBe("Folder/label 'Labels/X' not found.");
+    });
+
+    it("classifies textual \"Mailbox doesn't exist\"", () => {
+      const c = classifyError(new Error("Mailbox doesn't exist"), { folder: "Foo" });
+      expect(c.category).toBe("not_found");
+      expect(c.message).toBe("Folder/label 'Foo' not found.");
+    });
+
+    it("classifies \"does not exist\" without context to a generic message", () => {
+      const c = classifyError(new Error("Folder 'Bar' does not exist"));
+      expect(c.category).toBe("not_found");
+      expect(c.message).toBe("The requested folder or label was not found.");
+    });
+
+    it("matches a bare \"not found\" message", () => {
+      expect(classifyError(new Error("Resource not found")).category).toBe("not_found");
+    });
+  });
+
+  describe("auth", () => {
+    it("classifies authenticationFailed flag", () => {
+      const err = Object.assign(new Error("login failed"), { authenticationFailed: true });
+      const c = classifyError(err);
+      expect(c.category).toBe("auth");
+      expect(c.message).toMatch(/authentication failed/i);
+    });
+
+    it("classifies AUTHENTICATIONFAILED code", () => {
+      const err = Object.assign(new Error("nope"), { code: "AUTHENTICATIONFAILED" });
+      expect(classifyError(err).category).toBe("auth");
+    });
+
+    it("classifies \"Invalid credentials\" text", () => {
+      expect(classifyError(new Error("Invalid credentials")).category).toBe("auth");
+    });
+  });
+
+  describe("timeout", () => {
+    it("classifies ETIMEDOUT code", () => {
+      const err = Object.assign(new Error("socket hang"), { code: "ETIMEDOUT" });
+      const c = classifyError(err);
+      expect(c.category).toBe("timeout");
+      expect(c.message).toMatch(/timed out/i);
+    });
+
+    it("classifies \"timed out\" message", () => {
+      expect(classifyError(new Error("Operation timed out")).category).toBe("timeout");
+    });
+  });
+
+  describe("connection", () => {
+    it("classifies IMAPNotConnectedError by name", () => {
+      const err = new Error("Cannot fetch: IMAP connection unavailable");
+      err.name = "IMAPNotConnectedError";
+      const c = classifyError(err);
+      expect(c.category).toBe("connection");
+      expect(c.message).toMatch(/connection to the imap server/i);
+    });
+
+    it("classifies ECONNRESET code", () => {
+      const err = Object.assign(new Error("reset"), { code: "ECONNRESET" });
+      expect(classifyError(err).category).toBe("connection");
+    });
+
+    it("classifies \"not connected\" message", () => {
+      expect(classifyError(new Error("IMAP client not connected")).category).toBe("connection");
+    });
+  });
+
+  describe("internal (fallthrough)", () => {
+    it("classifies an unrecognised error as internal", () => {
+      const c = classifyError(new Error("Something weird happened"));
+      expect(c.category).toBe("internal");
+      expect(c.message).toMatch(/internal error/i);
+    });
+
+    it("never leaks the raw message into the internal category", () => {
+      const c = classifyError(new Error("SECRET stack trace line @user@host"));
+      expect(c.message).not.toContain("SECRET");
+    });
+
+    it("handles non-Error thrown values", () => {
+      expect(classifyError("a string").category).toBe("internal");
+      expect(classifyError(undefined).category).toBe("internal");
+      expect(classifyError(null).category).toBe("internal");
+      expect(classifyError(42).category).toBe("internal");
+    });
+  });
+
+  describe("priority ordering", () => {
+    it("prefers not_found over connection when both keywords present", () => {
+      // A NONEXISTENT rejection that also mentions "socket" must still be not_found.
+      const err = Object.assign(new Error("NONEXISTENT (over socket)"), {
+        responseText: "NONEXISTENT",
+      });
+      expect(classifyError(err).category).toBe("not_found");
+    });
+  });
+});
+
+describe("isFolderNotFoundError", () => {
+  it("is true for a NONEXISTENT rejection", () => {
+    const err = Object.assign(new Error("x"), { responseText: "NONEXISTENT" });
+    expect(isFolderNotFoundError(err)).toBe(true);
+  });
+
+  it("is false for an auth failure", () => {
+    const err = Object.assign(new Error("x"), { code: "AUTHENTICATIONFAILED" });
+    expect(isFolderNotFoundError(err)).toBe(false);
+  });
+
+  it("is false for an unrelated internal error", () => {
+    expect(isFolderNotFoundError(new Error("boom"))).toBe(false);
+  });
+});

--- a/src/utils/error-classify.ts
+++ b/src/utils/error-classify.ts
@@ -1,0 +1,159 @@
+/**
+ * Error classification for client-facing tool error messages.
+ *
+ * Cluster 6 (2026-05-31 consolidated report): many tools collapsed every
+ * failure into the opaque string "An error occurred", giving agents/users
+ * nothing actionable. This module maps a thrown error — including the
+ * imapflow-style server rejections that expose `responseText` /
+ * `responseStatus` / `code` — into a small set of stable, distinguishable
+ * categories plus a concise, actionable message.
+ *
+ * Internal stack detail is intentionally NOT included in the returned message;
+ * callers should log the raw error separately (the dispatcher already does).
+ */
+
+/** Stable, machine-stable error categories surfaced to callers. */
+export type ErrorCategory =
+  | "not_found" // a folder/label/mailbox does not exist
+  | "auth" // IMAP/SMTP authentication failed
+  | "connection" // connection lost / unavailable
+  | "timeout" // operation timed out
+  | "internal"; // anything else / unclassified
+
+export interface ClassifiedError {
+  category: ErrorCategory;
+  /** Concise, actionable, safe-to-surface message. No stack/PII. */
+  message: string;
+}
+
+/**
+ * imapflow rejections carry server response metadata on the error object.
+ * None of these are guaranteed present, so every read is defensive.
+ */
+interface ImapErrorShape {
+  responseText?: unknown;
+  responseStatus?: unknown;
+  code?: unknown;
+  authenticationFailed?: unknown;
+}
+
+function readImapShape(error: unknown): ImapErrorShape {
+  if (typeof error !== "object" || error === null) return {};
+  const e = error as Record<string, unknown>;
+  return {
+    responseText: e.responseText,
+    responseStatus: e.responseStatus,
+    code: e.code,
+    authenticationFailed: e.authenticationFailed,
+  };
+}
+
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+/**
+ * Classify an arbitrary thrown value into a category + actionable message.
+ *
+ * @param error The thrown value.
+ * @param context Optional hint about the resource being acted on (e.g. the
+ *   folder or label name) so a not-found message can name it precisely.
+ */
+export function classifyError(
+  error: unknown,
+  context?: { folder?: string },
+): ClassifiedError {
+  const shape = readImapShape(error);
+  const rawMsg = error instanceof Error ? error.message : asString(error);
+  const responseText = asString(shape.responseText);
+  const code = asString(shape.code);
+  // Single lowercase haystack covering message + server response text + code.
+  const hay = `${rawMsg} ${responseText} ${code}`.toLowerCase();
+
+  const folderLabel = context?.folder;
+
+  // ── not found ────────────────────────────────────────────────────────────
+  // imapflow throws on SELECT of a missing mailbox with responseText
+  // "NONEXISTENT" or a textual "Mailbox doesn't exist".
+  if (
+    hay.includes("nonexistent") ||
+    hay.includes("mailbox doesn't exist") ||
+    hay.includes("mailbox does not exist") ||
+    hay.includes("does not exist") ||
+    hay.includes("no such mailbox") ||
+    hay.includes("not found")
+  ) {
+    return {
+      category: "not_found",
+      message: folderLabel
+        ? `Folder/label '${folderLabel}' not found.`
+        : "The requested folder or label was not found.",
+    };
+  }
+
+  // ── auth ─────────────────────────────────────────────────────────────────
+  if (
+    shape.authenticationFailed === true ||
+    code === "AUTHENTICATIONFAILED" ||
+    hay.includes("authenticationfailed") ||
+    hay.includes("authentication failed") ||
+    hay.includes("invalid credentials") ||
+    hay.includes("login failed")
+  ) {
+    return {
+      category: "auth",
+      message:
+        "IMAP authentication failed. Check the mailbox credentials in Settings.",
+    };
+  }
+
+  // ── timeout ──────────────────────────────────────────────────────────────
+  // Checked before connection: a timeout often also reads as a conn issue.
+  if (
+    code === "ETIMEDOUT" ||
+    code === "ESOCKETTIMEDOUT" ||
+    hay.includes("timed out") ||
+    hay.includes("timeout")
+  ) {
+    return {
+      category: "timeout",
+      message: "The IMAP operation timed out. Please retry.",
+    };
+  }
+
+  // ── connection lost / unavailable ─────────────────────────────────────────
+  if (
+    (error instanceof Error && error.name === "IMAPNotConnectedError") ||
+    code === "ECONNRESET" ||
+    code === "ECONNREFUSED" ||
+    code === "EPIPE" ||
+    code === "ENOTFOUND" ||
+    code === "EHOSTUNREACH" ||
+    hay.includes("connection unavailable") ||
+    hay.includes("not connected") ||
+    hay.includes("connection closed") ||
+    hay.includes("connection lost") ||
+    hay.includes("socket")
+  ) {
+    return {
+      category: "connection",
+      message:
+        "Lost connection to the IMAP server. The connection will be retried — please try again.",
+    };
+  }
+
+  // ── fallthrough ────────────────────────────────────────────────────────────
+  return {
+    category: "internal",
+    message: "An internal error occurred. See server logs for details.",
+  };
+}
+
+/**
+ * Returns true when the error looks like a "mailbox/folder does not exist"
+ * rejection from the IMAP server. Used by read tools to convert an opaque
+ * server rejection into a precise, named not-found error up front.
+ */
+export function isFolderNotFoundError(error: unknown): boolean {
+  return classifyError(error).category === "not_found";
+}

--- a/src/utils/error-classify.ts
+++ b/src/utils/error-classify.ts
@@ -103,7 +103,7 @@ export function classifyError(
     return {
       category: "auth",
       message:
-        "IMAP authentication failed. Check the mailbox credentials in Settings.",
+        "Mail server authentication failed. Check the mailbox credentials in Settings.",
     };
   }
 
@@ -117,7 +117,7 @@ export function classifyError(
   ) {
     return {
       category: "timeout",
-      message: "The IMAP operation timed out. Please retry.",
+      message: "The mail server operation timed out. Please retry.",
     };
   }
 
@@ -138,7 +138,7 @@ export function classifyError(
     return {
       category: "connection",
       message:
-        "Lost connection to the IMAP server. The connection will be retried — please try again.",
+        "Lost connection to the mail server. The connection will be retried — please try again.",
     };
   }
 

--- a/test/e2e/scenarios/labels.e2e.test.ts
+++ b/test/e2e/scenarios/labels.e2e.test.ts
@@ -61,5 +61,14 @@ describe("labels.e2e", () => {
       const subjects = result.emails.map((e) => e.subject);
       expect(subjects.length).toBeGreaterThanOrEqual(2);
     });
+
+    it("returns an actionable not-found error for a missing label (Cluster 6)", async () => {
+      const raw = await h.callRaw("get_emails_by_label", { label: "NoSuchLabel", limit: 10 });
+      const text = "message" in raw ? raw.message : raw.content?.[0]?.text ?? "";
+      // Names the resolved Labels/<name> folder; never the opaque generic string.
+      expect(text).toContain("Labels/NoSuchLabel");
+      expect(text.toLowerCase()).toContain("not found");
+      expect(text).not.toBe("An error occurred");
+    });
   });
 });

--- a/test/e2e/scenarios/reading.e2e.test.ts
+++ b/test/e2e/scenarios/reading.e2e.test.ts
@@ -91,6 +91,15 @@ describe("reading.e2e", () => {
       );
       expect(result.emails.length).toBe(0);
     });
+
+    it("returns an actionable not-found error for a missing folder (Cluster 6)", async () => {
+      const raw = await h.callRaw("get_emails", { folder: "Folders/DoesNotExist", limit: 10 });
+      const text = "message" in raw ? raw.message : raw.content?.[0]?.text ?? "";
+      // Must name the folder and not collapse to the opaque generic string.
+      expect(text).toContain("Folders/DoesNotExist");
+      expect(text.toLowerCase()).toContain("not found");
+      expect(text).not.toBe("An error occurred");
+    });
   });
 
   describe("get_thread", () => {
@@ -131,6 +140,14 @@ describe("reading.e2e", () => {
       expect(result.success).toBe(true);
       expect(result.folder).toBe("INBOX");
       expect(result.count).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns an actionable not-found error for a missing folder (Cluster 6)", async () => {
+      const raw = await h.callRaw("sync_emails", { folder: "Folders/Nope", limit: 10 });
+      const text = "message" in raw ? raw.message : raw.content?.[0]?.text ?? "";
+      expect(text).toContain("Folders/Nope");
+      expect(text.toLowerCase()).toContain("not found");
+      expect(text).not.toBe("An error occurred");
     });
   });
 });


### PR DESCRIPTION
## Summary

Cluster 6 from the 2026-05-31 consolidated report: many tools collapsed every failure into the opaque string `"An error occurred"`, giving users/agents nothing actionable. The cited cases — `get_emails({ folder: "Labels/X" })`, `get_emails_by_label({ label: "X" })`, and `sync_emails({ folder: "Labels/X" })` against a non-existent folder/label — now return a precise, actionable message.

## Changes

- **New `src/utils/error-classify.ts`** — maps a thrown error (including imapflow rejections that expose `responseText` / `responseStatus` / `code`) into stable categories: `not_found`, `auth`, `connection`, `timeout`, `internal`. Returns concise, actionable, safe-to-surface messages; internal stack detail stays out of the user-facing string (still logged by the dispatcher).
- **`get_emails` / `get_emails_by_label` / `sync_emails`** — detect a missing-mailbox SELECT rejection (imapflow `NONEXISTENT` / "Mailbox doesn't exist") and throw `McpError(InvalidParams)` naming the resource, e.g. `Folder/label 'Labels/X' not found.`
- **`safeErrorMessage()`** (dispatcher path only) — routes previously-opaque IMAP/auth/connection/timeout failures through the classifier. All pre-existing specific branches are preserved.
- Did not touch `searchEmails` internals (Cluster 7) or `index.ts` startup/`main()`/`_startSettingsServerDaemon` (other batches).

## Tests

- New unit tests for the classifier (each input error shape → expected category/message), including non-Error values and priority ordering.
- E2E assertions added to `reading.e2e` (get_emails, sync_emails) and `labels.e2e` (get_emails_by_label): a missing folder/label yields a message that names the resource and contains "not found", never the generic string.
- Full unit suite: **1952 passed** (was 1917 baseline). `PRESHIP_NO_BRIDGE=1 npm run preship:fast` passes (after `npm ci` to resolve license inventory).

DO NOT MERGE per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)