### PR TITLE
v3.0.73 — field-report fixes (#1-#9) + Bridge semantics docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.73] — 2026-06-03
+
+Field-report fixes from driving the HTTP daemon against a real, All-Mail-heavy account, plus the Proton Bridge semantics research that grounds them (`docs/proton-bridge-imap.md`).
+
+### Fixed
+
+- **`get_email_by_id` reported the real folder, not "All Mail".** The folder scan returned the first UID match, and the All Mail union holds every message, so it masked the true location (breaking move verification). The union (`specialUse \All`) is now scanned **last** — real folders win; All Mail only for genuinely archived mail.
+- **`get_folders` counts no longer go stale after mutations.** The 5-minute folder-count cache was never invalidated on move/copy/delete/flag changes. It now clears on every count-changing op, and `sync_folders` force-refreshes (bypasses the cache).
+- **Name-collision on `create_folder` surfaces the Proton 409** ("a folder or label named X already exists — Proton shares one namespace") instead of an opaque "internal error", via error text **and** an existence check.
+- **`get_connection_status` probes SMTP auth live** (STARTTLS+AUTH, 8s timeout) instead of reporting a startup-only flag — it can no longer claim "connected" while sends fail. (The acute breakage was a stale Bridge password, fixed via keychain sync.)
+- **`move_to_folder` accepts nested folder paths** (`Life/Bills/X`), matching `bulk_move_emails`; it previously rejected the `/` separator.
+- **Cowork "agent approved" notification no longer repeats** — `ensureActiveServiceGrant` re-emitted `grant-approved` on every `client_credentials` re-auth; now only on a real transition.
+
+### Added / Changed
+
+- **File archived (All-Mail-only) mail into folders.** Bridge forbids MOVE out of the All Mail union (it's a union view with no "remove"), so `move_email`/`move_to_folder`/`bulk_move_emails` from an All-Mail source now degrade to a **verified-landing COPY** (the add-label half) — confirmed live (UIDPLUS). Real-folder sources keep MOVE. Same-location (source==target) moves short-circuit as no-ops.
+- **OAuth access tokens survive a daemon restart.** Tokens were in-memory only, so a restart 401'd every live token. They now persist to `~/.mailpouch-oauth-tokens.json` (0600, atomic) — **hashes only**, never the raw bearer, so a leaked file can't be replayed.
+- **`get_emails` adds `messageId`** (stable cross-folder identity; the `id` UID is per-folder) and a **`summaryOnly`** projection to omit body fields for lean listing.
+
 ## [3.0.72] — 2026-05-31
 
 ### Changed — deletion moves to Trash; mail is never permanently deleted (BREAKING)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.72-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.73-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/proton-bridge-imap.md
+++ b/docs/proton-bridge-imap.md
@@ -103,6 +103,35 @@ When an email is moved to Trash, Bridge removes all labels from it (same behavio
 - Moving an email to `Labels/Important` in IMAP applies the "Important" label (additive)
 - Bridge's `LabelConflictManager` handles inconsistencies between the local Gluon SQLite state and the Proton API state
 
+### How IMAP MOVE/COPY map to Proton label actions
+
+Bridge translates IMAP mailbox membership into Proton **label** operations (DeepWiki, *IMAP Service*): `AddMessagesToMailbox` → Proton `LabelMessages`, `RemoveMessagesFromMailbox` → `UnlabelMessages`. So:
+
+- An IMAP **COPY** to a mailbox = *add a label* (for `Folders/<x>`, the exclusive folder label; for `Labels/<x>`, an additive label).
+- An IMAP **MOVE** = *add the target label* **+** *remove the source label*.
+
+### The "All Mail" union — why you cannot MOVE out of it
+
+`All Mail` (`\All`) is **not a real storage location** — it is a *union view* of every message in the account, independent of the folder/label a message actually carries. Every message appears in `All Mail`.
+
+Because union membership is implicit (a message is in All Mail because it *exists*), **there is no "remove from All Mail" operation**. The *remove-from-source* half of a MOVE is therefore meaningless when the source is `All Mail`, and Bridge **accepts the MOVE but performs nothing** (a silent no-op), or rejects a MOVE into a system folder (`"IMAP operation failed"`). This is the field-observed "Bug A": `bulk_move_emails`/`move_email` with `sourceFolder:"All Mail"` returns *"accepted but could not be verified present in the target."*
+
+**COPY still works from All Mail**, because it is only an *add-label* — no removal from the union is attempted. This is also why `bulk_move_to_label` (IMAP COPY to `Labels/<x>`) succeeds from All Mail while MOVE does not. It matches Proton's own guidance: *"copy the message to the folder instead of moving it."*
+
+### Filing an "All-Mail-only" (archived) message into a folder
+
+A message that lives **only** in the `All Mail` union (no Inbox/Sent/custom folder — a true archive) cannot be relocated with MOVE. The working path:
+
+1. **COPY** the message to the destination `Folders/<name>` mailbox. Because Proton folders are *exclusive*, applying the folder label *sets the message's folder* — there is no separate "remove from All Mail" step to perform.
+2. **Verify it landed** (UIDPLUS `COPYUID`, or Message-ID search) — never assume success; a union no-op must be reported as a failure.
+
+This is the same `AddMessagesToMailbox` → `LabelMessages` mechanism as the label-COPY path that is already reliable from All Mail.
+
+> **Verification status (2026-06-03):** the COPY-to-`Folders/` path from All Mail is derived from the documented MOVE/COPY→label mapping and Proton's copy-not-move guidance, **not yet empirically confirmed** against live Bridge. Confirm with a non-destructive live test (scratch folders only) before wiring it into the move tools. Tracked as field finding #3.
+
+### Same-location moves are no-ops
+Moving a message from/to the **identical** mailbox does nothing, and the All Mail union "accepts" such a move silently. The MCP server short-circuits `source == target` as a success no-op rather than issuing the operation (`isSameLocation` in `SimpleIMAPService`).
+
 ## Special Folder Handling for Drafts
 
 Bridge handles draft messages distinctly:
@@ -211,7 +240,7 @@ These are used by `getFolders()` in the MCP server to populate `totalMessages` a
 ## Known Quirks and Issues
 
 ### 1. UID Scope is Per-Mailbox
-IMAP UIDs are unique within a mailbox, not globally. A UID `12345` in INBOX is a different message than UID `12345` in Sent. The MCP server's `getEmailById` searches all folders to find a UID, which is a workaround for this limitation but adds latency.
+IMAP UIDs are unique within a mailbox, not globally. A UID `12345` in INBOX is a different message than UID `12345` in Sent. The MCP server's `getEmailById` searches all folders to find a UID, which is a workaround for this limitation but adds latency. **The `All Mail` union is searched LAST** — because it contains every message, scanning it first would report `folder:"All Mail"` for messages that actually live in a real folder (the union masks the true location). Real folders win; All Mail is reported only for messages that exist nowhere else (true archive).
 
 ### 2. Label Duplication in IMAP
 Emails with labels appear in multiple IMAP folders simultaneously (their primary folder AND all `Labels/x` folders). Clients that count all mailboxes will see duplicates. The MCP server exposes folder listing as-is without deduplication.
@@ -237,6 +266,9 @@ In combined mode, all addresses share one IMAP mailbox. There is no way via stan
 ### 9. Labels Lost on Move to Trash
 When an email is moved to Trash via Bridge/IMAP, all its Proton labels are removed. This is by design (matching Proton web behavior) but may surprise users who move emails to Trash and then restore them — the labels will not be restored.
 
+### 10. Cannot MOVE Out of the "All Mail" Union (COPY Instead)
+`All Mail` (`\All`) is a union view of every message, not a real location, and has no "remove" operation. A MOVE whose source is `All Mail` is accepted but silently does nothing (or errors into a system folder). To file an All-Mail-only (archived) message into a folder, **COPY** it to the `Folders/<name>` mailbox (which applies the exclusive folder label) and verify it landed. See "The 'All Mail' union" section above. Deleting mail is likewise a move-to-Trash, never an EXPUNGE from the union.
+
 ## Sources
 
 - https://proton.me/support/labels-in-bridge
@@ -246,3 +278,5 @@ When an email is moved to Trash via Bridge/IMAP, all its Proton labels are remov
 - https://man.sr.ht/~rjarry/aerc/providers/protonmail.md
 - https://pkg.go.dev/github.com/ProtonMail/proton-bridge@v1.8.12/internal/imap/idle
 - https://github.com/Foundry376/Mailspring/issues/429
+- https://github.com/ProtonMail/gluon — Gluon IMAP server library (MOVE/UIDPLUS support; connector maps IMAP membership ↔ Proton labels)
+- https://proton.me/blog/gluon-imap-library — Gluon snapshot model overview

--- a/docs/proton-bridge-imap.md
+++ b/docs/proton-bridge-imap.md
@@ -122,12 +122,20 @@ Because union membership is implicit (a message is in All Mail because it *exist
 
 A message that lives **only** in the `All Mail` union (no Inbox/Sent/custom folder — a true archive) cannot be relocated with MOVE. The working path:
 
-1. **COPY** the message to the destination `Folders/<name>` mailbox. Because Proton folders are *exclusive*, applying the folder label *sets the message's folder* — there is no separate "remove from All Mail" step to perform.
+1. **COPY** the message (by its All Mail UID) to the destination `Folders/<name>` mailbox. This applies the folder label and files the message into that folder.
 2. **Verify it landed** (UIDPLUS `COPYUID`, or Message-ID search) — never assume success; a union no-op must be reported as a failure.
 
 This is the same `AddMessagesToMailbox` → `LabelMessages` mechanism as the label-COPY path that is already reliable from All Mail.
 
-> **Verification status (2026-06-03):** the COPY-to-`Folders/` path from All Mail is derived from the documented MOVE/COPY→label mapping and Proton's copy-not-move guidance, **not yet empirically confirmed** against live Bridge. Confirm with a non-destructive live test (scratch folders only) before wiring it into the move tools. Tracked as field finding #3.
+> **Verified 2026-06-03 against live Bridge** (non-destructive scratch test, UIDPLUS-confirmed):
+> - `COPY` from `All Mail` → `Folders/<scratch>` **succeeds and the message lands** (server returns a `COPYUID` map).
+> - `MOVE` from `All Mail` → `Folders/<scratch>` is **accepted but lands nothing** (the no-op).
+>
+> **Caveat — COPY adds, it does not atomically replace:** after a COPY-to-folder, the source message was observed *still present in its original folder* (checked +2 s). So COPY applies the target folder label without removing other folder labels at the IMAP layer; Proton's exclusivity is reconciled separately (and lazily). Implications for filing:
+> - **All-Mail-only (archived) message** → COPY-to-folder files it cleanly (there is no other folder to leave behind). This is the #3 path.
+> - **Message already in a real folder** → use a normal `MOVE` with the real `sourceFolder` (which works), *not* COPY-from-All-Mail — otherwise the message may transiently appear in two folders until Proton reconciles.
+>
+> This composes with finding #1: `get_email_by_id` now reports a message's real folder (or `All Mail` if it is archived), so a caller can choose MOVE-from-real-folder vs COPY-from-All-Mail correctly.
 
 ### Same-location moves are no-ops
 Moving a message from/to the **identical** mailbox does nothing, and the All Mail union "accepts" such a move silently. The MCP server short-circuits `source == target` as a success no-op rather than issuing the operation (`isSameLocation` in `SimpleIMAPService`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.72",
+  "version": "3.0.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.72",
+      "version": "3.0.73",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.72",
+  "version": "3.0.73",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agents/grant-store.test.ts
+++ b/src/agents/grant-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { AgentGrantStore } from "./grant-store.js";
+import { notifications } from "./notifications.js";
 import { rmSync, existsSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -18,6 +19,31 @@ describe("AgentGrantStore", () => {
   it("starts empty when no file exists", () => {
     const s = new AgentGrantStore(path);
     expect(s.list()).toEqual([]);
+  });
+
+  it("ensureActiveServiceGrant notifies once on create, NOT on every re-verify (no toast spam)", () => {
+    const s = new AgentGrantStore(path);
+    const kinds: string[] = [];
+    const unsub = notifications.subscribe((ev) => kinds.push(ev.kind));
+    try {
+      const args = { clientId: "pmc_cc", clientName: "cowork", preset: "full" as const };
+      s.ensureActiveServiceGrant(args); // first login → created
+      s.ensureActiveServiceGrant(args); // client_credentials re-auth → no-op, silent
+      s.ensureActiveServiceGrant(args); // again → still silent
+      expect(kinds).toEqual(["grant-created"]);
+      expect(s.get("pmc_cc")?.status).toBe("active");
+    } finally { unsub(); }
+  });
+
+  it("ensureActiveServiceGrant re-activating a non-active grant DOES notify (grant-approved)", () => {
+    const s = new AgentGrantStore(path);
+    s.createPending({ clientId: "pmc_cc2", clientName: "cowork" }); // pending, not active
+    const kinds: string[] = [];
+    const unsub = notifications.subscribe((ev) => kinds.push(ev.kind));
+    try {
+      s.ensureActiveServiceGrant({ clientId: "pmc_cc2", clientName: "cowork", preset: "full" });
+      expect(kinds).toEqual(["grant-approved"]); // real transition pending→active
+    } finally { unsub(); }
   });
 
   it("createPending seeds a pending grant and persists it", () => {

--- a/src/agents/grant-store.ts
+++ b/src/agents/grant-store.ts
@@ -206,9 +206,16 @@ export class AgentGrantStore {
         transport: "http",
         note: "service account (client_credentials)",
       };
+      // No-op re-verify of an already-active service grant: this runs on EVERY
+      // client_credentials login, so re-emitting a "grant-approved" event here
+      // spammed a notification/toast on each re-auth (e.g. cowork reconnecting).
+      // Only notify on a real transition — first creation, or (re)activation of
+      // a grant that wasn't already active.
+      const wasActive = existing?.status === "active";
       this.grants.set(args.clientId, grant);
       this.persist();
-      notifications.emitGrantChanged(existing ? "grant-approved" : "grant-created", grant);
+      if (!existing) notifications.emitGrantChanged("grant-created", grant);
+      else if (!wasActive) notifications.emitGrantChanged("grant-approved", grant);
       return grant;
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,7 @@ function recordFromEmail(m: EmailMessage): FtsRecord {
 const AGENT_GRANTS_PATH = _homeFile("MAILPOUCH_AGENTS", ".mailpouch-agents.json");
 const AGENT_AUDIT_PATH = _homeFile("MAILPOUCH_AGENT_AUDIT", ".mailpouch-agent-audit.jsonl");
 const SERVICE_ACCOUNTS_PATH = _homeFile("MAILPOUCH_SERVICE_ACCOUNTS", ".mailpouch-service-accounts.json");
+const OAUTH_TOKENS_PATH = _homeFile("MAILPOUCH_OAUTH_TOKENS", ".mailpouch-oauth-tokens.json");
 const agentGrants = new AgentGrantStore(AGENT_GRANTS_PATH);
 const grantManager = new GrantManager(agentGrants);
 const agentAudit = new AgentAuditLog({ path: AGENT_AUDIT_PATH });
@@ -2606,6 +2607,7 @@ async function main() {
         rateLimitBurst: remoteCn?.remoteRateLimitBurst ?? undefined,
         agentGrants,
         serviceAccounts,
+        oauthTokensPath: OAUTH_TOKENS_PATH,
       });
       logger.info(`mailpouch started on HTTP transport at ${handle.url}${handle.issuer ? ` (OAuth issuer ${handle.issuer})` : ""}`, "MCPServer");
       (globalThis as unknown as { __mailpouchHttpHandle?: { close(): Promise<void> } }).__mailpouchHttpHandle = handle;

--- a/src/services/folder-management.test.ts
+++ b/src/services/folder-management.test.ts
@@ -41,14 +41,26 @@ describe('Folder Management', () => {
       expect(result).toBe(true);
     });
 
-    it('should throw error if folder already exists', async () => {
+    it('should throw a clear "already exists" error on an IMAP ALREADYEXISTS', async () => {
       const mockClient = (service as any).client;
       mockClient.mailboxCreate.mockRejectedValueOnce({
         responseText: 'ALREADYEXISTS',
       });
 
       await expect(service.createFolder('INBOX')).rejects.toThrow(
-        "Folder 'INBOX' already exists"
+        /already exists/
+      );
+    });
+
+    it('surfaces the Proton 409 (Code=2500) cross-namespace collision as "already exists"', async () => {
+      const mockClient = (service as any).client;
+      // Bridge can return the Proton message without the uppercase IMAP token.
+      mockClient.mailboxCreate.mockRejectedValueOnce({
+        responseText: 'NO Label or folder with this name already exists (Code=2500)',
+      });
+
+      await expect(service.createFolder('Labels/Tech')).rejects.toThrow(
+        /already exists.*Proton shares one namespace/
       );
     });
 

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -2747,3 +2747,35 @@ describe("SimpleIMAPService.searchEmails freshness (cluster 7 / O1, v3.0.71)", (
     expect(results).toHaveLength(0);
   });
 });
+
+// ─── getEmailById folder resolution (#1: All Mail union must not mask the real folder) ───
+describe("SimpleIMAPService.getEmailById — All Mail must not mask the real folder", () => {
+  const folderList = [
+    { path: "All Mail", name: "All Mail", delimiter: "/", flags: new Set(), specialUse: "\\All" },
+    { path: "Folders/Tech", name: "Tech", delimiter: "/", flags: new Set(), specialUse: undefined },
+  ];
+
+  it("returns the real folder (not 'All Mail') when the message exists in both", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc, {
+      list: vi.fn().mockResolvedValue(folderList),
+      status: vi.fn().mockResolvedValue({ messages: 1, unseen: 0 }),
+    });
+    // Same UID present in the union AND the real folder — All Mail scanned last.
+    seedMessage(client, "All Mail", 900, { subject: "filed message" });
+    seedMessage(client, "Folders/Tech", 900, { subject: "filed message" });
+    const email = await svc.getEmailById("900");
+    expect(email?.folder).toBe("Folders/Tech");
+  });
+
+  it("falls back to 'All Mail' for a message that exists ONLY there (true archive)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc, {
+      list: vi.fn().mockResolvedValue(folderList),
+      status: vi.fn().mockResolvedValue({ messages: 1, unseen: 0 }),
+    });
+    seedMessage(client, "All Mail", 901, { subject: "archived message" });
+    const email = await svc.getEmailById("901");
+    expect(email?.folder).toBe("All Mail");
+  });
+});

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -2806,3 +2806,36 @@ describe("SimpleIMAPService.getEmailById — All Mail must not mask the real fol
     expect(email?.folder).toBe("All Mail");
   });
 });
+
+// ─── #2: folder-count cache must invalidate on mutation ───
+describe("SimpleIMAPService folder-count cache invalidation (#2)", () => {
+  function svcWithFolders() {
+    const svc = new SimpleIMAPService();
+    const list = vi.fn().mockResolvedValue([
+      { path: "INBOX", name: "INBOX", delimiter: "/", flags: new Set(), specialUse: undefined },
+    ]);
+    const status = vi.fn().mockResolvedValue({ messages: 5, unseen: 1 });
+    const client = connectSvc(svc, { list, status });
+    return { svc, client, status };
+  }
+
+  it("get_folders caches, but a move invalidates the cache so counts refetch", async () => {
+    const { svc, client, status } = svcWithFolders();
+    await svc.getFolders();
+    const afterFirst = status.mock.calls.length;
+    await svc.getFolders();
+    expect(status.mock.calls.length).toBe(afterFirst); // 2nd call served from cache — no STATUS
+    seedUids(client, "INBOX", [1]);
+    await svc.moveEmail("1", "Folders/X", "INBOX");      // mutation → clearFolderCache()
+    await svc.getFolders();
+    expect(status.mock.calls.length).toBeGreaterThan(afterFirst); // refetched after the move
+  });
+
+  it("syncFolders always bypasses the cache (explicit refresh)", async () => {
+    const { svc, status } = svcWithFolders();
+    await svc.getFolders();
+    const n = status.mock.calls.length;
+    await svc.syncFolders();
+    expect(status.mock.calls.length).toBeGreaterThan(n);
+  });
+});

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -529,6 +529,17 @@ describe("SimpleIMAPService.moveEmail", () => {
     expect(client.messageMove).not.toHaveBeenCalled();
   });
 
+  it("from the All Mail union, files via COPY (MOVE no-ops from the union)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    seedUids(client, "All Mail", [700]);
+    const result = await svc.moveEmail("700", "Folders/Tech", "All Mail");
+    expect(result).toBe(true);
+    // Filed via COPY (add-label) — never MOVE, which no-ops from the union.
+    expect(client.messageCopy).toHaveBeenCalledWith("700", "Folders/Tech", { uid: true });
+    expect(client.messageMove).not.toHaveBeenCalled();
+  });
+
   it("evicts old cache entry on move (UID is not stable across folders)", async () => {
     const svc = new SimpleIMAPService();
     const client = connectSvc(svc);
@@ -812,6 +823,17 @@ describe("SimpleIMAPService.bulkMoveEmails", () => {
     const results = await svc.bulkMoveEmails(["80", "81"], "All Mail", "All Mail");
     expect(results.success).toBe(2);
     expect(results.failed).toBe(0);
+    expect(client.messageMove).not.toHaveBeenCalled();
+  });
+
+  it("from the All Mail union, bulk-files via COPY (MOVE no-ops from the union)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    seedUids(client, "All Mail", [701, 702]);
+    const results = await svc.bulkMoveEmails(["701", "702"], "Folders/Tech", "All Mail");
+    expect(results.success).toBe(2);
+    expect(results.failed).toBe(0);
+    expect(client.messageCopy).toHaveBeenCalled();
     expect(client.messageMove).not.toHaveBeenCalled();
   });
 
@@ -2665,10 +2687,13 @@ describe("SimpleIMAPService move/copy honest verification (Bug A, All Mail sourc
     expect(bad.failed).toBe(2);
   });
 
-  it("bulkMoveEmails reports FAILURE when the move resolves but the message is absent from the target", async () => {
+  it("bulkMoveEmails from All Mail reports FAILURE when the COPY-file resolves but nothing lands", async () => {
     const svc = new SimpleIMAPService();
     const client = connectSvc(svc);
-    clientState(client).silentNoOp.move = true; // Bridge accepts MOVE from All Mail but does nothing
+    // From the All Mail union, bulkMoveEmails files via COPY (MOVE no-ops there).
+    // A copy the union accepts but doesn't perform must be an honest failure,
+    // never a false success.
+    clientState(client).silentNoOp.copy = true;
     seedUids(client, "All Mail", [10, 11, 12]);
 
     const results = await svc.bulkMoveEmails(["10", "11", "12"], "Folders/Work", "All Mail");
@@ -2678,7 +2703,7 @@ describe("SimpleIMAPService move/copy honest verification (Bug A, All Mail sourc
     expect(results.errors.join(" ")).toMatch(/not present|All Mail|union/i);
   });
 
-  it("bulkMoveEmails from a non-INBOX source verifies landing and succeeds (real move)", async () => {
+  it("bulkMoveEmails from All Mail files via COPY and verifies landing (success)", async () => {
     const svc = new SimpleIMAPService();
     const client = connectSvc(svc);
     seedUids(client, "All Mail", [10, 11, 12]);
@@ -2687,6 +2712,8 @@ describe("SimpleIMAPService move/copy honest verification (Bug A, All Mail sourc
 
     expect(results.success).toBe(3);
     expect(results.failed).toBe(0);
+    expect(client.messageCopy).toHaveBeenCalled();
+    expect(client.messageMove).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -521,6 +521,14 @@ describe("SimpleIMAPService.moveEmail", () => {
     expect(client.messageMove).toHaveBeenCalledWith("20", "Trash", { uid: true });
   });
 
+  it("source == target is a no-op (never issues a move; guards the All Mail union)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    const result = await svc.moveEmail("20", "All Mail", "All Mail");
+    expect(result).toBe(true);
+    expect(client.messageMove).not.toHaveBeenCalled();
+  });
+
   it("evicts old cache entry on move (UID is not stable across folders)", async () => {
     const svc = new SimpleIMAPService();
     const client = connectSvc(svc);
@@ -796,6 +804,15 @@ describe("SimpleIMAPService.bulkMoveEmails", () => {
     // Cache entries at the old folder key should be evicted (UID is not stable across folders)
     expect((svc as any).emailCache.has("INBOX:80")).toBe(false);
     expect((svc as any).emailCache.has("INBOX:81")).toBe(false);
+  });
+
+  it("source == target is a no-op per folder (counts success, issues no move; All Mail guard)", async () => {
+    const svc = new SimpleIMAPService();
+    const client = connectSvc(svc);
+    const results = await svc.bulkMoveEmails(["80", "81"], "All Mail", "All Mail");
+    expect(results.success).toBe(2);
+    expect(results.failed).toBe(0);
+    expect(client.messageMove).not.toHaveBeenCalled();
   });
 
   it("falls back to per-email move when batch fails", async () => {

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2055,6 +2055,13 @@ export class SimpleIMAPService {
         folder = email.folder;
       }
 
+      // Source == target → no-op. Moving within the same mailbox does nothing,
+      // and from the All Mail union it "succeeds" silently while moving nothing.
+      if (this.isSameLocation(folder, targetFolder)) {
+        logger.info(`Email ${emailId} is already in ${targetFolder}; move is a no-op (same location)`, 'IMAPService');
+        return true;
+      }
+
       let movedMid: string | undefined;
       const relocated = new Set<string>();
       let uidplus = false;
@@ -2377,6 +2384,12 @@ export class SimpleIMAPService {
     // otherwise count as a false success.
     const verifyJobs: Array<{ folder: string; accepted: string[]; midMap: Map<string, string>; relocated: Set<string>; uidplus: boolean }> = [];
     for (const [folder, ids] of emailsByFolder.entries()) {
+      // Source == target → no-op (incl. the All Mail union, which "accepts" the
+      // move silently while moving nothing). Count as success, don't issue it.
+      if (this.isSameLocation(folder, targetFolder)) {
+        for (let i = 0; i < ids.length; i++) results.success++;
+        continue;
+      }
       const lock = await this.client.getMailboxLock(folder);
       try {
         let existing: Set<string>;
@@ -2477,6 +2490,15 @@ export class SimpleIMAPService {
    *  we never permanently delete (EXPUNGE) mail. */
   private isTrashFolder(folder: string, trashPath: string): boolean {
     return folder === trashPath || folder.toLowerCase() === 'trash';
+  }
+
+  /** True if two folder paths refer to the same mailbox. Moving from/to the
+   *  identical location is a no-op — and critically, the "All Mail" union
+   *  (which holds every message from every folder) "accepts" such a move
+   *  silently while doing nothing, so we must short-circuit it rather than
+   *  issue the move. */
+  private isSameLocation(a: string, b: string): boolean {
+    return a.trim() === b.trim();
   }
 
   /**

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1161,6 +1161,8 @@ export class SimpleIMAPService {
               isHtml: looksLikeHtml,
               date: env.date ?? new Date(),
               folder,
+              // #9: stable cross-folder identity (the `id` UID is per-folder).
+              messageId: env.messageId || undefined,
               isRead: message.flags?.has('\\Seen') ?? false,
               isStarred: message.flags?.has('\\Flagged') ?? false,
               hasAttachment: attachmentCount > 0,
@@ -1300,6 +1302,8 @@ export class SimpleIMAPService {
               isEncryptedPGP: ctStr.includes('multipart/encrypted') && ctStr.includes('application/pgp-encrypted'),
               // Proton-specific stable ID
               protonId: typeof pmId === 'string' ? pmId.trim() : undefined,
+              // RFC Message-ID — stable identity across folders (#9).
+              messageId: parsed.messageId || undefined,
             };
 
             // GAP 7.5: setCacheEntry strips attachment binary content before storing

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -955,6 +955,16 @@ export class SimpleIMAPService {
     this.folderCachedAt = 0;
   }
 
+  /**
+   * Force a fresh folder fetch from IMAP, bypassing the cache. Backs the
+   * `sync_folders` tool — the cached `getFolders()` could otherwise return stale
+   * counts/structure right after a mutation made by another client.
+   */
+  async syncFolders(): Promise<EmailFolder[]> {
+    this.clearFolderCache();
+    return this.getFolders();
+  }
+
   /** Fetch all IMAP folders with message and unseen counts. Results are cached for {@link FOLDER_CACHE_TTL_MS}. */
   async getFolders(): Promise<EmailFolder[]> {
     const tags: SpanTags = {};
@@ -1954,6 +1964,7 @@ export class SimpleIMAPService {
         }
 
         logger.info(`Email ${emailId} marked as ${isRead ? 'read' : 'unread'}`, 'IMAPService');
+        this.clearFolderCache(); // unread count changed → next get_folders refetches
         return true;
       } finally {
         lock.release();
@@ -2119,6 +2130,7 @@ export class SimpleIMAPService {
       }
 
       logger.info(`Email ${emailId} moved from ${folder} to ${targetFolder}`, 'IMAPService');
+      this.clearFolderCache(); // folder counts changed → next get_folders refetches
       return true;
     } catch (error) {
       logger.error('Failed to move email', 'IMAPService', error);
@@ -2191,6 +2203,7 @@ export class SimpleIMAPService {
         throw new Error(`Copy of email ${emailId} to ${targetFolder} was accepted but could not be verified present there — likely a no-op from a union mailbox (e.g. All Mail), or the target does not exist. Pass the message's real source folder.`);
       }
       logger.info(`Email ${emailId} copied from ${folder} to ${targetFolder}`, 'IMAPService');
+      this.clearFolderCache(); // target folder count changed → next get_folders refetches
       return true;
     } catch (error) {
       logger.error('Failed to copy email to folder', 'IMAPService', error);
@@ -2230,6 +2243,7 @@ export class SimpleIMAPService {
         // Remove from cache using folder-qualified key
         this.evictCacheEntry(`${folder}:${emailId}`);
         logger.info(`Email ${emailId} deleted from ${folder}`, 'IMAPService');
+        this.clearFolderCache(); // folder count changed → next get_folders refetches
         return true;
       } finally {
         lock.release();
@@ -2494,6 +2508,7 @@ export class SimpleIMAPService {
 
     tags.successCount = results.success;
     tags.failCount = results.failed;
+    if (results.success > 0) this.clearFolderCache(); // counts changed → next get_folders refetches
     logger.info(`Bulk move completed: ${results.success} succeeded, ${results.failed} failed`, 'IMAPService');
     return results;
     }); // end tracer.span('imap.bulkMoveEmails')
@@ -2776,6 +2791,7 @@ export class SimpleIMAPService {
       } finally { lock.release(); }
     }
     tags.successCount = results.success; tags.failCount = results.failed;
+    if (results.success > 0) this.clearFolderCache(); // unread counts changed → next get_folders refetches
     logger.info(`Bulk mark-read completed: ${results.success}/${results.failed}`, 'IMAPService');
     return results;
     }); // end tracer.span('imap.bulkMarkRead')
@@ -3013,6 +3029,7 @@ export class SimpleIMAPService {
       }
     }
     tags.successCount = results.success; tags.failCount = results.failed;
+    if (results.success > 0) this.clearFolderCache(); // target counts changed → next get_folders refetches
     logger.info(`Bulk copy completed: ${results.success}/${results.failed}`, 'IMAPService');
     return results;
     }); // end tracer.span('imap.bulkCopyToFolder')
@@ -3090,6 +3107,7 @@ export class SimpleIMAPService {
     } finally { lock.release(); }
 
     tags.successCount = results.success; tags.failCount = results.failed;
+    if (results.success > 0) this.clearFolderCache(); // counts changed → next get_folders refetches
     logger.info(`Bulk delete-from-folder completed: ${results.success}/${results.failed}`, 'IMAPService');
     return results;
     }); // end tracer.span('imap.bulkDeleteFromFolder')

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2069,6 +2069,19 @@ export class SimpleIMAPService {
         return true;
       }
 
+      // From the All Mail union a MOVE no-ops — you cannot remove a message from
+      // the union (Bridge maps MOVE to add-target-label + remove-source-label;
+      // the remove half is meaningless here). The supported, verified operation
+      // is the add-label half: COPY the message into the target. This files an
+      // All-Mail-only (archived) message into a folder (or applies a label).
+      // A message in a REAL folder never reaches here — getEmailById resolves
+      // its true folder when sourceFolder is omitted (so it takes the MOVE path)
+      // — which also avoids COPY's add-without-remove leaving a second folder.
+      if (this.isAllMailFolder({ path: folder })) {
+        logger.info(`Email ${emailId} sourced from the All Mail union; filing into ${targetFolder} via COPY (MOVE no-ops from the union)`, 'IMAPService');
+        return this.copyEmailToFolder(emailId, targetFolder, folder);
+      }
+
       let movedMid: string | undefined;
       const relocated = new Set<string>();
       let uidplus = false;
@@ -2395,6 +2408,17 @@ export class SimpleIMAPService {
       // move silently while moving nothing). Count as success, don't issue it.
       if (this.isSameLocation(folder, targetFolder)) {
         for (let i = 0; i < ids.length; i++) results.success++;
+        continue;
+      }
+      // From the All Mail union, MOVE no-ops — file via COPY (the add-label
+      // half), verified-landing. Files All-Mail-only (archived) mail into a
+      // folder / applies a label. Foldered mail resolves to its real folder
+      // (when sourceFolder is omitted) and takes the MOVE path below.
+      if (this.isAllMailFolder({ path: folder })) {
+        const copied = await this.bulkCopyToFolder(ids, targetFolder, folder);
+        results.success += copied.success;
+        results.failed += copied.failed;
+        results.errors.push(...copied.errors);
         continue;
       }
       const lock = await this.client.getMailboxLock(folder);

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -3153,10 +3153,30 @@ export class SimpleIMAPService {
       logger.info(`Folder created: ${folderName}`, 'IMAPService');
       return true;
     } catch (error: unknown) {
-      const rt = (error as { responseText?: string }).responseText;
-      if (rt?.includes('ALREADYEXISTS')) {
-        logger.warn(`Folder already exists: ${folderName}`, 'IMAPService');
-        throw new Error(`Folder '${folderName}' already exists`);
+      const rt = (error as { responseText?: string }).responseText || '';
+      const em = error instanceof Error ? error.message : String(error);
+      const hay = `${rt} ${em}`.toLowerCase();
+      // Proton shares ONE namespace across folders and labels, so creating
+      // `Labels/Tech` when `Folders/Tech` exists (or a duplicate path) collides.
+      // Bridge surfaces this as an IMAP ALREADYEXISTS or the Proton 409
+      // (Code=2500) — but the text isn't always passed through, so also verify
+      // by listing (a folder/label leaf name is unique across both namespaces).
+      let conflict = hay.includes('alreadyexists') || hay.includes('already exists') || hay.includes('code=2500');
+      if (!conflict) {
+        try {
+          const leaf = (folderName.split('/').pop() || '').trim().toLowerCase();
+          const folders = await this.getFolders();
+          conflict = folders.some((f) => {
+            const p = f.path;
+            return p === folderName ||
+              ((p.startsWith('Folders/') || p.startsWith('Labels/')) &&
+                (p.split('/').pop() || '').trim().toLowerCase() === leaf);
+          });
+        } catch { /* listing failed — fall through to the raw error */ }
+      }
+      if (conflict) {
+        logger.warn(`Folder/label name already in use: ${folderName}`, 'IMAPService');
+        throw new Error(`A folder or label named '${folderName}' already exists. Proton shares one namespace across folders and labels, so the name can't be reused.`);
       }
       logger.error('Failed to create folder', 'IMAPService', error);
       throw error;

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1212,10 +1212,17 @@ export class SimpleIMAPService {
     }
 
     try {
-      // If a folder hint is provided, only look there; otherwise scan all folders
+      // If a folder hint is provided, only look there; otherwise scan all
+      // folders — but search the "All Mail" union LAST. All Mail holds every
+      // message, so scanning it first reports `folder:"All Mail"` for messages
+      // that actually live in a real folder (the union masks the true
+      // location). Real folders win; All Mail is the fallback only for mail
+      // that genuinely exists nowhere else (true archive).
       const foldersToSearch = folderHint
-        ? [{ path: folderHint }]
-        : await this.getFolders();
+        ? [{ path: folderHint } as { path: string; specialUse?: string | null }]
+        : [...await this.getFolders()].sort(
+            (a, b) => (this.isAllMailFolder(a) ? 1 : 0) - (this.isAllMailFolder(b) ? 1 : 0),
+          );
 
       for (const folder of foldersToSearch) {
         const lock = await this.client.getMailboxLock(folder.path);
@@ -2499,6 +2506,13 @@ export class SimpleIMAPService {
    *  issue the move. */
   private isSameLocation(a: string, b: string): boolean {
     return a.trim() === b.trim();
+  }
+
+  /** True if a folder is the "All Mail" union (specialUse \All, or the literal
+   *  path). All Mail holds EVERY message, so it must be searched LAST when
+   *  resolving a message's folder — otherwise it masks the real location. */
+  private isAllMailFolder(f: { path?: string; specialUse?: string | null }): boolean {
+    return f.specialUse === "\\All" || (f.path ?? "").trim() === "All Mail";
   }
 
   /**

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -9,7 +9,6 @@ import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import {
   optionalSourceFolder,
   requireNumericEmailId,
-  validateFolderName,
   validateLabelName,
   validateTargetFolder,
 } from "../utils/helpers.js";
@@ -357,11 +356,28 @@ export const handlers: Record<string, ToolHandler> = {
   move_to_folder: async (ctx) => {
     const { args, imapService, actionOk } = ctx;
     const mtfEmailId = requireNumericEmailId(args.emailId);
-    const folderName = args.folder as string;
-    const folderValidErr = validateFolderName(folderName);
-    if (folderValidErr) throw new McpError(ErrorCode.InvalidParams, folderValidErr);
+    if (typeof args.folder !== "string" || args.folder.trim() === "") {
+      throw new McpError(ErrorCode.InvalidParams, "folder must be a non-empty string.");
+    }
+    const folderName = args.folder.trim();
+    // Accept nested folder paths (mirror bulk_move_emails) — nested folders are
+    // first-class in get_folders. Reject only traversal / control chars / bad
+    // slashes, NOT the "/" separator itself (the old leaf-only validator broke
+    // every nested target). A leaf ("Work") or sub-path ("Life/Bills/Anthropic")
+    // is namespaced under Folders/; a fully-qualified "Folders/…" / "Labels/…"
+    // path is used as-is. The service re-validates the final path.
+    if (
+      folderName.includes("..") ||
+      /[\u0000-\u001f\u007f]/.test(folderName) ||
+      folderName.startsWith("/") ||
+      folderName.endsWith("/") ||
+      folderName.includes("//")
+    ) {
+      throw new McpError(ErrorCode.InvalidParams, "folder contains invalid characters (.., control characters, or leading/trailing/empty path segments).");
+    }
+    const target = /^(Folders|Labels)\//.test(folderName) ? folderName : `Folders/${folderName}`;
     const mtfSourceFolder = optionalSourceFolder(args.sourceFolder);
-    await imapService.moveEmail(mtfEmailId, `Folders/${folderName}`, mtfSourceFolder);
+    await imapService.moveEmail(mtfEmailId, target, mtfSourceFolder);
     return actionOk();
   },
 

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -41,7 +41,7 @@ const BULK_RESULT_SCHEMA = {
 const SOURCE_FOLDER_SCHEMA = {
   type: "string",
   description:
-    "Folder the UID(s) live in (e.g. INBOX, Folders/Work, Labels/Foo). Strongly recommended whenever the UIDs came from a folder other than INBOX — IMAP UIDs are folder-scoped, so without this the wrong folder may be selected and the operation may silently no-op.",
+    "Folder the UID(s) live in (e.g. INBOX, Folders/Work, Labels/Foo). Strongly recommended whenever the UIDs came from a folder other than INBOX — IMAP UIDs are folder-scoped, so without this the wrong folder may be selected and the operation may silently no-op. Avoid passing 'All Mail' as the source: it is a union view of every folder, not a real location, so moves out of it can silently do nothing — pass the message's actual folder instead. Moving to the folder a message is already in is a no-op.",
 };
 
 export const defs: ToolDef[] = [

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -115,7 +115,9 @@ export const handlers: Record<string, ToolHandler> = {
 
   sync_folders: async (ctx) => {
     const { imapService, ok } = ctx;
-    const folders = await imapService.getFolders();
+    // Force a fresh fetch (bypass the folder cache) — that's the whole point of
+    // an explicit "sync"; the cached get_folders could otherwise echo stale data.
+    const folders = await imapService.syncFolders();
     return ok({ success: true, folderCount: folders.length });
   },
 

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -42,11 +42,12 @@ import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 const EMAIL_SUMMARY_SCHEMA = {
   type: "object",
   properties: {
-    id: { type: "string", description: "IMAP UID for use in follow-up tool calls" },
+    id: { type: "string", description: "IMAP UID — per-folder, use for follow-up tool calls in THIS folder" },
+    messageId: { type: "string", description: "RFC Message-ID — stable identity across folders (the per-folder `id` is not)" },
     from: { type: "string" },
     to: { type: "array", items: { type: "string" } },
     subject: { type: "string" },
-    bodyPreview: { type: "string", description: "First ~300 chars of body" },
+    bodyPreview: { type: "string", description: "First ~300 chars of body (omitted when summaryOnly=true)" },
     date: { type: "string", format: "date-time" },
     folder: { type: "string" },
     isRead: { type: "boolean" },
@@ -61,7 +62,7 @@ export const defsEarly: ToolDef[] = [
     name: "get_emails",
     title: "Get Emails",
     description:
-      "Fetch a page of emails from a folder. Returns summary fields (id, from, subject, date, isRead, bodyPreview, isAnswered, isForwarded). Use id with get_email_by_id for full content including body and attachments. Pass nextCursor from a previous response to get the next page.",
+      "Fetch a page of emails from a folder. Returns summary fields (id, messageId, from, subject, date, isRead, bodyPreview). `id` is a per-folder IMAP UID; `messageId` is stable across folders. Use id with get_email_by_id for full content. Set summaryOnly=true to omit bodyPreview for lean listing/triage. Pass nextCursor from a previous response to get the next page.",
     annotations: { readOnlyHint: true, openWorldHint: true },
     inputSchema: {
       type: "object",
@@ -79,6 +80,10 @@ export const defsEarly: ToolDef[] = [
         cursor: {
           type: "string",
           description: "Opaque cursor from previous response nextCursor to get next page. Omit for first page.",
+        },
+        summaryOnly: {
+          type: "boolean",
+          description: "When true, omit bodyPreview (and body) from each item — leaner payload for listing/triage. Default false.",
         },
       },
     },
@@ -532,7 +537,12 @@ export const handlers: Record<string, ToolHandler> = {
       nextCursor = encodeCursor({ folder, offset: offset + limit, limit });
     }
 
-    const structured = { emails, folder, count: emails.length, ...(nextCursor ? { nextCursor } : {}) };
+    // #8: projection — drop the body fields for lean listing/triage payloads.
+    const projected = (args.summaryOnly === true)
+      ? emails.map((e) => { const { body: _b, bodyPreview: _p, ...rest } = e; void _b; void _p; return rest; })
+      : emails;
+
+    const structured = { emails: projected, folder, count: projected.length, ...(nextCursor ? { nextCursor } : {}) };
     return ok(structured);
   },
 

--- a/src/tools/system.ts
+++ b/src/tools/system.ts
@@ -157,12 +157,38 @@ export const handlers: Record<string, ToolHandler> = {
     const { imapService, smtpService, ok, config, state } = ctx;
     const { configExists, getConfigPath } = await import("../config/loader.js");
     const smtpBackoffMs = smtpService.backoff.delayUntilMs();
+
+    // #6b: probe SMTP auth LIVE (mirrors IMAP's healthCheck below) so status
+    // can't report "connected" while sends fail. Skip while in backoff — a probe
+    // would add to the abuse signal, and backoff already means "not usable now".
+    let smtpConnected: boolean;
+    let smtpError: string | undefined = state.smtpStatus.error;
+    let smtpLastCheck = state.smtpStatus.lastCheck;
+    if (smtpService.backoff.isBlocked() || smtpService.initError) {
+      smtpConnected = false;
+    } else {
+      let probeErr: string | undefined;
+      const verify = smtpService.verifyConnection().then(() => true).catch((e: unknown) => {
+        probeErr = e instanceof Error ? e.message : String(e);
+        return false;
+      });
+      const timeout = new Promise<boolean>((res) => setTimeout(() => {
+        probeErr = probeErr ?? "SMTP auth probe timed out";
+        res(false);
+      }, 8000));
+      smtpConnected = await Promise.race([verify, timeout]);
+      smtpError = smtpConnected ? undefined : (probeErr ?? smtpError);
+      smtpLastCheck = new Date();
+      // Keep the shared snapshot honest for other readers.
+      state.smtpStatus = { connected: smtpConnected, lastCheck: smtpLastCheck, ...(smtpError ? { error: smtpError } : {}) };
+    }
+
     const status = {
       smtp: {
-        connected: state.smtpStatus.connected,
+        connected: smtpConnected,
         host: config.smtp.host,
         port: config.smtp.port,
-        lastCheck: state.smtpStatus.lastCheck.toISOString(),
+        lastCheck: smtpLastCheck.toISOString(),
         insecureTls: smtpService.insecureTls,
         backoff: {
           active: smtpService.backoff.isBlocked(),
@@ -170,7 +196,7 @@ export const handlers: Record<string, ToolHandler> = {
           remainingMs: smtpBackoffMs,
         },
         ...(smtpService.initError ? { initError: smtpService.initError } : {}),
-        ...(state.smtpStatus.error ? { error: state.smtpStatus.error } : {}),
+        ...(smtpError ? { error: smtpError } : {}),
       },
       imap: {
         connected: imapService.isActive(),
@@ -191,7 +217,12 @@ export const handlers: Record<string, ToolHandler> = {
     const initErrorWarning = smtpService.initError
       ? `\n\u26a0 SMTP is not ready: ${smtpService.initError}`
       : "";
-    return ok(status, JSON.stringify(status) + insecureTlsWarning + backoffWarning + initErrorWarning);
+    // #6b: a genuine live-probe auth failure (not backoff/init) \u2014 sending is
+    // broken. Surface it so an agent doesn't trust a green status before sending.
+    const smtpAuthWarning = (!smtpConnected && !smtpService.backoff.isBlocked() && !smtpService.initError)
+      ? `\n\u26a0 SMTP authentication failed \u2014 sending is currently broken${smtpError ? `: ${smtpError}` : ""}. Fix the Bridge password in Settings \u2192 Connection.`
+      : "";
+    return ok(status, JSON.stringify(status) + insecureTlsWarning + backoffWarning + initErrorWarning + smtpAuthWarning);
   },
 
   sync_emails: async (ctx) => {

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -87,6 +87,12 @@ export interface HttpTransportOptions {
    * Their matching active AgentGrant is ensured by the caller at startup.
    */
   serviceAccounts?: ServiceAccountStore;
+  /**
+   * Optional path for persisting issued OAuth access-token hashes so they
+   * survive a daemon restart (field finding #7). Only hashes + metadata are
+   * written (0600) — never raw bearers. When omitted, tokens are in-memory only.
+   */
+  oauthTokensPath?: string;
 }
 
 export interface HttpTransportHandle {
@@ -249,7 +255,7 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
     );
   }
 
-  const oauthStore = new OAuthStore();
+  const oauthStore = new OAuthStore(opts.oauthTokensPath);
   // Register persisted service accounts as client_credentials clients so their
   // token-authenticated calls resolve to a human-readable client_name. Identity
   // is still the service-account store; this is display + metadata only.

--- a/src/transports/oauth-store.test.ts
+++ b/src/transports/oauth-store.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { OAuthStore, OAUTH_CODE_TTL_MS, OAUTH_ACCESS_TOKEN_TTL_MS } from "./oauth-store.js";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 describe("OAuthStore", () => {
   let store: OAuthStore;
@@ -173,4 +176,47 @@ describe("OAuthStore", () => {
       expect(store.stats().codes).toBeLessThanOrEqual(OAUTH_MAX_CODES);
     });
   });
+
+  describe("token persistence (#7 — survive daemon restart)", () => {
+    let dir: string; let path: string;
+    beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "mp-oauth-")); path = join(dir, "tokens.json"); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    it("a token issued by one store is valid in a fresh store loaded from disk", () => {
+      const a = new OAuthStore(path);
+      const t = a.issueToken({ clientId: "pmc_x", scopes: ["mcp"] });
+      // New process / daemon restart:
+      const b = new OAuthStore(path);
+      const rec = b.verifyToken(t.token);
+      expect(rec).not.toBeNull();
+      expect(rec!.clientId).toBe("pmc_x");
+    });
+
+    it("never writes the raw bearer to disk (hashes only)", () => {
+      const a = new OAuthStore(path);
+      const t = a.issueToken({ clientId: "pmc_y", scopes: ["mcp"] });
+      expect(existsSync(path)).toBe(true);
+      const onDisk = readFileSync(path, "utf-8");
+      expect(onDisk).not.toContain(t.token); // raw token must not be persisted
+    });
+
+    it("does not resurrect expired tokens on load", () => {
+      const a = new OAuthStore(path);
+      const t = a.issueToken({ clientId: "pmc_z", scopes: ["mcp"] });
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + OAUTH_ACCESS_TOKEN_TTL_MS + 1000);
+      const b = new OAuthStore(path);
+      expect(b.verifyToken(t.token)).toBeNull();
+      vi.useRealTimers();
+    });
+
+    it("revocation is persisted (revoked token stays invalid after restart)", () => {
+      const a = new OAuthStore(path);
+      const t = a.issueToken({ clientId: "pmc_r", scopes: ["mcp"] });
+      a.revokeToken(t.token);
+      const b = new OAuthStore(path);
+      expect(b.verifyToken(t.token)).toBeNull();
+    });
+  });
+
 });

--- a/src/transports/oauth-store.ts
+++ b/src/transports/oauth-store.ts
@@ -1,20 +1,19 @@
 /**
  * In-memory stores for the OAuth 2.1 authorization server.
  *
- * All state is process-local — matching mailpouch's single-user design.
- * A restart drops outstanding auth codes (short TTL anyway) and tokens
- * (requiring clients to re-auth); registered DCR clients are re-provisioned
- * on demand because MCP hosts will call the register endpoint again.
+ * Codes (60s TTL) and DCR clients are process-local: a restart drops codes
+ * (short-lived anyway) and clients re-register on demand.
  *
- * Rationale for not persisting to disk:
- *   - Keeps the attack surface small (no on-disk tokens to leak).
- *   - Tokens in this deployment are long-lived enough for an interactive
- *     session but re-issue is cheap.
- *   - Persistence is a follow-up PR when we tackle multi-instance or
- *     survivable restarts.
+ * Issued ACCESS TOKENS are optionally persisted (when the store is constructed
+ * with a path) so they survive a daemon restart — without persistence, a
+ * restart dropped the in-memory Map and 401'd every live token, silently
+ * breaking headless / static-config clients (field finding #7). Only the token
+ * HASH (the Map key) + metadata are written to disk (0600, atomic) — never the
+ * raw bearer — so a leaked file cannot be replayed as a credential.
  */
 
 import { createHash, randomBytes, randomUUID } from "crypto";
+import { readFileSync, writeFileSync, existsSync, renameSync } from "fs";
 
 export interface RegisteredClient {
   client_id: string;
@@ -89,6 +88,49 @@ export class OAuthStore {
    *  waiting for the 24 h TTL to expire. Kept consistent with `tokens` via the
    *  issueToken / revokeToken / evict / sweep paths. */
   private tokensByClient = new Map<string, Set<string>>();
+
+  /**
+   * Optional on-disk persistence of ISSUED TOKENS so they survive a daemon
+   * restart (XPORT/#7 — a restart used to drop the in-memory Map and 401 every
+   * live token, silently breaking headless/static-config clients). Only the
+   * token HASH (the Map key) + metadata are written — never the raw bearer — so
+   * a leaked file cannot be replayed as a credential. Codes (60s TTL) and DCR
+   * clients are intentionally NOT persisted.
+   */
+  constructor(private readonly persistPath?: string) {
+    if (persistPath) this.load();
+  }
+
+  private load(): void {
+    try {
+      if (!this.persistPath || !existsSync(this.persistPath)) return;
+      const raw = JSON.parse(readFileSync(this.persistPath, "utf-8")) as { tokens?: Array<{ h: string; r: IssuedToken }> };
+      const now = Date.now();
+      for (const entry of raw.tokens ?? []) {
+        const { h, r } = entry;
+        if (!h || !r || typeof r.expiresAt !== "number" || now > r.expiresAt) continue;
+        this.tokens.set(h, r);
+        let set = this.tokensByClient.get(r.clientId);
+        if (!set) { set = new Set(); this.tokensByClient.set(r.clientId, set); }
+        set.add(h);
+      }
+    } catch {
+      // Corrupt/unreadable token store → start fresh (clients re-auth). Never throw.
+    }
+  }
+
+  private persist(): void {
+    if (!this.persistPath) return;
+    try {
+      // Hashes only — the raw bearer is blanked so a leaked file can't be replayed.
+      const tokens = Array.from(this.tokens.entries()).map(([h, r]) => ({ h, r: { ...r, token: "" } }));
+      const tmp = `${this.persistPath}.${randomBytes(6).toString("hex")}.tmp`;
+      writeFileSync(tmp, JSON.stringify({ version: 1, tokens }), { mode: 0o600 });
+      renameSync(tmp, this.persistPath);
+    } catch {
+      // Best-effort — a failed persist must not break token issuance/verification.
+    }
+  }
 
   /** sha256(token) hex — the key under which a token's record lives. */
   private static hashToken(token: string): string {
@@ -182,6 +224,7 @@ export class OAuthStore {
     }
     this.tokens.set(OAuthStore.hashToken(token), rec);
     this.indexToken(rec);
+    this.persist();
     return rec;
   }
 
@@ -202,6 +245,7 @@ export class OAuthStore {
     const rec = this.tokens.get(hash);
     const removed = this.tokens.delete(hash);
     if (removed && rec) this.unindexToken(hash, rec.clientId);
+    if (removed) this.persist();
     return removed;
   }
 
@@ -217,6 +261,7 @@ export class OAuthStore {
       if (this.tokens.delete(token)) n++;
     }
     this.tokensByClient.delete(clientId);
+    if (n > 0) this.persist();
     return n;
   }
 
@@ -240,6 +285,7 @@ export class OAuthStore {
         tokens++;
       }
     }
+    if (tokens > 0) this.persist();
     return { codes, tokens };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,7 @@ export interface EmailMessage {
 
   // Proton-specific
   protonId?: string;         // X-Pm-Internal-Id header — stable Proton message ID (survives folder moves)
+  messageId?: string;        // RFC 5322 Message-ID header — stable identity across folders (the per-folder `id` UID is not)
 }
 
 export interface EmailAttachment {

--- a/src/utils/error-classify.ts
+++ b/src/utils/error-classify.ts
@@ -30,6 +30,7 @@ export class ConnectionStateError extends Error {
 /** Stable, machine-stable error categories surfaced to callers. */
 export type ErrorCategory =
   | "not_found" // a folder/label/mailbox does not exist
+  | "conflict" // a folder/label with that name already exists (Proton 409 / ALREADYEXISTS)
   | "auth" // IMAP/SMTP authentication failed
   | "connection" // connection lost / unavailable
   | "timeout" // operation timed out
@@ -103,6 +104,23 @@ export function classifyError(
       message: folderLabel
         ? `Folder/label '${folderLabel}' not found.`
         : "The requested folder or label was not found.",
+    };
+  }
+
+  // ── name conflict (folder/label already exists) ──────────────────────────
+  // Proton shares ONE namespace across folders and labels, so creating a name
+  // that exists in either returns the Proton 409 (Code=2500) / IMAP
+  // ALREADYEXISTS. Surface it as actionable instead of "internal".
+  if (
+    hay.includes("alreadyexists") ||
+    hay.includes("already exists") ||
+    hay.includes("code=2500")
+  ) {
+    return {
+      category: "conflict",
+      message: folderLabel
+        ? `A folder or label named '${folderLabel}' already exists. Proton shares one namespace across folders and labels, so the name can't be reused.`
+        : "A folder or label with that name already exists (Proton shares one namespace across folders and labels).",
     };
   }
 


### PR DESCRIPTION
## Summary
Field-report fixes from driving the HTTP daemon against a real, All-Mail-heavy account, plus the Proton Bridge MOVE/COPY semantics research that grounds them (`docs/proton-bridge-imap.md`, researched + live-confirmed).

## Fixes (field findings #1–#9)
- **#1** `get_email_by_id` returns the real folder (scan the All Mail union last) — fixes move verification.
- **#2** `get_folders` counts invalidate on every mutation; `sync_folders` force-refreshes.
- **#3** file archived (All-Mail-only) mail into folders via verified-landing **COPY** (Bridge forbids MOVE out of the union); same-location moves no-op.
- **#4** `move_to_folder` accepts nested paths.
- **#5** name-collision `create_folder` surfaces the Proton 409 / shared-namespace reason.
- **#6** `get_connection_status` probes SMTP auth **live** (no more "connected" while sends fail).
- **#7** OAuth access tokens persist across daemon restart (hashes only, never the raw bearer).
- **#8/#9** `get_emails` `summaryOnly` projection + stable `messageId` in listings.
- plus: stop the repeating "cowork approved" notification; delete = move-to-Trash (never EXPUNGE); the All-Mail move guard.

## Test plan
- [x] preship gate PASS (typecheck/lint/secrets/audit/license/build/unit/tarball/Greenmail E2E; Bridge E2E covered by the non-destructive safe-bridge gate, 8/8 on a real account)
- [x] ~2072 unit tests green
- [ ] CI matrix (ubuntu/macOS/windows × node 20/22) + CodeQL

## Security checklist
- [x] No secrets/keys/credentials committed
- [x] OAuth token persistence stores hashes only (no replayable bearers); 0600
- [x] No new attack surface beyond the documented daemon/OAuth model

🤖 Generated with [Claude Code](https://claude.com/claude-code)