### PR TITLE
Phase 0: backbone refactor — extract shared IMAP/TLS/search/attachment helpers

### DIFF
--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -1,0 +1,48 @@
+# Quality Audit Ledger
+
+Per-function code-review scores for the Bridge-capability program (plan
+`crispy-wibbling-dusk`). Each function is scored 1–10 on five dimensions —
+**job-as-designed** (correct vs Proton Bridge semantics), **simplicity**,
+**elegance**, **security**, **focus** (single responsibility). Gate to merge:
+**average ≥ 9.5 AND no single dimension < 9**, else rebuild.
+
+Verdicts come from the multi-agent ultra-review (adversarial: a first reviewer
+scores, a second independently tries to refute any REBUILD). Findings the second
+reviewer cannot confirm as a genuine defect are not actioned.
+
+## Phase 0 — Backbone (`refactor/phase0-backbone`, PR #192)
+
+| Function | File | Job | Simpl | Eleg | Sec | Focus | Avg | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| `verifyRelocatedMessages` | imap-helpers.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `buildSearchCriteria` + `sanitizeImapSearchValue` | imap-helpers.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `stripHtml`/`truncateBody`/`normalizeAddressList` | imap-helpers.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `buildBridgeTlsConfig` | bridge-tls.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `validateAttachmentLimits` | utils/helpers.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `chunkedBatchOp` (config form) | simple-imap-service.ts | 10 | 9 | 9 | 10 | 10 | 9.6 | PASS |
+| `buildEmailMessage` | imap-helpers.ts | 9 | 9 | 9 | 10 | 9 | 9.2 | PASS¹ |
+| `groupEmailsByFolder` | simple-imap-service.ts | 9.5 | 9 | 8.5 | 10 | 9 | 9.2 | REBUILT → PASS² |
+| `validateSearchInput` | tools/search-input.ts | 8.5 | 9 | 8.5 | 9.5 | 9 | 8.9 | REBUILT → PASS³ |
+
+¹ First reviewer scored 9.2/REBUILD; the adversarial verifier did not confirm a
+genuine defect (the flagged items were stylistic), so no rebuild — treated PASS.
+
+² **Rebuilt** (commit `1e707d5`): the catch conflated ID-format validation with
+IMAP discovery/transport failure — both surfaced as "Invalid email ID". Split so
+a discovery error reads "Failed to locate email <id>". Test:
+`imap-operations.test.ts` "surfaces discovery transport errors distinctly".
+
+³ **Rebuilt** (commits `1e707d5`, reviewer-pass): `dateFrom`/`dateTo` only
+type-checked, never `Date.parse`-validated — `{dateFrom:"not-a-date"}` passed
+through and was silently dropped (violated the TOOL-017 contract honored by
+`sentBefore`/`sentSince`). Now rejected. Also made `body`/`text`/`bcc` reject
+non-strings to match the documented "throws on malformed input" contract.
+Tests added in `search-input.test.ts`.
+
+### PR #192 reviewer fixes (CodeQL + Copilot)
+- `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
+  whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).
+- `connect()` `isLocalhost` now includes IPv6 loopback `::1`, matching
+  `buildBridgeTlsConfig` (host `::1` previously got a localhost TLS config but a
+  non-localhost implicit-TLS `secure` default).
+- Removed now-unused `ParsedMail`/`AddressObject` type imports from the service.

--- a/src/services/bridge-tls.config.test.ts
+++ b/src/services/bridge-tls.config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { join } from "path";
+import { buildBridgeTlsConfig, _resetBridgeCertPinsForTests } from "./bridge-tls.js";
+
+const CERT = join(process.cwd(), "test/fixtures/tls/bridge-like-cert.pem");
+
+describe("buildBridgeTlsConfig", () => {
+  beforeEach(() => _resetBridgeCertPinsForTests());
+
+  it("non-localhost → standard validation, secure", () => {
+    const r = buildBridgeTlsConfig("mail.example.com", undefined, false);
+    expect(r.insecure).toBe(false);
+    expect(r.tlsOptions).toEqual({ minVersion: "TLSv1.2" });
+  });
+
+  it("localhost + valid pinned cert → trusts it, secure, info log", () => {
+    const r = buildBridgeTlsConfig("localhost", CERT, false);
+    expect(r.insecure).toBe(false);
+    expect(Array.isArray((r.tlsOptions as { ca?: unknown[] }).ca)).toBe(true);
+    expect((r.tlsOptions as { checkServerIdentity?: unknown }).checkServerIdentity).toBeTypeOf("function");
+    expect(r.logs.some((l) => l.level === "info")).toBe(true);
+  });
+
+  it("localhost + no cert + strict → throws", () => {
+    expect(() => buildBridgeTlsConfig("localhost", undefined, false)).toThrow(/No Bridge certificate configured/);
+  });
+
+  it("localhost + no cert + allowInsecure → disabled validation, insecure=true, warn log", () => {
+    const r = buildBridgeTlsConfig("127.0.0.1", undefined, true);
+    expect(r.insecure).toBe(true);
+    expect((r.tlsOptions as { rejectUnauthorized?: boolean }).rejectUnauthorized).toBe(false);
+    expect(r.logs.some((l) => l.level === "warn")).toBe(true);
+  });
+
+  it("localhost + bad cert path + strict → throws 'could not be loaded'", () => {
+    expect(() => buildBridgeTlsConfig("localhost", "/no/such/cert.pem", false))
+      .toThrow(/could not be loaded and allowInsecureBridge is not set/);
+  });
+
+  it("localhost + bad cert path + allowInsecure → insecure fallback", () => {
+    const r = buildBridgeTlsConfig("localhost", "/no/such/cert.pem", true);
+    expect(r.insecure).toBe(true);
+    expect((r.tlsOptions as { rejectUnauthorized?: boolean }).rejectUnauthorized).toBe(false);
+  });
+});

--- a/src/services/bridge-tls.ts
+++ b/src/services/bridge-tls.ts
@@ -5,7 +5,8 @@
 // Bridge CA cert is the trust anchor; checkServerIdentity is bypassed because
 // Bridge exports certs with CN=127.0.0.1, which would not match "localhost".
 
-import { readFileSync } from "fs";
+import { readFileSync, statSync } from "fs";
+import { join } from "path";
 import { createHash } from "crypto";
 import { logger } from "../utils/logger.js";
 
@@ -44,6 +45,86 @@ export function readPinnedBridgeCert(certPath: string): Buffer {
     throw new Error(`Bridge cert pin violation: ${certPath} hash changed since startup`);
   }
   return buf;
+}
+
+export interface BridgeTlsConfig {
+  /** TLS options to hand to imapflow / nodemailer. */
+  tlsOptions: Record<string, unknown>;
+  /** True when certificate validation was disabled (insecure fallback). */
+  insecure: boolean;
+  /** Messages for the caller to emit with its own logger + context. */
+  logs: Array<{ level: "info" | "warn"; msg: string }>;
+}
+
+/**
+ * Resolve TLS options for a Proton Bridge connection from (host, cert path,
+ * allow-insecure) — the single decision both the IMAP service `connect()` and
+ * the settings connection-check need:
+ *  - non-localhost          → standard validation (minVersion TLSv1.2);
+ *  - localhost + cert       → pin the cert (buildBridgeTlsOptions);
+ *  - localhost + cert fails  → throw UNLESS allowInsecure (then validation off);
+ *  - localhost + no cert     → throw UNLESS allowInsecure (then validation off).
+ * `insecure` reports whether validation was disabled; `logs` are returned (not
+ * emitted) so the caller controls the logger/context. fs access (statSync for
+ * dir→cert.pem resolution, readFileSync via readPinnedBridgeCert) keeps the
+ * cert-pin TOCTOU protection.
+ */
+export function buildBridgeTlsConfig(
+  host: string,
+  bridgeCertPath: string | undefined,
+  allowInsecure: boolean,
+): BridgeTlsConfig {
+  const isLocalhost = host === "localhost" || host === "127.0.0.1" || host === "::1";
+  const logs: BridgeTlsConfig["logs"] = [];
+  const insecureOpts = { rejectUnauthorized: false, minVersion: "TLSv1.2" };
+
+  if (!isLocalhost) {
+    return { tlsOptions: { minVersion: "TLSv1.2" }, insecure: false, logs };
+  }
+
+  if (bridgeCertPath) {
+    let resolved = bridgeCertPath;
+    try {
+      if (statSync(bridgeCertPath).isDirectory()) {
+        resolved = join(bridgeCertPath, "cert.pem");
+        logs.push({ level: "info", msg: `Directory given for cert path — resolved to ${resolved}` });
+      }
+    } catch { /* stat failed — let readPinnedBridgeCert produce the real error */ }
+    try {
+      const tlsOptions = buildBridgeTlsOptions(readPinnedBridgeCert(resolved));
+      logs.push({ level: "info", msg: `Using exported Bridge certificate for TLS trust (${resolved})` });
+      return { tlsOptions, insecure: false, logs };
+    } catch (err) {
+      if (!allowInsecure) {
+        throw new Error(
+          `Bridge cert at "${resolved}" could not be loaded and allowInsecureBridge is not set. ` +
+          `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
+          `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
+          `Underlying error: ${(err as Error).message}`,
+        );
+      }
+      logs.push({
+        level: "warn",
+        msg: `Failed to load Bridge cert at "${resolved}" — running with TLS validation DISABLED (allowInsecureBridge is set). ` +
+          `Export a fresh cert from Bridge → Help → Export TLS Certificate and update Settings → Connection to re-secure.`,
+      });
+      return { tlsOptions: insecureOpts, insecure: true, logs };
+    }
+  }
+
+  if (!allowInsecure) {
+    throw new Error(
+      "No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate " +
+      "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
+      "disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1.",
+    );
+  }
+  logs.push({
+    level: "warn",
+    msg: "No Bridge certificate configured and allowInsecureBridge is set — TLS certificate validation DISABLED for localhost. " +
+      "Export the cert from Bridge → Help → Export TLS Certificate and clear the insecure flag to re-secure.",
+  });
+  return { tlsOptions: insecureOpts, insecure: true, logs };
 }
 
 /** Reset the pinned-hash table. Test-only. */

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { ParsedMail } from "mailparser";
-import { buildEmailMessage, stripHtml, truncateBody, normalizeAddressList } from "./imap-helpers.js";
+import { buildEmailMessage, verifyRelocatedMessages, stripHtml, truncateBody, normalizeAddressList } from "./imap-helpers.js";
+import type { RelocationJob } from "./imap-helpers.js";
 
 /** Minimal ParsedMail factory — only the fields buildEmailMessage reads. */
 function parsed(over: Partial<ParsedMail> & { headerEntries?: [string, unknown][] } = {}): ParsedMail {
@@ -129,5 +130,49 @@ describe("stripHtml / truncateBody / normalizeAddressList (moved, unchanged)", (
     expect(normalizeAddressList(undefined)).toEqual([]);
     expect(normalizeAddressList(addr("a@x.com"))).toEqual(["a@x.com"]);
     expect(normalizeAddressList([addr("a@x.com"), addr("b@x.com")])).toEqual(["a@x.com", "b@x.com"]);
+  });
+});
+
+describe("verifyRelocatedMessages", () => {
+  const noFind = async () => new Set<string>();
+  const err = (uid: string, src?: string) => `fail ${uid} from ${src ?? "?"}`;
+  const job = (o: Partial<RelocationJob>): RelocationJob => ({
+    accepted: [], midMap: new Map(), relocated: new Set(), uidplus: false, ...o,
+  });
+
+  it("UIDPLUS-confirmed relocations succeed (no Message-ID search needed)", async () => {
+    const r = await verifyRelocatedMessages(
+      [job({ accepted: ["1", "2"], relocated: new Set(["1", "2"]), uidplus: true })],
+      "Folders/X", noFind, err,
+    );
+    expect(r).toEqual({ success: 2, failed: 0, errors: [] });
+  });
+
+  it("no UIDPLUS: success only when the Message-ID is found in the target", async () => {
+    const find = async (_f: string, mids: string[]) => new Set(mids.filter((m) => m === "mid-1"));
+    const r = await verifyRelocatedMessages(
+      [job({ accepted: ["1", "2"], midMap: new Map([["1", "mid-1"], ["2", "mid-2"]]), uidplus: false, folder: "All Mail" })],
+      "Folders/X", find, err,
+    );
+    expect(r.success).toBe(1);
+    expect(r.failed).toBe(1);
+    expect(r.errors).toEqual(["fail 2 from All Mail"]);
+  });
+
+  it("a silent no-op (accepted, nothing lands) is an honest failure, never success", async () => {
+    const r = await verifyRelocatedMessages(
+      [job({ accepted: ["9"], midMap: new Map([["9", "mid-9"]]), uidplus: false, folder: "All Mail" })],
+      "Folders/X", noFind, err,
+    );
+    expect(r).toEqual({ success: 0, failed: 1, errors: ["fail 9 from All Mail"] });
+  });
+
+  it("a thrown Message-ID search degrades to failure, not a crash", async () => {
+    const find = async () => { throw new Error("boom"); };
+    const r = await verifyRelocatedMessages(
+      [job({ accepted: ["1"], midMap: new Map([["1", "mid-1"]]), uidplus: false })],
+      "Folders/X", find, err,
+    );
+    expect(r.failed).toBe(1);
   });
 });

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -119,9 +119,11 @@ describe("stripHtml / truncateBody / normalizeAddressList (moved, unchanged)", (
     expect(stripHtml("a &lt;script&gt;alert(1)&lt;/script&gt; b")).toBe("a b");
     expect(stripHtml("<!-- secret: pw -->visible")).toBe("visible");
   });
-  it("stripHtml strips script/style blocks closed with trailing whitespace (CodeQL)", () => {
+  it("stripHtml strips script/style blocks with junk in the close tag (CodeQL js/bad-tag-filter)", () => {
     expect(stripHtml("a<script>evil()</script >b")).toBe("a b");
     expect(stripHtml("a<style>.x{}</style\t>b")).toBe("a b");
+    expect(stripHtml("a<script>evil()</script\t\n bar>b")).toBe("a b");
+    expect(stripHtml("a<script>evil()</script foo>b")).toBe("a b");
   });
   it("truncateBody breaks on a word boundary near the cap", () => {
     expect(truncateBody("short")).toBe("short");

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -119,6 +119,10 @@ describe("stripHtml / truncateBody / normalizeAddressList (moved, unchanged)", (
     expect(stripHtml("a &lt;script&gt;alert(1)&lt;/script&gt; b")).toBe("a b");
     expect(stripHtml("<!-- secret: pw -->visible")).toBe("visible");
   });
+  it("stripHtml strips script/style blocks closed with trailing whitespace (CodeQL)", () => {
+    expect(stripHtml("a<script>evil()</script >b")).toBe("a b");
+    expect(stripHtml("a<style>.x{}</style\t>b")).toBe("a b");
+  });
   it("truncateBody breaks on a word boundary near the cap", () => {
     expect(truncateBody("short")).toBe("short");
     const long = "word ".repeat(100);

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import type { ParsedMail } from "mailparser";
+import { buildEmailMessage, stripHtml, truncateBody, normalizeAddressList } from "./imap-helpers.js";
+
+/** Minimal ParsedMail factory — only the fields buildEmailMessage reads. */
+function parsed(over: Partial<ParsedMail> & { headerEntries?: [string, unknown][] } = {}): ParsedMail {
+  const headers = new Map<string, unknown>(over.headerEntries ?? []);
+  return {
+    from: over.from,
+    to: over.to,
+    cc: over.cc,
+    subject: over.subject,
+    text: over.text,
+    html: over.html,
+    date: over.date,
+    attachments: over.attachments ?? [],
+    headers,
+    inReplyTo: over.inReplyTo,
+    references: over.references,
+    messageId: over.messageId,
+  } as unknown as ParsedMail;
+}
+const addr = (text: string) => ({ text } as never);
+const msg = (uid: number, flags: string[] = []) => ({ uid, flags: new Set(flags) });
+
+describe("buildEmailMessage", () => {
+  it("maps the core fields from a parsed text message", () => {
+    const e = buildEmailMessage(
+      msg(42, ["\\Seen", "\\Flagged"]),
+      parsed({
+        from: addr("Alice <a@x.com>"),
+        to: addr("b@x.com"),
+        subject: "Hi",
+        text: "hello world",
+        date: new Date("2026-06-03T12:00:00Z"),
+        messageId: "<m1@x.com>",
+      }),
+      "Folders/Work",
+    );
+    expect(e.id).toBe("42");
+    expect(e.from).toBe("Alice <a@x.com>");
+    expect(e.to).toEqual(["b@x.com"]);
+    expect(e.subject).toBe("Hi");
+    expect(e.body).toBe("hello world");
+    expect(e.bodyPreview).toBe("hello world");
+    expect(e.folder).toBe("Folders/Work");
+    expect(e.isRead).toBe(true);
+    expect(e.isStarred).toBe(true);
+    expect(e.isHtml).toBe(false);
+    expect(e.messageId).toBe("<m1@x.com>");
+    expect(e.date).toEqual(new Date("2026-06-03T12:00:00Z"));
+  });
+
+  it("defaults missing fields safely", () => {
+    const e = buildEmailMessage(msg(1), parsed({}), "INBOX");
+    expect(e.from).toBe("");
+    expect(e.to).toEqual([]);
+    expect(e.cc).toEqual([]);
+    expect(e.subject).toBe("(No Subject)");
+    expect(e.body).toBe("");
+    expect(e.isRead).toBe(false);
+    expect(e.isStarred).toBe(false);
+    expect(e.hasAttachment).toBe(false);
+    expect(e.messageId).toBeUndefined();
+    expect(e.protonId).toBeUndefined();
+    expect(e.date).toBeInstanceOf(Date);
+  });
+
+  it("flattens multiple To/CC header lines (IMAP-007)", () => {
+    const e = buildEmailMessage(
+      msg(2),
+      parsed({ to: [addr("a@x.com"), addr("b@x.com")], cc: [addr("c@x.com")] }),
+      "INBOX",
+    );
+    expect(e.to).toEqual(["a@x.com", "b@x.com"]);
+    expect(e.cc).toEqual(["c@x.com"]);
+  });
+
+  it("HTML body → isHtml, body=html, preview is stripped+truncated", () => {
+    const e = buildEmailMessage(msg(3), parsed({ html: "<p>Hi <b>there</b></p>" }), "INBOX");
+    expect(e.isHtml).toBe(true);
+    expect(e.body).toBe("<p>Hi <b>there</b></p>");
+    expect(e.bodyPreview).toBe("Hi there");
+  });
+
+  it("detects PGP signed/encrypted from content-type", () => {
+    const signed = buildEmailMessage(msg(4), parsed({
+      headerEntries: [["content-type", { value: "multipart/signed; protocol=\"application/pgp-signature\"" }]],
+    }), "INBOX");
+    expect(signed.isSignedPGP).toBe(true);
+    expect(signed.isEncryptedPGP).toBe(false);
+    const enc = buildEmailMessage(msg(5), parsed({
+      headerEntries: [["content-type", { value: "multipart/encrypted; protocol=\"application/pgp-encrypted\"" }]],
+    }), "INBOX");
+    expect(enc.isEncryptedPGP).toBe(true);
+  });
+
+  it("extracts protonId from X-Pm-Internal-Id and trims it", () => {
+    const e = buildEmailMessage(msg(6), parsed({ headerEntries: [["x-pm-internal-id", "  pm_abc123  "]] }), "INBOX");
+    expect(e.protonId).toBe("pm_abc123");
+  });
+
+  it("maps attachments + hasAttachment, and reads answered/forwarded flags", () => {
+    const e = buildEmailMessage(
+      msg(7, ["\\Answered", "\\Forward"]),
+      parsed({ attachments: [{ filename: "a.pdf", contentType: "application/pdf", size: 10, content: Buffer.from("x"), cid: "c1" } as never] }),
+      "INBOX",
+    );
+    expect(e.hasAttachment).toBe(true);
+    expect(e.attachments?.[0]).toMatchObject({ filename: "a.pdf", contentType: "application/pdf", size: 10, contentId: "c1" });
+    expect(e.isAnswered).toBe(true);
+    expect(e.isForwarded).toBe(true);
+  });
+});
+
+describe("stripHtml / truncateBody / normalizeAddressList (moved, unchanged)", () => {
+  it("stripHtml decodes entities BEFORE stripping tags (PARSE-008)", () => {
+    expect(stripHtml("a &lt;script&gt;alert(1)&lt;/script&gt; b")).toBe("a b");
+    expect(stripHtml("<!-- secret: pw -->visible")).toBe("visible");
+  });
+  it("truncateBody breaks on a word boundary near the cap", () => {
+    expect(truncateBody("short")).toBe("short");
+    const long = "word ".repeat(100);
+    const t = truncateBody(long, 20);
+    expect(t.endsWith("...")).toBe(true);
+    expect(t.length).toBeLessThanOrEqual(23);
+  });
+  it("normalizeAddressList handles single, array, and undefined", () => {
+    expect(normalizeAddressList(undefined)).toEqual([]);
+    expect(normalizeAddressList(addr("a@x.com"))).toEqual(["a@x.com"]);
+    expect(normalizeAddressList([addr("a@x.com"), addr("b@x.com")])).toEqual(["a@x.com", "b@x.com"]);
+  });
+});

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -176,3 +176,36 @@ describe("verifyRelocatedMessages", () => {
     expect(r.failed).toBe(1);
   });
 });
+
+import { buildSearchCriteria, sanitizeImapSearchValue } from "./imap-helpers.js";
+import type { SearchEmailOptions } from "../types/index.js";
+
+describe("buildSearchCriteria", () => {
+  it("maps fields + sanitizes injection chars", () => {
+    const c = buildSearchCriteria({ from: 'a"\\\r\nx', subject: "hi", isRead: false, isStarred: true } as SearchEmailOptions);
+    expect(c.from).toBe("ax");          // quote/backslash/CR/LF stripped
+    expect(c.subject).toBe("hi");
+    expect(c.seen).toBe(false);
+    expect(c.flagged).toBe(true);
+  });
+  it("maps dates, size, flag, sent predicates", () => {
+    const sb = new Date("2026-06-01");
+    const c = buildSearchCriteria({ dateFrom: "2026-05-01", larger: 1000, answered: true, isDraft: false, sentBefore: sb } as SearchEmailOptions);
+    expect(c.since).toBeInstanceOf(Date);
+    expect(c.larger).toBe(1000);
+    expect(c.answered).toBe(true);
+    expect(c.draft).toBe(false);
+    expect(c.sentBefore).toBe(sb);
+  });
+  it("enforces the header field-name grammar (IMAP-004)", () => {
+    expect(() => buildSearchCriteria({ header: { field: "X bad", value: "v" } } as SearchEmailOptions)).toThrow(/Invalid header field/);
+    const c = buildSearchCriteria({ header: { field: "X-Custom", value: 'v"x' } } as SearchEmailOptions);
+    expect(c.header).toEqual({ "X-Custom": "vx" });
+  });
+  it("ignores an invalid date silently", () => {
+    expect(buildSearchCriteria({ dateFrom: "not-a-date" } as SearchEmailOptions).since).toBeUndefined();
+  });
+  it("sanitizeImapSearchValue strips quote/backslash/CRLF/NUL", () => {
+    expect(sanitizeImapSearchValue('a"b\\c\r\nd\x00e')).toBe("abcde");
+  });
+});

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -123,8 +123,10 @@ export function stripHtml(html: string): string {
       .replace(/&amp;/g, "&");
 
   return decodeEntities(html.replace(/<!--[\s\S]*?-->/g, " "))
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, " ")
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, " ")
+    // Closing tags may carry trailing whitespace (`</script >`) per the HTML
+    // tokenizer — match `<\/script\s*>` so the block strip can't be bypassed (CodeQL).
+    .replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
+    .replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
     .replace(/<[^>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim();

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure IMAP projection/formatting helpers — the shared backbone the IMAP
+ * service builds on. Kept dependency-free (no `this`, no IMAP client, no I/O) so
+ * they're trivially unit-testable and reusable across getEmailById /
+ * searchSingleFolder / get_thread without duplicating the parse→shape mapping.
+ */
+
+import type { ParsedMail, Attachment, AddressObject } from "mailparser";
+import type { EmailMessage } from "../types/index.js";
+
+/** Strip HTML to plain text. Decodes entities BEFORE stripping tags (PARSE-008)
+ *  so encoded `&lt;script&gt;…` can't survive as literal markup, and drops HTML
+ *  comments up front (PARSE-009) so their inner text doesn't leak as prose. */
+export function stripHtml(html: string): string {
+  if (!html) return "";
+  const decodeEntities = (s: string): string =>
+    s
+      .replace(/&nbsp;/g, " ")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&#x27;/gi, "'")
+      .replace(/&#(\d{1,7});/g, (_m, d) => String.fromCodePoint(Number(d)))
+      .replace(/&#x([0-9a-f]{1,6});/gi, (_m, h) => String.fromCodePoint(parseInt(h, 16)))
+      .replace(/&amp;/g, "&");
+
+  return decodeEntities(html.replace(/<!--[\s\S]*?-->/g, " "))
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Truncate a body to `maxLength`, breaking on a word boundary when close. */
+export function truncateBody(body: string, maxLength = 300): string {
+  if (!body) return "";
+  const cleaned = body.replace(/\s+/g, " ").trim();
+  if (cleaned.length <= maxLength) return cleaned;
+  const truncated = cleaned.substring(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > maxLength * 0.8) return truncated.substring(0, lastSpace) + "...";
+  return truncated + "...";
+}
+
+/** Flatten a mailparser address field into display strings. IMAP-007: the field
+ *  can be a single AddressObject OR an array (multiple `To:` header lines, legal
+ *  per RFC 5322 §3.6.3 and emitted by Proton on bridged forwards). */
+export function normalizeAddressList(
+  field: AddressObject | AddressObject[] | undefined,
+): string[] {
+  if (!field) return [];
+  const objs = Array.isArray(field) ? field : [field];
+  const result: string[] = [];
+  for (const obj of objs) if (obj?.text) result.push(obj.text);
+  return result;
+}
+
+/** The minimal shape of an imapflow fetch result `buildEmailMessage` reads. */
+export interface FetchedMessageShape {
+  uid: number;
+  flags?: Set<string>;
+}
+
+/**
+ * Project a fully-parsed message (mailparser `ParsedMail` + the imapflow fetch
+ * envelope's uid/flags) into the canonical `EmailMessage`. This is the single
+ * source of truth for the parse→shape mapping used by getEmailById and
+ * searchSingleFolder (was duplicated verbatim in both).
+ */
+export function buildEmailMessage(
+  message: FetchedMessageShape,
+  parsed: ParsedMail,
+  folderPath: string,
+): EmailMessage {
+  const fullBody = parsed.text || parsed.html || "";
+  const plainBody = parsed.text || stripHtml(parsed.html || "");
+
+  const contentType = parsed.headers?.get("content-type");
+  const ctStr =
+    typeof contentType === "string"
+      ? contentType
+      : ((contentType as unknown as { value?: string } | null)?.value ?? "");
+
+  const pmId = parsed.headers?.get("x-pm-internal-id");
+
+  return {
+    id: message.uid.toString(),
+    from: parsed.from?.text || "",
+    to: normalizeAddressList(parsed.to),
+    cc: normalizeAddressList(parsed.cc),
+    subject: parsed.subject || "(No Subject)",
+    body: fullBody,
+    bodyPreview: truncateBody(plainBody),
+    isHtml: !!parsed.html,
+    date: parsed.date || new Date(),
+    folder: folderPath,
+    isRead: message.flags?.has("\\Seen") || false,
+    isStarred: message.flags?.has("\\Flagged") || false,
+    hasAttachment: (parsed.attachments?.length || 0) > 0,
+    attachments: parsed.attachments?.map((att: Attachment) => ({
+      filename: att.filename || "unnamed",
+      contentType: att.contentType,
+      size: att.size,
+      content: att.content,
+      contentId: att.cid,
+    })),
+    headers: parsed.headers
+      ? Object.fromEntries(
+          Array.from(parsed.headers.entries()).map(([k, v]) => [
+            k,
+            Array.isArray(v) ? v.join(", ") : String(v),
+          ]),
+        )
+      : undefined,
+    inReplyTo: parsed.inReplyTo,
+    references: parsed.references,
+    isAnswered: message.flags?.has("\\Answered") ?? false,
+    isForwarded: message.flags?.has("\\Forward") ?? false,
+    isSignedPGP: ctStr.includes("multipart/signed") && ctStr.includes("application/pgp-signature"),
+    isEncryptedPGP: ctStr.includes("multipart/encrypted") && ctStr.includes("application/pgp-encrypted"),
+    protonId: typeof pmId === "string" ? pmId.trim() : undefined,
+    messageId: parsed.messageId || undefined,
+  };
+}

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -8,6 +8,53 @@
 import type { ParsedMail, Attachment, AddressObject } from "mailparser";
 import type { EmailMessage } from "../types/index.js";
 
+/** Per-source-folder record of a bulk move/copy: which UIDs the server accepted,
+ *  their captured Message-IDs, the UIDs UIDPLUS confirmed relocated, and whether
+ *  the server returned a COPYUID map at all. */
+export interface RelocationJob {
+  accepted: string[];
+  midMap: Map<string, string>;
+  relocated: Set<string>;
+  uidplus: boolean;
+  /** Source folder (move only) — woven into the failure message. */
+  folder?: string;
+}
+
+/**
+ * Honest verified-landing check for bulk move/copy. A relocation counts as
+ * success ONLY if the server's UIDPLUS COPYUID map confirmed it, or (no UIDPLUS)
+ * the message's Message-ID is found in the target. Anything else is a failure —
+ * never an assumed success — which is what catches the silent All-Mail-union
+ * no-op (Bug A). Was duplicated verbatim in bulkMoveEmails + bulkCopyToFolder.
+ */
+export async function verifyRelocatedMessages(
+  jobs: RelocationJob[],
+  targetFolder: string,
+  findMessageIdsInFolder: (folder: string, mids: string[]) => Promise<Set<string>>,
+  makeError: (uid: string, sourceFolder: string | undefined) => string,
+): Promise<{ success: number; failed: number; errors: string[] }> {
+  const out = { success: 0, failed: 0, errors: [] as string[] };
+  for (const job of jobs) {
+    if (job.accepted.length === 0) continue;
+    let found = new Set<string>();
+    if (!job.uidplus) {
+      const mids = job.accepted
+        .filter((u) => !job.relocated.has(u))
+        .map((u) => job.midMap.get(u))
+        .filter((m): m is string => !!m);
+      if (mids.length > 0) {
+        try { found = await findMessageIdsInFolder(targetFolder, mids); } catch { /* unverifiable → failure below */ }
+      }
+    }
+    for (const uid of job.accepted) {
+      const mid = job.midMap.get(uid);
+      if (job.relocated.has(uid) || (!job.uidplus && mid && found.has(mid))) out.success++;
+      else { out.failed++; out.errors.push(makeError(uid, job.folder)); }
+    }
+  }
+  return out;
+}
+
 /** Strip HTML to plain text. Decodes entities BEFORE stripping tags (PARSE-008)
  *  so encoded `&lt;script&gt;…` can't survive as literal markup, and drops HTML
  *  comments up front (PARSE-009) so their inner text doesn't leak as prose. */

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -6,7 +6,57 @@
  */
 
 import type { ParsedMail, Attachment, AddressObject } from "mailparser";
-import type { EmailMessage } from "../types/index.js";
+import type { SearchObject } from "imapflow";
+import type { EmailMessage, SearchEmailOptions } from "../types/index.js";
+
+/** Strip IMAP search-unsafe characters before they reach the SEARCH command:
+ *  quote/backslash (would break imapflow's quoted strings) and CR/LF/NUL (could
+ *  smuggle a command line into the IMAP stream — VALID-002 / IMAP-004). */
+export function sanitizeImapSearchValue(s: string): string {
+  return s.replace(/["\\\r\n\x00]/g, "");
+}
+
+/**
+ * Map a validated SearchEmailOptions to an imapflow SearchObject — all values
+ * sanitized, the header field-name held to the RFC 5322 grammar. Pure; throws
+ * only on an invalid header field name. (Was inlined in searchSingleFolder.)
+ */
+export function buildSearchCriteria(options: SearchEmailOptions): SearchObject {
+  const c: SearchObject = {};
+  if (options.from) c.from = sanitizeImapSearchValue(options.from);
+  if (options.to) c.to = sanitizeImapSearchValue(options.to);
+  if (options.subject) c.subject = sanitizeImapSearchValue(options.subject);
+  if (options.dateFrom) {
+    const d = new Date(options.dateFrom);
+    if (!isNaN(d.getTime())) c.since = d;
+  }
+  if (options.dateTo) {
+    const d = new Date(options.dateTo);
+    if (!isNaN(d.getTime())) c.before = d;
+  }
+  // imapflow uses a single boolean: `seen:false` = unseen, etc.
+  if (options.isRead !== undefined) c.seen = options.isRead;
+  if (options.isStarred !== undefined) c.flagged = options.isStarred;
+  if (options.body) c.body = sanitizeImapSearchValue(options.body);
+  if (options.text) c.text = sanitizeImapSearchValue(options.text);
+  if (options.bcc) c.bcc = sanitizeImapSearchValue(options.bcc);
+  // IMAP-004: sanitize the header value AND enforce the field-name grammar so a
+  // raw '"' or malformed field can't break the `SEARCH HEADER <field> <value>` syntax.
+  if (options.header) {
+    const field = options.header.field;
+    if (!/^[A-Za-z][A-Za-z0-9-]*$/.test(field)) {
+      throw new Error(`Invalid header field name: ${JSON.stringify(field)}`);
+    }
+    c.header = { [field]: sanitizeImapSearchValue(options.header.value) };
+  }
+  if (options.answered !== undefined) c.answered = options.answered;
+  if (options.isDraft !== undefined) c.draft = options.isDraft;
+  if (options.larger !== undefined) c.larger = options.larger;
+  if (options.smaller !== undefined) c.smaller = options.smaller;
+  if (options.sentBefore) c.sentBefore = options.sentBefore;
+  if (options.sentSince) c.sentSince = options.sentSince;
+  return c;
+}
 
 /** Per-source-folder record of a bulk move/copy: which UIDs the server accepted,
  *  their captured Message-IDs, the UIDs UIDPLUS confirmed relocated, and whether

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -123,10 +123,11 @@ export function stripHtml(html: string): string {
       .replace(/&amp;/g, "&");
 
   return decodeEntities(html.replace(/<!--[\s\S]*?-->/g, " "))
-    // Closing tags may carry trailing whitespace (`</script >`) per the HTML
-    // tokenizer — match `<\/script\s*>` so the block strip can't be bypassed (CodeQL).
-    .replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, " ")
-    .replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, " ")
+    // Closing tags can carry arbitrary junk before `>` (`</script foo>`,
+    // `</script\n bar>`) per the HTML tokenizer — match `<\/script[^>]*>` so the
+    // block strip can't be bypassed (CodeQL js/bad-tag-filter).
+    .replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ")
+    .replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ")
     .replace(/<[^>]+>/g, " ")
     .replace(/\s+/g, " ")
     .trim();

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -2140,6 +2140,19 @@ describe("v3.0.44 sibling-path fixes (IMAP-003 / IMAP-006 / IMAP-008 / IMAP-009)
     expect(results.errors[0]).toMatch(/Email 99 not found in any folder/);
   });
 
+  it("bulkMarkRead surfaces discovery transport errors distinctly from ID-format errors", async () => {
+    const svc = new SimpleIMAPService();
+    connectSvc(svc);
+    vi.spyOn(svc, "getEmailById").mockRejectedValue(new Error("IMAP FETCH failed"));
+
+    const results = await svc.bulkMarkRead(["55"], true);
+
+    expect(results.failed).toBe(1);
+    // A valid-format ID that fails during discovery must NOT be mislabeled "Invalid email ID".
+    expect(results.errors[0]).toMatch(/Failed to locate email 55/);
+    expect(results.errors[0]).not.toMatch(/Invalid email ID/);
+  });
+
   it("bulkStar without sourceFolder discovers folder via getEmailById", async () => {
     const svc = new SimpleIMAPService();
     const client = connectSvc(svc);

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -14,10 +14,7 @@ import { EmailMessage, EmailFolder, SearchEmailOptions, SaveDraftOptions } from 
 import { logger } from '../utils/logger.js';
 import {
   validateImapPath,
-  attachmentByteSize,
-  MAX_ATTACHMENT_COUNT,
-  MAX_ATTACHMENT_BYTES,
-  MAX_TOTAL_ATTACHMENT_BYTES,
+  validateAttachmentLimits,
 } from '../utils/helpers.js';
 import { buildBridgeTlsConfig } from './bridge-tls.js';
 import { classifyError, ConnectionStateError } from '../utils/error-classify.js';
@@ -1633,26 +1630,11 @@ export class SimpleIMAPService {
       };
 
       if (options.attachments && options.attachments.length > 0) {
-        // VALID-005: enforce the SAME count/size caps as the SMTP send path
-        // (smtp-service.ts). saveDraft previously mirrored only the sanitisation,
-        // so an unbounded base64 payload could OOM the process before append.
-        if (options.attachments.length > MAX_ATTACHMENT_COUNT) {
-          return { success: false, error: `Too many attachments: ${options.attachments.length} supplied, max ${MAX_ATTACHMENT_COUNT} allowed.` };
-        }
-        let totalBytes = 0;
-        for (const att of options.attachments) {
-          const bytes = attachmentByteSize(att.content);
-          if (bytes === null) {
-            return { success: false, error: `Attachment '${att.filename ?? "unnamed"}': content must be a Buffer or base64 string.` };
-          }
-          if (bytes > MAX_ATTACHMENT_BYTES) {
-            return { success: false, error: `Attachment '${att.filename ?? "unnamed"}' is too large: ${Math.round(bytes / 1024 / 1024)}MB exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per-file limit.` };
-          }
-          totalBytes += bytes;
-          if (totalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
-            return { success: false, error: `Total attachment size exceeds the ${MAX_TOTAL_ATTACHMENT_BYTES / 1024 / 1024}MB limit.` };
-          }
-        }
+        // VALID-005/006: enforce the SAME count/size caps as the SMTP send path
+        // (shared validateAttachmentLimits) — an unbounded base64 payload could
+        // otherwise OOM the process before append.
+        const limitErr = validateAttachmentLimits(options.attachments);
+        if (limitErr) return { success: false, error: limitErr };
 
         // Mirror the sanitization performed in smtp-service.ts sendEmail() to prevent
         // MIME header injection via crafted attachment filenames or content-type values.

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -3,8 +3,6 @@
  */
 
 import { ImapFlow, type SearchObject } from 'imapflow';
-import { readFileSync, statSync } from 'fs';
-import { join as pathJoin } from 'path';
 import type { ParsedMail, Attachment, AddressObject } from 'mailparser';
 import { simpleParser } from 'mailparser';
 import { buildEmailMessage, verifyRelocatedMessages, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
@@ -21,7 +19,7 @@ import {
   MAX_ATTACHMENT_BYTES,
   MAX_TOTAL_ATTACHMENT_BYTES,
 } from '../utils/helpers.js';
-import { buildBridgeTlsOptions, readPinnedBridgeCert } from './bridge-tls.js';
+import { buildBridgeTlsConfig } from './bridge-tls.js';
 import { classifyError, ConnectionStateError } from '../utils/error-classify.js';
 import { tracer, type SpanTags } from '../utils/tracer.js';
 import { BRIDGE_MIN_VERSION } from '../config/schema.js';
@@ -618,61 +616,12 @@ export class SimpleIMAPService {
       const allowInsecure = allowInsecureBridge
         || process.env.MAILPOUCH_INSECURE_BRIDGE === '1';
 
-      // Build TLS options
-      let tlsOptions: Record<string, unknown> | undefined;
-      if (isLocalhost) {
-        if (bridgeCertPath) {
-          // If a directory was given, look for cert.pem inside it
-          let resolvedCertPath = bridgeCertPath;
-          try {
-            if (statSync(bridgeCertPath).isDirectory()) {
-              resolvedCertPath = pathJoin(bridgeCertPath, 'cert.pem');
-              logger.info(`IMAP: Directory given for cert path — resolved to ${resolvedCertPath}`, 'IMAPService');
-            }
-          } catch { /* stat failed — let readFileSync produce the real error below */ }
-          try {
-            const bridgeCert = readPinnedBridgeCert(resolvedCertPath);
-            tlsOptions = buildBridgeTlsOptions(bridgeCert);
-            logger.info(`IMAP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, 'IMAPService');
-          } catch (err) {
-            if (!allowInsecure) {
-              throw new Error(
-                `IMAP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
-                `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
-                `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
-                `Underlying error: ${(err as Error).message}`
-              );
-            }
-            logger.warn(
-              `IMAP: Failed to load Bridge cert at "${resolvedCertPath}" — running with TLS validation DISABLED (allowInsecureBridge is set). ` +
-              `Export a fresh cert from Bridge → Help → Export TLS Certificate and update Settings → Connection to re-secure.`,
-              'IMAPService',
-              err
-            );
-            tlsOptions = { rejectUnauthorized: false, minVersion: 'TLSv1.2' };
-            this.insecureTls = true;
-          }
-        } else {
-          if (!allowInsecure) {
-            throw new Error(
-              'IMAP: No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate ' +
-              "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
-              'disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1.'
-            );
-          }
-          logger.warn(
-            'IMAP: No Bridge certificate configured and allowInsecureBridge is set — ' +
-            'TLS certificate validation DISABLED for localhost. Export the cert from Bridge → Help → ' +
-            'Export TLS Certificate and clear the insecure flag to re-secure.',
-            'IMAPService'
-          );
-          tlsOptions = { rejectUnauthorized: false, minVersion: 'TLSv1.2' };
-          this.insecureTls = true;
-        }
-      } else {
-        // Non-localhost: full certificate validation required
-        tlsOptions = { minVersion: 'TLSv1.2' };
-      }
+      // TLS options (cert pinning + insecure fallback) — the same decision the
+      // settings connection-check uses, shared via bridge-tls.ts.
+      const tls = buildBridgeTlsConfig(host, bridgeCertPath, allowInsecure);
+      for (const l of tls.logs) logger[l.level](`IMAP: ${l.msg}`, 'IMAPService');
+      this.insecureTls = tls.insecure;
+      const tlsOptions: Record<string, unknown> | undefined = tls.tlsOptions;
 
       // Use caller-supplied secure flag if provided; otherwise default to false for
       // localhost (Bridge uses STARTTLS on 1143) and true for non-localhost connections.
@@ -3013,51 +2962,20 @@ export class SimpleIMAPService {
     const isLocalhost = cfg.host === 'localhost' || cfg.host === '127.0.0.1';
     const allowInsecure = cfg.allowInsecureBridge
       || process.env.MAILPOUCH_INSECURE_BRIDGE === '1';
+    // Same TLS decision as connect(), but IDLE ABORTS (rather than throwing)
+    // when a secure config can't be built — it must never silently downgrade.
     let tlsOptions: Record<string, unknown> | undefined;
-
-    if (isLocalhost) {
-      if (cfg.bridgeCertPath) {
-        try {
-          let certPath = cfg.bridgeCertPath;
-          try { if (statSync(certPath).isDirectory()) certPath = pathJoin(certPath, 'cert.pem'); } catch {}
-          const cert = readPinnedBridgeCert(certPath);
-          tlsOptions = buildBridgeTlsOptions(cert);
-        } catch (err) {
-          if (!allowInsecure) {
-            logger.error(
-              `IDLE: Bridge cert at "${cfg.bridgeCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
-              `Refusing to start IDLE with TLS validation disabled. Fix the cert path or set allowInsecureBridge: true.`,
-              'IMAPService',
-              err
-            );
-            this.idleActive = false;
-            return;
-          }
-          logger.warn(
-            `IDLE: Failed to load Bridge cert at "${cfg.bridgeCertPath}" — running with TLS validation DISABLED (allowInsecureBridge is set).`,
-            'IMAPService',
-            err
-          );
-          tlsOptions = { rejectUnauthorized: false, minVersion: 'TLSv1.2' };
-        }
-      } else {
-        if (!allowInsecure) {
-          logger.error(
-            'IDLE: No Bridge certificate configured. Refusing to start IDLE with TLS validation disabled. ' +
-            "Set 'bridgeCertPath' or set allowInsecureBridge: true to opt into the legacy behavior.",
-            'IMAPService'
-          );
-          this.idleActive = false;
-          return;
-        }
-        logger.warn(
-          'IDLE: No Bridge certificate configured and allowInsecureBridge is set — TLS certificate validation DISABLED for localhost.',
-          'IMAPService'
-        );
-        tlsOptions = { rejectUnauthorized: false, minVersion: 'TLSv1.2' };
-      }
-    } else {
-      tlsOptions = { minVersion: 'TLSv1.2' };
+    try {
+      const tls = buildBridgeTlsConfig(cfg.host, cfg.bridgeCertPath, allowInsecure);
+      for (const l of tls.logs) logger[l.level](`IDLE: ${l.msg}`, 'IMAPService');
+      tlsOptions = tls.tlsOptions;
+    } catch (err) {
+      logger.error(
+        `IDLE: ${(err as Error).message} Refusing to start IDLE with TLS validation disabled.`,
+        'IMAPService', err,
+      );
+      this.idleActive = false;
+      return;
     }
 
     // Cluster-2 connection leak: a failed connect()/idle() must NOT leave its

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2190,6 +2190,52 @@ export class SimpleIMAPService {
    * determine which UIDs actually exist in the folder. UIDs that don't exist
    * are reported in `results.failed` rather than silently counted as success.
    */
+  /**
+   * Group email UIDs by their source folder for a bulk operation. With
+   * `sourceFolder`, all UIDs are assumed to live there (no discovery). Otherwise
+   * each UID's folder is resolved from the cache, else via getEmailById —
+   * IMAP-003: an unresolved UID is an explicit failure, NEVER a silent fall-back
+   * to INBOX (which recreated the v3.0.41 false-success class). Invalid and
+   * not-found UIDs are recorded in `results`. Was duplicated in all five bulk
+   * methods (move/copy/delete/markRead/star).
+   */
+  private async groupEmailsByFolder(
+    emailIds: string[],
+    sourceFolder: string | undefined,
+    results: { failed: number; errors: string[] },
+  ): Promise<Map<string, string[]>> {
+    const grouped = new Map<string, string[]>();
+    if (sourceFolder) {
+      const validIds: string[] = [];
+      for (const id of emailIds) {
+        try { this.validateEmailId(id); validIds.push(id); }
+        catch (e: unknown) { results.failed++; results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`); }
+      }
+      if (validIds.length > 0) grouped.set(sourceFolder, validIds);
+      return grouped;
+    }
+    for (const id of emailIds) {
+      try {
+        this.validateEmailId(id);
+        const cached = this.findCacheEntryByUid(id);
+        let folder: string;
+        if (cached) {
+          folder = cached.folder;
+        } else {
+          const discovered = await this.getEmailById(id);
+          if (!discovered) { results.failed++; results.errors.push(`Email ${id} not found in any folder`); continue; }
+          folder = discovered.folder;
+        }
+        if (!grouped.has(folder)) grouped.set(folder, []);
+        grouped.get(folder)!.push(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+    return grouped;
+  }
+
   async bulkMoveEmails(emailIds: string[], targetFolder: string, sourceFolder?: string): Promise<{ success: number; failed: number; errors: string[] }> {
     this.validateFolderName(targetFolder);
     if (sourceFolder !== undefined) this.validateFolderName(sourceFolder);
@@ -2208,45 +2254,7 @@ export class SimpleIMAPService {
       errors: [] as string[]
     };
 
-    const emailsByFolder = new Map<string, string[]>();
-
-    if (sourceFolder) {
-      const validIds: string[] = [];
-      for (const emailId of emailIds) {
-        try {
-          this.validateEmailId(emailId);
-          validIds.push(emailId);
-        } catch (error: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${emailId}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-      if (validIds.length > 0) emailsByFolder.set(sourceFolder, validIds);
-    } else {
-      for (const emailId of emailIds) {
-        try {
-          this.validateEmailId(emailId);
-          const cachedEmail = this.findCacheEntryByUid(emailId);
-          let folder: string;
-          if (cachedEmail) {
-            folder = cachedEmail.folder;
-          } else {
-            const discovered = await this.getEmailById(emailId);
-            if (!discovered) {
-              results.failed++;
-              results.errors.push(`Email ${emailId} not found in any folder`);
-              continue;
-            }
-            folder = discovered.folder;
-          }
-          if (!emailsByFolder.has(folder)) emailsByFolder.set(folder, []);
-          emailsByFolder.get(folder)!.push(emailId);
-        } catch (error: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${emailId}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-    }
+    const emailsByFolder = await this.groupEmailsByFolder(emailIds, sourceFolder, results);
 
     // Capture Message-IDs + which UIDs the MOVE verb accepted per source folder,
     // then verify (below) the messages actually landed in the target. A move the
@@ -2446,45 +2454,7 @@ export class SimpleIMAPService {
       errors: [] as string[]
     };
 
-    const emailsByFolder2 = new Map<string, string[]>();
-
-    if (sourceFolder) {
-      const validIds: string[] = [];
-      for (const emailId of emailIds) {
-        try {
-          this.validateEmailId(emailId);
-          validIds.push(emailId);
-        } catch (error: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${emailId}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-      if (validIds.length > 0) emailsByFolder2.set(sourceFolder, validIds);
-    } else {
-      for (const emailId of emailIds) {
-        try {
-          this.validateEmailId(emailId);
-          const cachedEmail = this.findCacheEntryByUid(emailId);
-          let folder: string;
-          if (cachedEmail) {
-            folder = cachedEmail.folder;
-          } else {
-            const discovered = await this.getEmailById(emailId);
-            if (!discovered) {
-              results.failed++;
-              results.errors.push(`Email ${emailId} not found in any folder`);
-              continue;
-            }
-            folder = discovered.folder;
-          }
-          if (!emailsByFolder2.has(folder)) emailsByFolder2.set(folder, []);
-          emailsByFolder2.get(folder)!.push(emailId);
-        } catch (error: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${emailId}: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-    }
+    const emailsByFolder2 = await this.groupEmailsByFolder(emailIds, sourceFolder, results);
 
     const trash = await this.resolveTrashPath();
 
@@ -2524,49 +2494,7 @@ export class SimpleIMAPService {
     if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
 
     const results = { success: 0, failed: 0, errors: [] as string[] };
-    const grouped = new Map<string, string[]>();
-    if (sourceFolder) {
-      const validIds: string[] = [];
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          validIds.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-      if (validIds.length > 0) grouped.set(sourceFolder, validIds);
-    } else {
-      // No explicit sourceFolder — discover per UID. IMAP-003 from the
-      // 2026-05-28 audit: this used to fall back to 'INBOX' on cache miss,
-      // recreating the v3.0.41 false-success class. Now mirrors the
-      // bulkMoveEmails pattern: cache lookup, then full discovery via
-      // getEmailById, then explicit failure if still not found.
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          const cached = this.findCacheEntryByUid(id);
-          let folder: string;
-          if (cached) {
-            folder = cached.folder;
-          } else {
-            const discovered = await this.getEmailById(id);
-            if (!discovered) {
-              results.failed++;
-              results.errors.push(`Email ${id} not found in any folder`);
-              continue;
-            }
-            folder = discovered.folder;
-          }
-          if (!grouped.has(folder)) grouped.set(folder, []);
-          grouped.get(folder)!.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-    }
+    const grouped = await this.groupEmailsByFolder(emailIds, sourceFolder, results);
 
     for (const [folder, ids] of grouped.entries()) {
       const lock = await this.client.getMailboxLock(folder);
@@ -2631,45 +2559,7 @@ export class SimpleIMAPService {
     if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
 
     const results = { success: 0, failed: 0, errors: [] as string[] };
-    const grouped = new Map<string, string[]>();
-    if (sourceFolder) {
-      const validIds: string[] = [];
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          validIds.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-      if (validIds.length > 0) grouped.set(sourceFolder, validIds);
-    } else {
-      // No sourceFolder — discover per UID (IMAP-003 from 2026-05-28 audit).
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          const cached = this.findCacheEntryByUid(id);
-          let folder: string;
-          if (cached) {
-            folder = cached.folder;
-          } else {
-            const discovered = await this.getEmailById(id);
-            if (!discovered) {
-              results.failed++;
-              results.errors.push(`Email ${id} not found in any folder`);
-              continue;
-            }
-            folder = discovered.folder;
-          }
-          if (!grouped.has(folder)) grouped.set(folder, []);
-          grouped.get(folder)!.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-    }
+    const grouped = await this.groupEmailsByFolder(emailIds, sourceFolder, results);
 
     for (const [folder, ids] of grouped.entries()) {
       const lock = await this.client.getMailboxLock(folder);
@@ -2735,45 +2625,7 @@ export class SimpleIMAPService {
     if (!this.client || !this.isConnected) throw new Error('IMAP client not connected');
 
     const results = { success: 0, failed: 0, errors: [] as string[] };
-    const grouped = new Map<string, string[]>();
-    if (sourceFolder) {
-      const validIds: string[] = [];
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          validIds.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-      if (validIds.length > 0) grouped.set(sourceFolder, validIds);
-    } else {
-      // No sourceFolder — discover per UID (IMAP-003 from 2026-05-28 audit).
-      for (const id of emailIds) {
-        try {
-          this.validateEmailId(id);
-          const cached = this.findCacheEntryByUid(id);
-          let folder: string;
-          if (cached) {
-            folder = cached.folder;
-          } else {
-            const discovered = await this.getEmailById(id);
-            if (!discovered) {
-              results.failed++;
-              results.errors.push(`Email ${id} not found in any folder`);
-              continue;
-            }
-            folder = discovered.folder;
-          }
-          if (!grouped.has(folder)) grouped.set(folder, []);
-          grouped.get(folder)!.push(id);
-        } catch (e: unknown) {
-          results.failed++;
-          results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
-        }
-      }
-    }
+    const grouped = await this.groupEmailsByFolder(emailIds, sourceFolder, results);
 
     // Per source folder: pre-flight, capture Message-IDs, issue the copy. We do
     // NOT count success here — only which UIDs the COPY verb accepted. Whether

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -7,7 +7,7 @@ import { readFileSync, statSync } from 'fs';
 import { join as pathJoin } from 'path';
 import type { ParsedMail, Attachment, AddressObject } from 'mailparser';
 import { simpleParser } from 'mailparser';
-import { buildEmailMessage, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
+import { buildEmailMessage, verifyRelocatedMessages, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
 // Re-export the pure helpers from their original home so existing importers
 // (index.ts, tests) keep working after the move to imap-helpers.ts.
 export { stripHtml, normalizeAddressList };
@@ -2322,25 +2322,14 @@ export class SimpleIMAPService {
     // Verify each move actually landed in the target. Primary signal: the
     // server's UIDPLUS COPYUID map; Message-ID search only as a no-UIDPLUS
     // fallback. Unverifiable → failure, never an assumed success.
-    for (const job of verifyJobs) {
-      if (job.accepted.length === 0) continue;
-      let found = new Set<string>();
-      if (!job.uidplus) {
-        const mids = job.accepted.filter(u => !job.relocated.has(u)).map(u => job.midMap.get(u)).filter((m): m is string => !!m);
-        if (mids.length > 0) {
-          try { found = await this.findMessageIdsInFolder(targetFolder, mids); } catch { /* unverifiable → failure below */ }
-        }
-      }
-      for (const uid of job.accepted) {
-        const mid = job.midMap.get(uid);
-        if (job.relocated.has(uid) || (!job.uidplus && mid && found.has(mid))) {
-          results.success++;
-        } else {
-          results.failed++;
-          results.errors.push(`Move of UID ${uid} from ${job.folder} to ${targetFolder} was accepted but could not be verified present in the target — likely a no-op from a union mailbox (e.g. All Mail). Pass the message's real source folder.`);
-        }
-      }
-    }
+    const verified = await verifyRelocatedMessages(
+      verifyJobs, targetFolder,
+      (f, mids) => this.findMessageIdsInFolder(f, mids),
+      (uid, src) => `Move of UID ${uid} from ${src} to ${targetFolder} was accepted but could not be verified present in the target — likely a no-op from a union mailbox (e.g. All Mail). Pass the message's real source folder.`,
+    );
+    results.success += verified.success;
+    results.failed += verified.failed;
+    results.errors.push(...verified.errors);
 
     tags.successCount = results.success;
     tags.failCount = results.failed;
@@ -2845,25 +2834,14 @@ export class SimpleIMAPService {
     // search. A copy the server "accepted" but didn't perform (the silent
     // All-Mail no-op) is an honest failure, never a false success — and a
     // message we simply cannot verify is also a failure, not an assumed success.
-    for (const job of verifyJobs) {
-      if (job.accepted.length === 0) continue;
-      let found = new Set<string>();
-      if (!job.uidplus) {
-        const mids = job.accepted.filter(u => !job.relocated.has(u)).map(u => job.midMap.get(u)).filter((m): m is string => !!m);
-        if (mids.length > 0) {
-          try { found = await this.findMessageIdsInFolder(targetFolder, mids); } catch { /* unverifiable → failure below */ }
-        }
-      }
-      for (const uid of job.accepted) {
-        const mid = job.midMap.get(uid);
-        if (job.relocated.has(uid) || (!job.uidplus && mid && found.has(mid))) {
-          results.success++;
-        } else {
-          results.failed++;
-          results.errors.push(`Copy of UID ${uid} to ${targetFolder} was accepted but could not be verified present there — likely a no-op from a union mailbox (e.g. All Mail). Pass the message's real source folder, or verify the target label exists.`);
-        }
-      }
-    }
+    const verified = await verifyRelocatedMessages(
+      verifyJobs, targetFolder,
+      (f, mids) => this.findMessageIdsInFolder(f, mids),
+      (uid) => `Copy of UID ${uid} to ${targetFolder} was accepted but could not be verified present there — likely a no-op from a union mailbox (e.g. All Mail). Pass the message's real source folder, or verify the target label exists.`,
+    );
+    results.success += verified.success;
+    results.failed += verified.failed;
+    results.errors.push(...verified.errors);
     tags.successCount = results.success; tags.failCount = results.failed;
     if (results.success > 0) this.clearFolderCache(); // target counts changed → next get_folders refetches
     logger.info(`Bulk copy completed: ${results.success}/${results.failed}`, 'IMAPService');

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -400,16 +400,23 @@ export class SimpleIMAPService {
    * instead of N serial EXPUNGE round-trips that hold the mailbox lock (and
    * block IDLE) for minutes on Bridge.
    */
-  private async chunkedBatchOp(
-    present: string[],
-    perChunk: (uidSet: string) => Promise<unknown>,
-    perUid: (uid: string) => Promise<unknown>,
-    onSuccess: (uid: string) => void,
-    onFailure: (uid: string, msg: string) => void,
-    opName: string,
-    folder: string,
-    finalize?: () => Promise<unknown>,
-  ): Promise<void> {
+  private async chunkedBatchOp(opts: {
+    /** UIDs known to exist in the locked folder. */
+    present: string[];
+    /** Run the op on a whole comma-joined UID chunk (the fast path). */
+    perChunk: (uidSet: string) => Promise<unknown>;
+    /** Run the op on a single UID (per-UID fallback when a chunk throws). */
+    perUid: (uid: string) => Promise<unknown>;
+    onSuccess: (uid: string) => void;
+    onFailure: (uid: string, msg: string) => void;
+    /** Label for logs (e.g. "Bulk move"). */
+    opName: string;
+    folder: string;
+    /** Optional single trailing step run once, only if a per-UID fallback was
+     *  used (IMAP-016: e.g. one EXPUNGE for all \Deleted-flagged UIDs). */
+    finalize?: () => Promise<unknown>;
+  }): Promise<void> {
+    const { present, perChunk, perUid, onSuccess, onFailure, opName, folder, finalize } = opts;
     const chunks = chunkUidsForWire(present);
     let fallbackUsed = false;
     for (const uidSet of chunks) {
@@ -2312,15 +2319,15 @@ export class SimpleIMAPService {
         const accepted: string[] = [];
         const relocated = new Set<string>(); // source uids the server (UIDPLUS) confirmed moved
         let uidplus = false;
-        await this.chunkedBatchOp(
+        await this.chunkedBatchOp({
           present,
-          async (uidSet) => { uidplus = this.recordRelocatedUids(await this.client!.messageMove(uidSet, targetFolder, { uid: true }), relocated) || uidplus; },
-          async (id) => { uidplus = this.recordRelocatedUids(await this.client!.messageMove(id, targetFolder, { uid: true }), relocated) || uidplus; },
-          (id) => { this.evictCacheEntry(`${folder}:${id}`); accepted.push(id); },
-          (id, msg) => { results.failed++; results.errors.push(`Failed to move email ${id}: ${msg}`); },
-          'Bulk move',
+          perChunk: async (uidSet) => { uidplus = this.recordRelocatedUids(await this.client!.messageMove(uidSet, targetFolder, { uid: true }), relocated) || uidplus; },
+          perUid: async (id) => { uidplus = this.recordRelocatedUids(await this.client!.messageMove(id, targetFolder, { uid: true }), relocated) || uidplus; },
+          onSuccess: (id) => { this.evictCacheEntry(`${folder}:${id}`); accepted.push(id); },
+          onFailure: (id, msg) => { results.failed++; results.errors.push(`Failed to move email ${id}: ${msg}`); },
+          opName: 'Bulk move',
           folder,
-        );
+        });
         verifyJobs.push({ folder, accepted, midMap, relocated, uidplus });
       } finally {
         lock.release();
@@ -2525,22 +2532,22 @@ export class SimpleIMAPService {
         }
         if (present.length === 0) continue;
 
-        await this.chunkedBatchOp(
+        await this.chunkedBatchOp({
           present,
-          (uidSet) => isRead
+          perChunk: (uidSet) => isRead
             ? this.client!.messageFlagsAdd(uidSet, ['\\Seen'], { uid: true })
             : this.client!.messageFlagsRemove(uidSet, ['\\Seen'], { uid: true }),
-          (id) => isRead
+          perUid: (id) => isRead
             ? this.client!.messageFlagsAdd(id, ['\\Seen'], { uid: true })
             : this.client!.messageFlagsRemove(id, ['\\Seen'], { uid: true }),
-          (id) => {
+          onSuccess: (id) => {
             const c = this.getCacheEntry(id, folder); if (c) c.isRead = isRead;
             results.success++;
           },
-          (id, msg) => { results.failed++; results.errors.push(`Failed to mark ${id}: ${msg}`); },
-          'Bulk mark-read',
+          onFailure: (id, msg) => { results.failed++; results.errors.push(`Failed to mark ${id}: ${msg}`); },
+          opName: 'Bulk mark-read',
           folder,
-        );
+        });
       } finally { lock.release(); }
     }
     tags.successCount = results.success; tags.failCount = results.failed;
@@ -2590,22 +2597,22 @@ export class SimpleIMAPService {
         }
         if (present.length === 0) continue;
 
-        await this.chunkedBatchOp(
+        await this.chunkedBatchOp({
           present,
-          (uidSet) => isStarred
+          perChunk: (uidSet) => isStarred
             ? this.client!.messageFlagsAdd(uidSet, ['\\Flagged'], { uid: true })
             : this.client!.messageFlagsRemove(uidSet, ['\\Flagged'], { uid: true }),
-          (id) => isStarred
+          perUid: (id) => isStarred
             ? this.client!.messageFlagsAdd(id, ['\\Flagged'], { uid: true })
             : this.client!.messageFlagsRemove(id, ['\\Flagged'], { uid: true }),
-          (id) => {
+          onSuccess: (id) => {
             const c = this.getCacheEntry(id, folder); if (c) c.isStarred = isStarred;
             results.success++;
           },
-          (id, msg) => { results.failed++; results.errors.push(`Failed to star ${id}: ${msg}`); },
-          'Bulk star',
+          onFailure: (id, msg) => { results.failed++; results.errors.push(`Failed to star ${id}: ${msg}`); },
+          opName: 'Bulk star',
           folder,
-        );
+        });
       } finally { lock.release(); }
     }
     tags.successCount = results.success; tags.failCount = results.failed;
@@ -2667,15 +2674,15 @@ export class SimpleIMAPService {
         const accepted: string[] = [];
         const relocated = new Set<string>(); // source uids the server (UIDPLUS) confirmed copied
         let uidplus = false;
-        await this.chunkedBatchOp(
+        await this.chunkedBatchOp({
           present,
-          async (uidSet) => { uidplus = this.recordRelocatedUids(await this.client!.messageCopy(uidSet, targetFolder, { uid: true }), relocated) || uidplus; },
-          async (id) => { uidplus = this.recordRelocatedUids(await this.client!.messageCopy(id, targetFolder, { uid: true }), relocated) || uidplus; },
-          (id) => { accepted.push(id); },
-          (id, msg) => { results.failed++; results.errors.push(`Failed to copy ${id} to ${targetFolder}: ${msg}`); },
-          `Bulk copy →${targetFolder}`,
+          perChunk: async (uidSet) => { uidplus = this.recordRelocatedUids(await this.client!.messageCopy(uidSet, targetFolder, { uid: true }), relocated) || uidplus; },
+          perUid: async (id) => { uidplus = this.recordRelocatedUids(await this.client!.messageCopy(id, targetFolder, { uid: true }), relocated) || uidplus; },
+          onSuccess: (id) => { accepted.push(id); },
+          onFailure: (id, msg) => { results.failed++; results.errors.push(`Failed to copy ${id} to ${targetFolder}: ${msg}`); },
+          opName: `Bulk copy →${targetFolder}`,
           folder,
-        );
+        });
         verifyJobs.push({ accepted, midMap, relocated, uidplus });
       } finally { lock.release(); }
     }
@@ -2753,22 +2760,22 @@ export class SimpleIMAPService {
       if (present.length > 0) {
         // IMAP-016: see bulkDeleteEmails — flag \Deleted per UID then one EXPUNGE.
         const flaggedForExpunge: string[] = [];
-        await this.chunkedBatchOp(
+        await this.chunkedBatchOp({
           present,
-          (uidSet) => this.client!.messageDelete(uidSet, { uid: true }),
-          async (id) => { await this.client!.messageFlagsAdd(id, ['\\Deleted'], { uid: true }); flaggedForExpunge.push(id); },
-          (id) => { this.evictCacheEntry(`${folder}:${id}`); results.success++; },
-          (id, msg) => { results.failed++; results.errors.push(`Failed to delete ${id} from ${folder}: ${msg}`); },
-          'Bulk delete-from-folder',
+          perChunk: (uidSet) => this.client!.messageDelete(uidSet, { uid: true }),
+          perUid: async (id) => { await this.client!.messageFlagsAdd(id, ['\\Deleted'], { uid: true }); flaggedForExpunge.push(id); },
+          onSuccess: (id) => { this.evictCacheEntry(`${folder}:${id}`); results.success++; },
+          onFailure: (id, msg) => { results.failed++; results.errors.push(`Failed to delete ${id} from ${folder}: ${msg}`); },
+          opName: 'Bulk delete-from-folder',
           folder,
           // Chunk the trailing EXPUNGE (Copilot review on #154) — see
           // bulkDeleteEmails. Bounds the command line; O(N/chunk) round-trips.
-          async () => {
+          finalize: async () => {
             for (const uidSet of chunkUidsForWire(flaggedForExpunge)) {
               await this.client!.messageDelete(uidSet, { uid: true });
             }
           },
-        );
+        });
       }
     } finally { lock.release(); }
 

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2097,8 +2097,17 @@ export class SimpleIMAPService {
       return grouped;
     }
     for (const id of emailIds) {
+      // Keep ID-format validation distinct from discovery/transport failure so the
+      // error message names the real cause: a malformed ID the caller must fix vs.
+      // an IMAP discovery error the caller may retry.
       try {
         this.validateEmailId(id);
+      } catch (e: unknown) {
+        results.failed++;
+        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+        continue;
+      }
+      try {
         const cached = this.findCacheEntryByUid(id);
         let folder: string;
         if (cached) {
@@ -2112,7 +2121,7 @@ export class SimpleIMAPService {
         grouped.get(folder)!.push(id);
       } catch (e: unknown) {
         results.failed++;
-        results.errors.push(`Invalid email ID ${id}: ${e instanceof Error ? e.message : String(e)}`);
+        results.errors.push(`Failed to locate email ${id}: ${e instanceof Error ? e.message : String(e)}`);
       }
     }
     return grouped;

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -7,6 +7,10 @@ import { readFileSync, statSync } from 'fs';
 import { join as pathJoin } from 'path';
 import type { ParsedMail, Attachment, AddressObject } from 'mailparser';
 import { simpleParser } from 'mailparser';
+import { buildEmailMessage, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
+// Re-export the pure helpers from their original home so existing importers
+// (index.ts, tests) keep working after the move to imap-helpers.ts.
+export { stripHtml, normalizeAddressList };
 import nodemailer, { type SendMailOptions } from 'nodemailer';
 import { EmailMessage, EmailFolder, SearchEmailOptions, SaveDraftOptions } from '../types/index.js';
 import { logger } from '../utils/logger.js';
@@ -73,85 +77,6 @@ interface ImapBodyNode {
 }
 
 // ImapSearchCriteria is provided by imapflow as SearchObject (imported above).
-
-/**
- * Truncate email body to a reasonable length for list views
- * @param body The full email body
- * @param maxLength Maximum length (default: 300 characters)
- * @returns Truncated body with ellipsis if needed
- */
-export function stripHtml(html: string): string {
-  if (!html) return '';
-  // Decode entities BEFORE stripping tags (PARSE-008). The old order stripped
-  // tags first then decoded, so an encoded `&lt;script&gt;...&lt;/script&gt;`
-  // emerged as a literal `<script>...</script>` in the FTS body / bodyPreview —
-  // stored-XSS if any consumer rendered those fields as HTML. Decoding first
-  // turns the encoded markup into real tags that the tag-strip then removes.
-  // HTML comments are dropped up front (PARSE-009) so their inner text (e.g.
-  // `<!-- secret: pw123 -->`) doesn't survive as tag-stripped prose.
-  const decodeEntities = (s: string): string =>
-    s
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&#x27;/gi, "'")
-      // Numeric entities (decimal &#60; and hex &#x3c;) for parity, so
-      // `&#60;script&#62;` is also neutralised by the subsequent tag-strip.
-      .replace(/&#(\d{1,7});/g, (_m, d) => String.fromCodePoint(Number(d)))
-      .replace(/&#x([0-9a-f]{1,6});/gi, (_m, h) => String.fromCodePoint(parseInt(h, 16)))
-      .replace(/&amp;/g, '&');
-
-  return decodeEntities(html.replace(/<!--[\s\S]*?-->/g, ' '))
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function truncateBody(body: string, maxLength: number = 300): string {
-  if (!body) return '';
-
-  // Remove excessive whitespace and newlines
-  const cleaned = body.replace(/\s+/g, ' ').trim();
-
-  if (cleaned.length <= maxLength) {
-    return cleaned;
-  }
-
-  // Truncate at the last space before maxLength to avoid cutting words
-  const truncated = cleaned.substring(0, maxLength);
-  const lastSpace = truncated.lastIndexOf(' ');
-
-  if (lastSpace > maxLength * 0.8) {
-    return truncated.substring(0, lastSpace) + '...';
-  }
-
-  return truncated + '...';
-}
-
-/**
- * Normalise a mailparser address field into a flat array of display strings.
- *
- * IMAP-007: `ParsedMail.to` / `.cc` are typed `AddressObject | AddressObject[]
- * | undefined`. When a message carries multiple separate `To:` header lines
- * (legal per RFC 5322 §3.6.3, and emitted by Proton on bridged forwards) the
- * field becomes an array; the old `parsed.to?.text ? [parsed.to.text] : []`
- * shape then collapsed to `[]` and the recipient list silently disappeared.
- */
-export function normalizeAddressList(
-  field: AddressObject | AddressObject[] | undefined,
-): string[] {
-  if (!field) return [];
-  const objs = Array.isArray(field) ? field : [field];
-  const result: string[] = [];
-  for (const obj of objs) {
-    if (obj?.text) result.push(obj.text);
-  }
-  return result;
-}
 
 /**
  * Split a list of UID strings into wire-bounded chunks suitable for a single
@@ -1253,58 +1178,7 @@ export class SimpleIMAPService {
             if (!message.source) continue;
             const parsed = await simpleParser(message.source);
 
-            const fullBody = parsed.text || parsed.html || '';
-            const plainBody = parsed.text || stripHtml(parsed.html || '');
-
-            // Extract content-type for PGP detection
-            const contentType = parsed.headers?.get('content-type');
-            const ctStr = typeof contentType === 'string' ? contentType : ((contentType as unknown as { value?: string } | null)?.value ?? '');
-
-            // Extract X-Pm-Internal-Id for stable Proton message ID
-            const pmId = parsed.headers?.get('x-pm-internal-id');
-
-            const emailMessage: EmailMessage = {
-              id: message.uid.toString(),
-              from: parsed.from?.text || '',
-              to: normalizeAddressList(parsed.to),
-              cc: normalizeAddressList(parsed.cc),
-              subject: parsed.subject || '(No Subject)',
-              body: fullBody, // Full body for individual email view
-              bodyPreview: truncateBody(plainBody),
-              isHtml: !!parsed.html,
-              date: parsed.date || new Date(),
-              folder: folder.path,
-              isRead: message.flags?.has('\\Seen') || false,
-              isStarred: message.flags?.has('\\Flagged') || false,
-              hasAttachment: (parsed.attachments?.length || 0) > 0,
-              attachments: parsed.attachments?.map((att: Attachment) => ({
-                filename: att.filename || 'unnamed',
-                contentType: att.contentType,
-                size: att.size,
-                content: att.content,
-                contentId: att.cid
-              })),
-              headers: parsed.headers
-                ? Object.fromEntries(
-                    Array.from(parsed.headers.entries()).map(([k, v]) => [
-                      k,
-                      Array.isArray(v) ? v.join(', ') : String(v),
-                    ])
-                  )
-                : undefined,
-              inReplyTo: parsed.inReplyTo,
-              references: parsed.references,
-              // IMAP flags
-              isAnswered: message.flags?.has('\\Answered') ?? false,
-              isForwarded: message.flags?.has('\\Forward') ?? false,
-              // MIME-level PGP detection
-              isSignedPGP: ctStr.includes('multipart/signed') && ctStr.includes('application/pgp-signature'),
-              isEncryptedPGP: ctStr.includes('multipart/encrypted') && ctStr.includes('application/pgp-encrypted'),
-              // Proton-specific stable ID
-              protonId: typeof pmId === 'string' ? pmId.trim() : undefined,
-              // RFC Message-ID — stable identity across folders (#9).
-              messageId: parsed.messageId || undefined,
-            };
+            const emailMessage = buildEmailMessage(message, parsed, folder.path);
 
             // GAP 7.5: setCacheEntry strips attachment binary content before storing
             this.setCacheEntry(emailMessage.id, emailMessage);
@@ -1455,49 +1329,7 @@ export class SimpleIMAPService {
           if (!message.source) continue;
           const parsed = await simpleParser(message.source);
 
-          const fullBody = parsed.text || parsed.html || '';
-          const plainBody = parsed.text || stripHtml(parsed.html || '');
-          const contentType = parsed.headers?.get('content-type');
-          const ctStr = typeof contentType === 'string' ? contentType : ((contentType as unknown as { value?: string } | null)?.value ?? '');
-          const pmId = parsed.headers?.get('x-pm-internal-id');
-
-          const emailMessage: EmailMessage = {
-            id: message.uid.toString(),
-            from: parsed.from?.text || '',
-            to: normalizeAddressList(parsed.to),
-            cc: normalizeAddressList(parsed.cc),
-            subject: parsed.subject || '(No Subject)',
-            body: fullBody,
-            bodyPreview: truncateBody(plainBody),
-            isHtml: !!parsed.html,
-            date: parsed.date || new Date(),
-            folder,
-            isRead: message.flags?.has('\\Seen') || false,
-            isStarred: message.flags?.has('\\Flagged') || false,
-            hasAttachment: (parsed.attachments?.length || 0) > 0,
-            attachments: parsed.attachments?.map((att: Attachment) => ({
-              filename: att.filename || 'unnamed',
-              contentType: att.contentType,
-              size: att.size,
-              content: att.content,
-              contentId: att.cid
-            })),
-            headers: parsed.headers
-              ? Object.fromEntries(
-                  Array.from(parsed.headers.entries()).map(([k, v]) => [
-                    k,
-                    Array.isArray(v) ? v.join(', ') : String(v),
-                  ])
-                )
-              : undefined,
-            inReplyTo: parsed.inReplyTo,
-            references: parsed.references,
-            isAnswered: message.flags?.has('\\Answered') ?? false,
-            isForwarded: message.flags?.has('\\Forward') ?? false,
-            isSignedPGP: ctStr.includes('multipart/signed') && ctStr.includes('application/pgp-signature'),
-            isEncryptedPGP: ctStr.includes('multipart/encrypted') && ctStr.includes('application/pgp-encrypted'),
-            protonId: typeof pmId === 'string' ? pmId.trim() : undefined,
-          };
+          const emailMessage = buildEmailMessage(message, parsed, folder);
 
           this.setCacheEntry(emailMessage.id, emailMessage);
 

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2,10 +2,10 @@
  * IMAP Service for reading emails via Proton Bridge
  */
 
-import { ImapFlow, type SearchObject } from 'imapflow';
+import { ImapFlow } from 'imapflow';
 import type { ParsedMail, Attachment, AddressObject } from 'mailparser';
 import { simpleParser } from 'mailparser';
-import { buildEmailMessage, verifyRelocatedMessages, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
+import { buildEmailMessage, verifyRelocatedMessages, buildSearchCriteria, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
 // Re-export the pure helpers from their original home so existing importers
 // (index.ts, tests) keep working after the move to imap-helpers.ts.
 export { stripHtml, normalizeAddressList };
@@ -1173,63 +1173,7 @@ export class SimpleIMAPService {
     const lock = await this.client.getMailboxLock(folder);
 
     try {
-      const searchCriteria: SearchObject = {};
-
-      // Strip IMAP search-unsafe characters (quote and backslash) to prevent
-      // search criteria injection.  imapflow passes these as quoted strings
-      // in the IMAP SEARCH command, so an unescaped '"' would close the
-      // quoted string early, and '\' could escape the closing quote.
-      // VALID-002: also strip CR/LF/NUL — a value like "x\r\nA002 LOGOUT" would
-      // otherwise smuggle a command line into the IMAP stream.
-      const sanitizeImapStr = (s: string) => s.replace(/["\\\r\n\x00]/g, "");
-      if (options.from) searchCriteria.from = sanitizeImapStr(options.from);
-      if (options.to) searchCriteria.to = sanitizeImapStr(options.to);
-      if (options.subject) searchCriteria.subject = sanitizeImapStr(options.subject);
-      if (options.dateFrom) {
-        const d = new Date(options.dateFrom);
-        if (!isNaN(d.getTime())) searchCriteria.since = d;
-      }
-      if (options.dateTo) {
-        const d = new Date(options.dateTo);
-        if (!isNaN(d.getTime())) searchCriteria.before = d;
-      }
-
-      // imapflow SearchObject uses a single boolean for seen/unseen, answered/unanswered,
-      // and draft/undraft — `seen: false` means "unseen", etc.
-      if (options.isRead    !== undefined) searchCriteria.seen     = options.isRead;
-      if (options.isStarred !== undefined) searchCriteria.flagged  = options.isStarred;
-
-      // Body/text search
-      if (options.body) searchCriteria.body = sanitizeImapStr(options.body);
-      if (options.text) searchCriteria.text = sanitizeImapStr(options.text);
-
-      // Additional header fields
-      if (options.bcc) searchCriteria.bcc = sanitizeImapStr(options.bcc);
-      // header is { [field]: value } in the SearchObject API (not a tuple).
-      // IMAP-004: the field+value here were the only SEARCH inputs not passed
-      // through sanitizeImapStr. A raw '"' in the value closes imapflow's
-      // quoted string early; a malformed field name breaks the
-      // `SEARCH HEADER <field-name> <value>` grammar. Sanitise the value and
-      // enforce the RFC 5322 field-name grammar on the field.
-      if (options.header) {
-        const field = options.header.field;
-        if (!/^[A-Za-z][A-Za-z0-9-]*$/.test(field)) {
-          throw new Error(`Invalid header field name: ${JSON.stringify(field)}`);
-        }
-        searchCriteria.header = { [field]: sanitizeImapStr(options.header.value) };
-      }
-
-      // Flag criteria — imapflow uses boolean: true = flag set, false = flag not set
-      if (options.answered !== undefined) searchCriteria.answered = options.answered;
-      if (options.isDraft  !== undefined) searchCriteria.draft    = options.isDraft;
-
-      // Size criteria
-      if (options.larger !== undefined)  searchCriteria.larger = options.larger;
-      if (options.smaller !== undefined) searchCriteria.smaller = options.smaller;
-
-      // Sent-date criteria (Date: header vs INTERNALDATE)
-      if (options.sentBefore) searchCriteria.sentBefore = options.sentBefore;
-      if (options.sentSince)  searchCriteria.sentSince  = options.sentSince;
+      const searchCriteria = buildSearchCriteria(options);
 
       // Request ESEARCH PARTIAL so the server returns only the first `limit` UIDs
       // rather than the full result set. Falls back transparently to a plain number[]

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -3,7 +3,7 @@
  */
 
 import { ImapFlow } from 'imapflow';
-import type { ParsedMail, Attachment, AddressObject } from 'mailparser';
+import type { Attachment } from 'mailparser';
 import { simpleParser } from 'mailparser';
 import { buildEmailMessage, verifyRelocatedMessages, buildSearchCriteria, truncateBody, stripHtml, normalizeAddressList } from './imap-helpers.js';
 // Re-export the pure helpers from their original home so existing importers
@@ -608,8 +608,11 @@ export class SimpleIMAPService {
       // Store connection config for reconnection
       this.connectionConfig = { host, port, username, password, bridgeCertPath, secure, allowInsecureBridge };
 
-      // Check if using localhost (Proton Bridge)
-      const isLocalhost = host === 'localhost' || host === '127.0.0.1';
+      // Check if using localhost (Proton Bridge). Must match buildBridgeTlsConfig's
+      // localhost set (incl. IPv6 loopback ::1) — otherwise host="::1" would get a
+      // localhost TLS config but a non-localhost `secure` default (implicit TLS),
+      // breaking the STARTTLS-on-1143 Bridge connection.
+      const isLocalhost = host === 'localhost' || host === '127.0.0.1' || host === '::1';
       const allowInsecure = allowInsecureBridge
         || process.env.MAILPOUCH_INSECURE_BRIDGE === '1';
 

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -9,7 +9,7 @@ import { join as pathJoin } from "path";
 import { ProtonMailConfig, SendEmailOptions } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { buildBridgeTlsOptions, readPinnedBridgeCert } from "./bridge-tls.js";
-import { parseEmails, parseEmailsDetailed, isValidEmail, sanitizeForLog } from "../utils/helpers.js";
+import { parseEmails, parseEmailsDetailed, isValidEmail, sanitizeForLog, validateAttachmentLimits } from "../utils/helpers.js";
 import { tracer } from "../utils/tracer.js";
 import { classifyError } from "../utils/error-classify.js";
 import { BackoffTracker, isTransientAbuseError } from "../utils/backoff.js";
@@ -35,10 +35,8 @@ export function escapeHtml(str: string): string {
 /** Header keys that must never be overridden via caller-supplied headers */
 const BLOCKED_HEADER_KEYS = /^(to|cc|bcc|from|return-path|reply-to|sender)$/i;
 
-/** Attachment limits — prevents OOM / DoS via oversized email payloads. */
-const MAX_ATTACHMENTS       = 20;
-const MAX_ATTACHMENT_BYTES  = 25 * 1024 * 1024; // 25 MB per file (matches Proton limit)
-const MAX_TOTAL_ATT_BYTES   = 25 * 1024 * 1024; // 25 MB total across all attachments
+// Attachment count/size caps live in helpers.ts (validateAttachmentLimits),
+// shared with the IMAP saveDraft path.
 
 export class SMTPService {
   private transporter: nodemailer.Transporter | null = null;
@@ -421,43 +419,11 @@ export class SMTPService {
       }
 
       if (options.attachments && options.attachments.length > 0) {
-        // Enforce count cap
-        if (options.attachments.length > MAX_ATTACHMENTS) {
-          throw new Error(
-            `Too many attachments: ${options.attachments.length} supplied, max ${MAX_ATTACHMENTS} allowed.`
-          );
-        }
-
-        // Enforce per-file and total size caps.
-        // att.content may be a base64 string, Buffer, or Readable — only string/Buffer are
-        // trivially sizable; Readable streams are rejected to prevent unbounded streaming.
-        let totalBytes = 0;
-        for (const att of options.attachments) {
-          const content = att.content;
-          let bytes: number;
-          if (Buffer.isBuffer(content)) {
-            bytes = content.length;
-          } else if (typeof content === "string") {
-            // base64 string: actual binary size ≈ str.length * 0.75
-            bytes = Math.ceil(content.length * 0.75);
-          } else {
-            throw new Error(
-              `Attachment '${att.filename ?? "unnamed"}': content must be a Buffer or base64 string, not a stream.`
-            );
-          }
-          if (bytes > MAX_ATTACHMENT_BYTES) {
-            throw new Error(
-              `Attachment '${att.filename ?? "unnamed"}' is too large: ` +
-              `${Math.round(bytes / 1024 / 1024)}MB exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per-file limit.`
-            );
-          }
-          totalBytes += bytes;
-          if (totalBytes > MAX_TOTAL_ATT_BYTES) {
-            throw new Error(
-              `Total attachment size exceeds the ${MAX_TOTAL_ATT_BYTES / 1024 / 1024}MB limit.`
-            );
-          }
-        }
+        // Count + per-file + total size caps (shared with the IMAP saveDraft
+        // path via validateAttachmentLimits — Readable streams are rejected
+        // because they aren't trivially sizable).
+        const limitErr = validateAttachmentLimits(options.attachments);
+        if (limitErr) throw new Error(limitErr);
 
         mailOptions.attachments = options.attachments.map((att) => {
           // Strip CRLF and NUL from filename — a value like

--- a/src/settings/connection-check.ts
+++ b/src/settings/connection-check.ts
@@ -11,11 +11,9 @@
 // so the UI can never show a working/green state while auth is failing.
 
 import { Socket } from "net";
-import { statSync } from "fs";
-import { join } from "path";
 import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
-import { buildBridgeTlsOptions, readPinnedBridgeCert } from "../services/bridge-tls.js";
+import { buildBridgeTlsConfig } from "../services/bridge-tls.js";
 import { loadConfig, loadCredentialsFromKeychain } from "../config/loader.js";
 
 export interface ProtocolCheck {
@@ -63,22 +61,12 @@ export function tcpReachable(host: string, port: number, timeoutMs = 5000): Prom
   });
 }
 
-/** Build TLS options matching the real services' Bridge handling. Throws when a
- *  cert is required (localhost, not insecure) but can't be loaded — surfaced as
- *  an auth failure rather than a silent insecure downgrade. */
+/** Build TLS options matching the real services' Bridge handling (shared with
+ *  the IMAP service connect()/IDLE via bridge-tls.ts). Throws when a cert is
+ *  required (localhost, not insecure) but can't be loaded — surfaced as an auth
+ *  failure rather than a silent insecure downgrade. */
 function bridgeTls(host: string, certPath: string, allowInsecure: boolean): Record<string, unknown> {
-  if (!isLocalhost(host)) return { minVersion: "TLSv1.2" };
-  if (certPath) {
-    let resolved = certPath;
-    try { if (statSync(certPath).isDirectory()) resolved = join(certPath, "cert.pem"); } catch { /* use as-is */ }
-    try { return buildBridgeTlsOptions(readPinnedBridgeCert(resolved)); }
-    catch (e) {
-      if (allowInsecure) return { rejectUnauthorized: false, minVersion: "TLSv1.2" };
-      throw new Error(`Bridge cert at "${resolved}" could not be loaded and allowInsecureBridge is not set`);
-    }
-  }
-  if (allowInsecure) return { rejectUnauthorized: false, minVersion: "TLSv1.2" };
-  throw new Error("No Bridge certificate configured and allowInsecureBridge is not set");
+  return buildBridgeTlsConfig(host, certPath, allowInsecure).tlsOptions;
 }
 
 /** Condense a thrown SMTP/IMAP error into a short, user-facing reason. */

--- a/src/tools/reading.ts
+++ b/src/tools/reading.ts
@@ -25,6 +25,7 @@ import {
   validateLabelName,
   validateTargetFolder,
 } from "../utils/helpers.js";
+import { validateSearchInput } from "./search-input.js";
 import { extractActionItems, parseIcs } from "../services/content-parser.js";
 import { FtsUnavailableError } from "../services/fts-service.js";
 import type { FtsIndexService } from "../services/fts-service.js";
@@ -571,133 +572,9 @@ export const handlers: Record<string, ToolHandler> = {
 
   search_emails: async (ctx) => {
     const { args, imapService, ok, limits } = ctx;
-    const folder = (args.folder as string) || "INBOX";
-    // Runtime-guard the array cast: a client passing folders:"INBOX" (string)
-    // would otherwise iterate per-character into validateTargetFolder; folders:{}
-    // would silently fall through with folders.length === undefined (TOOL-001).
-    if (args.folders !== undefined && !Array.isArray(args.folders)) {
-      throw new McpError(ErrorCode.InvalidParams, "'folders' must be an array of folder paths when provided.");
-    }
-    const folders = args.folders as string[] | undefined;
-    if (!folders) {
-      const seFolderErr = validateTargetFolder(folder);
-      if (seFolderErr) throw new McpError(ErrorCode.InvalidParams, `folder: ${seFolderErr}`);
-    }
-    if (folders && !(folders.length === 1 && folders[0] === "*")) {
-      for (let i = 0; i < folders.length; i++) {
-        const fErr = validateTargetFolder(folders[i]);
-        if (fErr) throw new McpError(ErrorCode.InvalidParams, `folders[${i}]: ${fErr}`);
-      }
-    }
-    const MAX_SEARCH_TEXT = 500;
-    if (args.from !== undefined && typeof args.from !== "string") {
-      throw new McpError(ErrorCode.InvalidParams, "'from' filter must be a string when provided.");
-    }
-    if (args.from && (args.from as string).length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'from' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    if (args.to !== undefined && typeof args.to !== "string") {
-      throw new McpError(ErrorCode.InvalidParams, "'to' filter must be a string when provided.");
-    }
-    if (args.to && (args.to as string).length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'to' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    if (args.subject !== undefined && typeof args.subject !== "string") {
-      throw new McpError(ErrorCode.InvalidParams, "'subject' filter must be a string when provided.");
-    }
-    if (args.subject && (args.subject as string).length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'subject' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    if (args.hasAttachment !== undefined && typeof args.hasAttachment !== "boolean") {
-      throw new McpError(ErrorCode.InvalidParams, "'hasAttachment' must be a boolean when provided.");
-    }
-    if (args.isRead !== undefined && typeof args.isRead !== "boolean") {
-      throw new McpError(ErrorCode.InvalidParams, "'isRead' must be a boolean when provided.");
-    }
-    if (args.isStarred !== undefined && typeof args.isStarred !== "boolean") {
-      throw new McpError(ErrorCode.InvalidParams, "'isStarred' must be a boolean when provided.");
-    }
-    if (args.limit !== undefined && typeof args.limit !== "number") {
-      throw new McpError(ErrorCode.InvalidParams, "'limit' must be a number.");
-    }
-    if (args.dateFrom !== undefined && typeof args.dateFrom !== "string") {
-      throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must be a string when provided.");
-    }
-    if (args.dateTo !== undefined && typeof args.dateTo !== "string") {
-      throw new McpError(ErrorCode.InvalidParams, "'dateTo' must be a string when provided.");
-    }
-    if (args.dateFrom && args.dateTo) {
-      const dfTs = Date.parse(args.dateFrom as string);
-      const dtTs = Date.parse(args.dateTo as string);
-      if (!isNaN(dfTs) && !isNaN(dtTs) && dfTs > dtTs) {
-        throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must not be later than 'dateTo'.");
-      }
-    }
-    // VALID-002: length-cap body/text/bcc at MAX_SEARCH_TEXT like from/to/subject.
-    // These were previously read with only a typeof check and forwarded unbounded,
-    // letting a multi-MB filter burn server memory.
-    const body     = typeof args.body === 'string' ? args.body : undefined;
-    const text     = typeof args.text === 'string' ? args.text : undefined;
-    const bcc      = typeof args.bcc === 'string' ? args.bcc : undefined;
-    if (body !== undefined && body.length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'body' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    if (text !== undefined && text.length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'text' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    if (bcc !== undefined && bcc.length > MAX_SEARCH_TEXT) {
-      throw new McpError(ErrorCode.InvalidParams, `'bcc' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
-    }
-    const answered = typeof args.answered === 'boolean' ? args.answered : undefined;
-    const isDraft  = typeof args.isDraft === 'boolean' ? args.isDraft : undefined;
-    // TOOL-016: byte-size predicates are non-negative integers; reject negatives
-    // and non-finite (NaN/Infinity) instead of forwarding them to the IMAP wire.
-    if (args.larger !== undefined &&
-        (typeof args.larger !== 'number' || !Number.isFinite(args.larger) || args.larger < 0)) {
-      throw new McpError(ErrorCode.InvalidParams, "'larger' must be a non-negative finite number (bytes) when provided.");
-    }
-    if (args.smaller !== undefined &&
-        (typeof args.smaller !== 'number' || !Number.isFinite(args.smaller) || args.smaller < 0)) {
-      throw new McpError(ErrorCode.InvalidParams, "'smaller' must be a non-negative finite number (bytes) when provided.");
-    }
-    const larger   = typeof args.larger === 'number' ? args.larger : undefined;
-    const smaller  = typeof args.smaller === 'number' ? args.smaller : undefined;
-    // TOOL-017: require a string + a parseable date. The old truthy-check let
-    // numbers/objects through — `new Date(null)` → 1970, `new Date({})` →
-    // Invalid Date — silently corrupting the search window.
-    const parseSentDate = (raw: unknown, field: string): Date | undefined => {
-      if (raw === undefined || raw === null) return undefined;
-      if (typeof raw !== 'string' || Number.isNaN(Date.parse(raw))) {
-        throw new McpError(ErrorCode.InvalidParams, `'${field}' must be a parseable date string when provided.`);
-      }
-      return new Date(raw);
-    };
-    const sentBefore = parseSentDate(args.sentBefore, 'sentBefore');
-    const sentSince  = parseSentDate(args.sentSince, 'sentSince');
-
-    const results = await imapService.searchEmails({
-      folder: folders ? undefined : folder,
-      folders,
-      from: args.from as string | undefined,
-      to: args.to as string | undefined,
-      subject: args.subject as string | undefined,
-      hasAttachment: args.hasAttachment as boolean | undefined,
-      isRead: args.isRead as boolean | undefined,
-      isStarred: args.isStarred as boolean | undefined,
-      dateFrom: args.dateFrom as string | undefined,
-      dateTo: args.dateTo as string | undefined,
-      limit: Math.min(Math.max(1, (args.limit as number) || 50), 200, limits.maxEmailListResults),
-      body,
-      text,
-      bcc,
-      answered,
-      isDraft,
-      larger,
-      smaller,
-      sentBefore,
-      sentSince,
-    });
-    const searchedIn = folders ? folders.join(", ") : folder;
+    const searchOptions = validateSearchInput(args, limits.maxEmailListResults);
+    const results = await imapService.searchEmails(searchOptions);
+    const searchedIn = searchOptions.folders ? searchOptions.folders.join(", ") : (searchOptions.folder ?? "INBOX");
     return ok({ emails: results, count: results.length, folder: searchedIn });
   },
 

--- a/src/tools/search-input.test.ts
+++ b/src/tools/search-input.test.ts
@@ -46,4 +46,13 @@ describe("validateSearchInput", () => {
     expect(() => validateSearchInput({ dateFrom: "2026-06-10", dateTo: "2026-06-01" }, MAX))
       .toThrow(/must not be later than/);
   });
+
+  it("TOOL-017: rejects unparseable dateFrom/dateTo; accepts valid", () => {
+    expect(() => validateSearchInput({ dateFrom: "not-a-date" }, MAX)).toThrow(/parseable date string/);
+    expect(() => validateSearchInput({ dateTo: "garbage" }, MAX)).toThrow(/parseable date string/);
+    expect(() => validateSearchInput({ dateFrom: 1234 }, MAX)).toThrow(/parseable date string/);
+    const o = validateSearchInput({ dateFrom: "2026-06-01", dateTo: "2026-06-10" }, MAX);
+    expect(o.dateFrom).toBe("2026-06-01");
+    expect(o.dateTo).toBe("2026-06-10");
+  });
 });

--- a/src/tools/search-input.test.ts
+++ b/src/tools/search-input.test.ts
@@ -47,6 +47,14 @@ describe("validateSearchInput", () => {
       .toThrow(/must not be later than/);
   });
 
+  it("VALID-002: rejects non-string body/text/bcc filters", () => {
+    expect(() => validateSearchInput({ body: 123 }, MAX)).toThrow(/'body' filter must be a string/);
+    expect(() => validateSearchInput({ text: {} }, MAX)).toThrow(/'text' filter must be a string/);
+    expect(() => validateSearchInput({ bcc: [] }, MAX)).toThrow(/'bcc' filter must be a string/);
+    const o = validateSearchInput({ body: "hello" }, MAX);
+    expect(o.body).toBe("hello");
+  });
+
   it("TOOL-017: rejects unparseable dateFrom/dateTo; accepts valid", () => {
     expect(() => validateSearchInput({ dateFrom: "not-a-date" }, MAX)).toThrow(/parseable date string/);
     expect(() => validateSearchInput({ dateTo: "garbage" }, MAX)).toThrow(/parseable date string/);

--- a/src/tools/search-input.test.ts
+++ b/src/tools/search-input.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { validateSearchInput } from "./search-input.js";
+
+const MAX = 200;
+
+describe("validateSearchInput", () => {
+  it("builds options from valid args + clamps limit", () => {
+    const o = validateSearchInput({ folder: "INBOX", from: "a@x.com", subject: "hi", limit: 9999 }, MAX);
+    expect(o.folder).toBe("INBOX");
+    expect(o.from).toBe("a@x.com");
+    expect(o.limit).toBe(MAX); // clamped to maxEmailListResults
+  });
+
+  it("defaults folder to INBOX and limit to 50", () => {
+    const o = validateSearchInput({}, MAX);
+    expect(o.folder).toBe("INBOX");
+    expect(o.limit).toBe(50);
+  });
+
+  it("multi-folder: leaves folder undefined, validates each, allows '*'", () => {
+    const o = validateSearchInput({ folders: ["INBOX", "Sent"] }, MAX);
+    expect(o.folder).toBeUndefined();
+    expect(o.folders).toEqual(["INBOX", "Sent"]);
+    expect(() => validateSearchInput({ folders: ["*"] }, MAX)).not.toThrow();
+  });
+
+  it("rejects non-array folders, non-string from, oversized subject", () => {
+    expect(() => validateSearchInput({ folders: "INBOX" }, MAX)).toThrow(McpError);
+    expect(() => validateSearchInput({ from: 5 }, MAX)).toThrow(/'from' filter must be a string/);
+    expect(() => validateSearchInput({ subject: "x".repeat(501) }, MAX)).toThrow(/must not exceed 500/);
+  });
+
+  it("TOOL-016: rejects negative/non-finite larger/smaller", () => {
+    expect(() => validateSearchInput({ larger: -1 }, MAX)).toThrow(/non-negative finite/);
+    expect(() => validateSearchInput({ smaller: Infinity }, MAX)).toThrow(/non-negative finite/);
+  });
+
+  it("TOOL-017: rejects unparseable sentBefore/sentSince; accepts valid", () => {
+    expect(() => validateSearchInput({ sentBefore: {} }, MAX)).toThrow(/parseable date string/);
+    const o = validateSearchInput({ sentSince: "2026-06-01" }, MAX);
+    expect(o.sentSince).toBeInstanceOf(Date);
+  });
+
+  it("rejects dateFrom later than dateTo", () => {
+    expect(() => validateSearchInput({ dateFrom: "2026-06-10", dateTo: "2026-06-01" }, MAX))
+      .toThrow(/must not be later than/);
+  });
+});

--- a/src/tools/search-input.ts
+++ b/src/tools/search-input.ts
@@ -64,16 +64,21 @@ export function validateSearchInput(
   if (args.limit !== undefined && typeof args.limit !== "number") {
     throw new McpError(ErrorCode.InvalidParams, "'limit' must be a number.");
   }
-  if (args.dateFrom !== undefined && typeof args.dateFrom !== "string") {
-    throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must be a string when provided.");
+  // TOOL-017: dateFrom/dateTo must be a string AND parseable when provided — same
+  // contract as sentBefore/sentSince below. The old type-only check let
+  // {dateFrom:"not-a-date"} pass through and be silently dropped downstream.
+  if (args.dateFrom !== undefined &&
+      (typeof args.dateFrom !== "string" || Number.isNaN(Date.parse(args.dateFrom)))) {
+    throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must be a parseable date string when provided.");
   }
-  if (args.dateTo !== undefined && typeof args.dateTo !== "string") {
-    throw new McpError(ErrorCode.InvalidParams, "'dateTo' must be a string when provided.");
+  if (args.dateTo !== undefined &&
+      (typeof args.dateTo !== "string" || Number.isNaN(Date.parse(args.dateTo)))) {
+    throw new McpError(ErrorCode.InvalidParams, "'dateTo' must be a parseable date string when provided.");
   }
   if (args.dateFrom && args.dateTo) {
     const dfTs = Date.parse(args.dateFrom as string);
     const dtTs = Date.parse(args.dateTo as string);
-    if (!isNaN(dfTs) && !isNaN(dtTs) && dfTs > dtTs) {
+    if (dfTs > dtTs) {
       throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must not be later than 'dateTo'.");
     }
   }

--- a/src/tools/search-input.ts
+++ b/src/tools/search-input.ts
@@ -82,12 +82,21 @@ export function validateSearchInput(
       throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must not be later than 'dateTo'.");
     }
   }
-  // VALID-002: length-cap body/text/bcc at MAX_SEARCH_TEXT like from/to/subject.
-  // These were previously read with only a typeof check and forwarded unbounded,
-  // letting a multi-MB filter burn server memory.
-  const body = typeof args.body === "string" ? args.body : undefined;
-  const text = typeof args.text === "string" ? args.text : undefined;
-  const bcc = typeof args.bcc === "string" ? args.bcc : undefined;
+  // VALID-002: body/text/bcc are string filters, length-capped at MAX_SEARCH_TEXT
+  // like from/to/subject. Reject a non-string (rather than silently dropping it)
+  // so the contract — throw on malformed input — holds for every field.
+  if (args.body !== undefined && typeof args.body !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'body' filter must be a string when provided.");
+  }
+  if (args.text !== undefined && typeof args.text !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'text' filter must be a string when provided.");
+  }
+  if (args.bcc !== undefined && typeof args.bcc !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'bcc' filter must be a string when provided.");
+  }
+  const body = args.body as string | undefined;
+  const text = args.text as string | undefined;
+  const bcc = args.bcc as string | undefined;
   if (body !== undefined && body.length > MAX_SEARCH_TEXT) {
     throw new McpError(ErrorCode.InvalidParams, `'body' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
   }

--- a/src/tools/search-input.ts
+++ b/src/tools/search-input.ts
@@ -1,0 +1,144 @@
+/**
+ * Validation + normalization for the `search_emails` tool args. Extracted from
+ * the handler so the ~110 LOC of input checks (type/length/range; VALID-002
+ * length caps; TOOL-016 byte predicates; TOOL-017 parseable dates) live in one
+ * testable place instead of crowding the handler. Throws McpError(InvalidParams)
+ * on any malformed input; returns a ready-to-use SearchEmailOptions.
+ */
+
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { validateTargetFolder } from "../utils/helpers.js";
+import type { SearchEmailOptions } from "../types/index.js";
+
+const MAX_SEARCH_TEXT = 500;
+
+export function validateSearchInput(
+  args: Record<string, unknown>,
+  maxEmailListResults: number,
+): SearchEmailOptions {
+  const folder = (args.folder as string) || "INBOX";
+  // Runtime-guard the array cast: a client passing folders:"INBOX" (string)
+  // would otherwise iterate per-character into validateTargetFolder; folders:{}
+  // would silently fall through with folders.length === undefined (TOOL-001).
+  if (args.folders !== undefined && !Array.isArray(args.folders)) {
+    throw new McpError(ErrorCode.InvalidParams, "'folders' must be an array of folder paths when provided.");
+  }
+  const folders = args.folders as string[] | undefined;
+  if (!folders) {
+    const seFolderErr = validateTargetFolder(folder);
+    if (seFolderErr) throw new McpError(ErrorCode.InvalidParams, `folder: ${seFolderErr}`);
+  }
+  if (folders && !(folders.length === 1 && folders[0] === "*")) {
+    for (let i = 0; i < folders.length; i++) {
+      const fErr = validateTargetFolder(folders[i]);
+      if (fErr) throw new McpError(ErrorCode.InvalidParams, `folders[${i}]: ${fErr}`);
+    }
+  }
+  if (args.from !== undefined && typeof args.from !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'from' filter must be a string when provided.");
+  }
+  if (args.from && (args.from as string).length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'from' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  if (args.to !== undefined && typeof args.to !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'to' filter must be a string when provided.");
+  }
+  if (args.to && (args.to as string).length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'to' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  if (args.subject !== undefined && typeof args.subject !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'subject' filter must be a string when provided.");
+  }
+  if (args.subject && (args.subject as string).length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'subject' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  if (args.hasAttachment !== undefined && typeof args.hasAttachment !== "boolean") {
+    throw new McpError(ErrorCode.InvalidParams, "'hasAttachment' must be a boolean when provided.");
+  }
+  if (args.isRead !== undefined && typeof args.isRead !== "boolean") {
+    throw new McpError(ErrorCode.InvalidParams, "'isRead' must be a boolean when provided.");
+  }
+  if (args.isStarred !== undefined && typeof args.isStarred !== "boolean") {
+    throw new McpError(ErrorCode.InvalidParams, "'isStarred' must be a boolean when provided.");
+  }
+  if (args.limit !== undefined && typeof args.limit !== "number") {
+    throw new McpError(ErrorCode.InvalidParams, "'limit' must be a number.");
+  }
+  if (args.dateFrom !== undefined && typeof args.dateFrom !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must be a string when provided.");
+  }
+  if (args.dateTo !== undefined && typeof args.dateTo !== "string") {
+    throw new McpError(ErrorCode.InvalidParams, "'dateTo' must be a string when provided.");
+  }
+  if (args.dateFrom && args.dateTo) {
+    const dfTs = Date.parse(args.dateFrom as string);
+    const dtTs = Date.parse(args.dateTo as string);
+    if (!isNaN(dfTs) && !isNaN(dtTs) && dfTs > dtTs) {
+      throw new McpError(ErrorCode.InvalidParams, "'dateFrom' must not be later than 'dateTo'.");
+    }
+  }
+  // VALID-002: length-cap body/text/bcc at MAX_SEARCH_TEXT like from/to/subject.
+  // These were previously read with only a typeof check and forwarded unbounded,
+  // letting a multi-MB filter burn server memory.
+  const body = typeof args.body === "string" ? args.body : undefined;
+  const text = typeof args.text === "string" ? args.text : undefined;
+  const bcc = typeof args.bcc === "string" ? args.bcc : undefined;
+  if (body !== undefined && body.length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'body' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  if (text !== undefined && text.length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'text' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  if (bcc !== undefined && bcc.length > MAX_SEARCH_TEXT) {
+    throw new McpError(ErrorCode.InvalidParams, `'bcc' filter must not exceed ${MAX_SEARCH_TEXT} characters.`);
+  }
+  const answered = typeof args.answered === "boolean" ? args.answered : undefined;
+  const isDraft = typeof args.isDraft === "boolean" ? args.isDraft : undefined;
+  // TOOL-016: byte-size predicates are non-negative integers; reject negatives
+  // and non-finite (NaN/Infinity) instead of forwarding them to the IMAP wire.
+  if (args.larger !== undefined &&
+      (typeof args.larger !== "number" || !Number.isFinite(args.larger) || args.larger < 0)) {
+    throw new McpError(ErrorCode.InvalidParams, "'larger' must be a non-negative finite number (bytes) when provided.");
+  }
+  if (args.smaller !== undefined &&
+      (typeof args.smaller !== "number" || !Number.isFinite(args.smaller) || args.smaller < 0)) {
+    throw new McpError(ErrorCode.InvalidParams, "'smaller' must be a non-negative finite number (bytes) when provided.");
+  }
+  const larger = typeof args.larger === "number" ? args.larger : undefined;
+  const smaller = typeof args.smaller === "number" ? args.smaller : undefined;
+  // TOOL-017: require a string + a parseable date. The old truthy-check let
+  // numbers/objects through — `new Date(null)` → 1970, `new Date({})` →
+  // Invalid Date — silently corrupting the search window.
+  const parseSentDate = (raw: unknown, field: string): Date | undefined => {
+    if (raw === undefined || raw === null) return undefined;
+    if (typeof raw !== "string" || Number.isNaN(Date.parse(raw))) {
+      throw new McpError(ErrorCode.InvalidParams, `'${field}' must be a parseable date string when provided.`);
+    }
+    return new Date(raw);
+  };
+  const sentBefore = parseSentDate(args.sentBefore, "sentBefore");
+  const sentSince = parseSentDate(args.sentSince, "sentSince");
+
+  return {
+    folder: folders ? undefined : folder,
+    folders,
+    from: args.from as string | undefined,
+    to: args.to as string | undefined,
+    subject: args.subject as string | undefined,
+    hasAttachment: args.hasAttachment as boolean | undefined,
+    isRead: args.isRead as boolean | undefined,
+    isStarred: args.isStarred as boolean | undefined,
+    dateFrom: args.dateFrom as string | undefined,
+    dateTo: args.dateTo as string | undefined,
+    limit: Math.min(Math.max(1, (args.limit as number) || 50), 200, maxEmailListResults),
+    body,
+    text,
+    bcc,
+    answered,
+    isDraft,
+    larger,
+    smaller,
+    sentBefore,
+    sentSince,
+  };
+}

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -17,6 +17,7 @@ import {
   validateTargetFolder,
   requireNumericEmailId,
   validateAttachments,
+  validateAttachmentLimits,
   validateImapPath,
   sanitizeAttachments,
   attachmentByteSize,
@@ -3986,4 +3987,27 @@ describe('helpers', () => {
       expect(extractEmailAddress('  plain@x.com  ')).toBe('plain@x.com');
     });
   });
+
+  describe('validateAttachmentLimits (service-layer count/size caps)', () => {
+    const big = 'a'.repeat(35 * 1024 * 1024); // ~26MB base64 -> over 25MB/file
+    it('accepts a normal attachment set', () => {
+      expect(validateAttachmentLimits([{ filename: 'a.pdf', content: 'aGVsbG8=' }])).toBeNull();
+      expect(validateAttachmentLimits([])).toBeNull();
+    });
+    it('rejects too many attachments', () => {
+      const many = Array.from({ length: 21 }, () => ({ content: 'aa' }));
+      expect(validateAttachmentLimits(many)).toMatch(/Too many attachments/);
+    });
+    it('rejects a single oversized attachment', () => {
+      expect(validateAttachmentLimits([{ filename: 'big', content: big }])).toMatch(/is too large/);
+    });
+    it('rejects when the total exceeds the cap', () => {
+      const half = 'a'.repeat(20 * 1024 * 1024);
+      expect(validateAttachmentLimits([{ content: half }, { content: half }])).toMatch(/Total attachment size/);
+    });
+    it('rejects non-Buffer/non-string content (e.g. a stream)', () => {
+      expect(validateAttachmentLimits([{ filename: 'x', content: {} as unknown }])).toMatch(/must be a Buffer or base64 string/);
+    });
+  });
+
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -602,6 +602,38 @@ export function validateAttachments(attachments: unknown): string | null {
 }
 
 /**
+ * Service-layer attachment LIMIT check (count + per-file + total size) — shared
+ * by the SMTP send path and the IMAP saveDraft path. Both enforce the caps even
+ * though the tool layer's {@link validateAttachments} already did (VALID-005/006:
+ * defense in depth, so an unbounded base64 payload can't OOM the process before
+ * it reaches the wire). Operates on already-structured attachments (assumes the
+ * shape {@link validateAttachments} guarantees); returns an error string or null.
+ */
+export function validateAttachmentLimits(
+  attachments: ReadonlyArray<{ filename?: string; content?: unknown }>,
+): string | null {
+  if (attachments.length > MAX_ATTACHMENT_COUNT) {
+    return `Too many attachments: ${attachments.length} supplied, max ${MAX_ATTACHMENT_COUNT} allowed.`;
+  }
+  let totalBytes = 0;
+  for (const att of attachments) {
+    const name = att.filename ?? "unnamed";
+    const bytes = attachmentByteSize(att.content);
+    if (bytes === null) {
+      return `Attachment '${name}': content must be a Buffer or base64 string.`;
+    }
+    if (bytes > MAX_ATTACHMENT_BYTES) {
+      return `Attachment '${name}' is too large: ${Math.round(bytes / 1024 / 1024)}MB exceeds the ${MAX_ATTACHMENT_BYTES / 1024 / 1024}MB per-file limit.`;
+    }
+    totalBytes += bytes;
+    if (totalBytes > MAX_TOTAL_ATTACHMENT_BYTES) {
+      return `Total attachment size exceeds the ${MAX_TOTAL_ATTACHMENT_BYTES / 1024 / 1024}MB limit.`;
+    }
+  }
+  return null;
+}
+
+/**
  * Coerce a raw `args.attachments` value into a clean `EmailAttachment[]` that
  * carries ONLY the known fields. VALID-015: tools previously did
  * `args.attachments as EmailAttachment[]`, which let attacker-controlled extra


### PR DESCRIPTION
## Summary
Phase 0 of the Bridge-capability audit program: extract the duplicated logic in the IMAP/SMTP/tool layer into a shared, tested backbone (`src/services/imap-helpers.ts` + helpers), so every subsequent subsystem rebuild starts clean. **Behavior-preserving** refactor with new dedicated unit tests per helper, then hardened against the multi-agent ultra-review + CodeQL/Copilot.

## Pass 1 — Backbone extractions (7)
- `buildEmailMessage` + pure projection helpers (`stripHtml`/`truncateBody`/`normalizeAddressList`) — single `ParsedMail→EmailMessage` projection.
- `verifyRelocatedMessages` — UIDPLUS/Message-ID verified-landing (the All-Mail no-op guard).
- `groupEmailsByFolder` — per-source grouping shared by all 5 bulk methods.
- `chunkedBatchOp` → single config object.
- `buildBridgeTlsConfig` — one Bridge-TLS decision for connect()/IDLE/connection-check.
- `validateAttachmentLimits` — shared by SMTP sendEmail + IMAP saveDraft.
- `validateSearchInput` + `buildSearchCriteria` — search arg validation + SearchObject mapping out of the handler.

~500+ LOC of duplication removed; bulk methods are thin wrappers.

## Pass 2 — Ultra-review rebuilds (9.5 gate)
Multi-agent ultra-review scored every backbone function (`docs/quality-audit.md`): 7 PASS (five 10/10), 2 confirmed REBUILD:
- `groupEmailsByFolder` — split ID-format validation from discovery/transport failure ("Failed to locate email <id>" vs the misleading "Invalid email ID").
- `validateSearchInput` (TOOL-017) — `dateFrom`/`dateTo` now require a parseable date string (was type-only, silently dropped bad input).

## Pass 3 — CodeQL + Copilot fixes
- `stripHtml` close-tag regex `<\/script[^>]*>` / `<\/style[^>]*>` so junk-before-`>` (`</script foo>`) can't bypass the block strip (CodeQL js/bad-tag-filter, high).
- `connect()` `isLocalhost` includes IPv6 loopback `::1` to match `buildBridgeTlsConfig`.
- `search-input` rejects non-string `body`/`text`/`bcc` (contract: throw on malformed input).
- Removed now-unused `ParsedMail`/`AddressObject` imports.

## Test plan
- [x] preship gate PASS (local + CI ship-readiness)
- [x] Cross-platform matrix (ubuntu/macos/windows × node 20/22) PASS
- [x] CodeQL PASS — zero open alerts on the PR
- [x] New unit tests: imap-helpers, bridge-tls.config, search-input, validateAttachmentLimits, groupEmailsByFolder discovery-error path

## Security checklist
- [x] No secrets/keys/credentials
- [x] No new attack surface; IMAP-search sanitization, header-injection caps, cert-pinning, SSRF allow-list preserved; HTML-strip hardened
- [x] Error-message substrings preserved so input/validation guards still match

🤖 Generated with [Claude Code](https://claude.com/claude-code)