### PR TITLE
Phase 1: Folders — expose specialUse/folderType + fix fail-open protection

### DIFF
--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -39,6 +39,29 @@ through and was silently dropped (violated the TOOL-017 contract honored by
 non-strings to match the documented "throws on malformed input" contract.
 Tests added in `search-input.test.ts`.
 
+## Phase 1 — Folders (`refactor/phase1-folders`)
+
+| Function | File | Job | Simpl | Eleg | Sec | Focus | Avg | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| `deleteFolder` | simple-imap-service.ts | 10 | 9 | 10 | 10 | 9 | 9.6 | PASS |
+| `createFolder` + `ensureFolderExists` | simple-imap-service.ts | 9 | 9 | 9 | 9.5 | 9 | 9.1 | PASS¹ |
+| `renameFolder` | simple-imap-service.ts | 8.5 | 9 | 8.5 | 9 | 9 | 8.8 | REBUILT → PASS² |
+| `get_folders` tool + schema | tools/folders.ts | 8 | 9 | 8 | 9 | 8 | 8.4 | REBUILT → PASS³ |
+| `getFolders` + `syncFolders` | simple-imap-service.ts | 7 | 8 | 8 | 6 | 8 | 7.4 | REBUILT → PASS⁴ |
+
+¹ First reviewer 9.1/REBUILD; adversarial verifier did not confirm a genuine defect — PASS.
+
+² **Rebuilt:** added the same cross-namespace collision detection `createFolder` has (extracted to shared `isNameInUse`); the listing fallback now catches a `Folders/X`→`Labels/X` collision even when Bridge omits the ALREADYEXISTS text. Also refuses renaming a folder INTO a reserved system name. Tests in `folder-management.test.ts`.
+
+³ **Rebuilt** (this branch's primary capability gap): `get_folders` `outputSchema` now advertises `specialUse` + `folderType` (enum system|user-folder|label), and the description steers agents to special-use over English-name matching and away from the `\All` union. Tests in `folders.test.ts`.
+
+⁴ **Rebuilt — two blockers + a security fix:**
+- **`isProtectedFolder` failed OPEN** (security): if `getFolders()` threw, it swallowed and returned `false`, letting `delete`/`rename` hit a localised system mailbox (e.g. `Papelera`=\Trash). Now fails CLOSED — discovery failure propagates and the destructive op refuses.
+- **`Promise.all` → `Promise.allSettled`**: one folder's `STATUS` rejection no longer nukes the whole listing; a failed probe yields 0/0 counts.
+- **IMAP-012**: a cold-cache + disconnect now throws `IMAPNotConnectedError` instead of returning `[]` (indistinguishable from a zero-folder account), matching `getEmails`.
+- **Constant drift**: `SYSTEM_PATHS`/`PROTECTED_NAMES` unified into one `SYSTEM_FOLDER_NAMES` source of truth (classification now includes `junk`).
+Tests: allSettled best-effort, junk classification, localised-mailbox protection, fail-closed-on-discovery-failure.
+
 ### PR #192 reviewer fixes (CodeQL + Copilot)
 - `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
   whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).

--- a/src/services/folder-management.test.ts
+++ b/src/services/folder-management.test.ts
@@ -12,9 +12,13 @@ vi.mock('imapflow', () => {
       mailboxRename: vi.fn().mockResolvedValue(undefined),
       on: vi.fn(), // enables client.on('close'/'error') event handler registration
       list: vi.fn().mockResolvedValue([
-        { path: 'INBOX', delimiter: '/', flags: new Set() },
-        { path: 'Sent', delimiter: '/', flags: new Set() },
+        { path: 'INBOX', name: 'INBOX', delimiter: '/', flags: new Set() },
+        { path: 'Sent', name: 'Sent', delimiter: '/', flags: new Set() },
       ]),
+      // getFolders fans STATUS out per folder; isProtectedFolder relies on a
+      // working getFolders to resolve specialUse (fail-closed), so the mock must
+      // answer STATUS.
+      status: vi.fn().mockResolvedValue({ messages: 0, unseen: 0 }),
     };
   });
 
@@ -167,7 +171,7 @@ describe('Folder Management', () => {
       });
 
       await expect(service.renameFolder('OldName', 'ExistingName')).rejects.toThrow(
-        "Folder 'ExistingName' already exists"
+        "A folder or label named 'ExistingName' already exists"
       );
     });
 
@@ -184,6 +188,52 @@ describe('Folder Management', () => {
       mockClient.mailboxRename.mockRejectedValueOnce(genericError);
 
       await expect(service.renameFolder('OldName', 'NewName')).rejects.toThrow('Internal server error');
+    });
+  });
+
+  describe('Bridge-semantics protections (Phase 1 ultra-review)', () => {
+    it('protects a LOCALISED system mailbox by specialUse, not just English name', async () => {
+      const mockClient = (service as any).client;
+      // Spanish Trash: name check misses it; specialUse \Trash must still protect it.
+      mockClient.list.mockResolvedValueOnce([
+        { path: 'Papelera', name: 'Papelera', delimiter: '/', flags: new Set(), specialUse: '\\Trash' },
+      ]);
+      await expect(service.deleteFolder('Papelera')).rejects.toThrow(
+        'Cannot delete protected folder: Papelera'
+      );
+      expect(mockClient.mailboxDelete).not.toHaveBeenCalled();
+    });
+
+    it('fails CLOSED: refuses delete when folder discovery fails (no silent destroy)', async () => {
+      const mockClient = (service as any).client;
+      mockClient.list.mockRejectedValueOnce(new Error('discovery down'));
+      // A non-English name can't be ruled out as a localised system mailbox when
+      // discovery fails — the delete must throw, never proceed.
+      await expect(service.deleteFolder('Folders/Maybe')).rejects.toThrow();
+      expect(mockClient.mailboxDelete).not.toHaveBeenCalled();
+    });
+
+    it('refuses renaming a folder INTO a reserved system name', async () => {
+      const mockClient = (service as any).client;
+      await expect(service.renameFolder('Folders/Work', 'Inbox')).rejects.toThrow(
+        'Cannot rename to a protected folder name: Inbox'
+      );
+      expect(mockClient.mailboxRename).not.toHaveBeenCalled();
+    });
+
+    it('detects a cross-namespace rename collision even when the server omits ALREADYEXISTS text', async () => {
+      const mockClient = (service as any).client;
+      // Labels/Tech already exists; renaming Folders/Tech collides on the shared
+      // leaf name. Server returns a generic error with no alreadyexists text →
+      // the listing-based isNameInUse fallback must still catch it.
+      mockClient.list.mockResolvedValue([
+        { path: 'INBOX', name: 'INBOX', delimiter: '/', flags: new Set() },
+        { path: 'Labels/Tech', name: 'Tech', delimiter: '/', flags: new Set() },
+      ]);
+      mockClient.mailboxRename.mockRejectedValueOnce(new Error('generic failure'));
+      await expect(service.renameFolder('Folders/Tech', 'Labels/Tech')).rejects.toThrow(
+        "A folder or label named 'Labels/Tech' already exists"
+      );
     });
   });
 

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -1220,13 +1220,13 @@ describe("SimpleIMAPService.getFolders", () => {
     expect(folders[0].path).toBe("INBOX");
   });
 
-  it("returns empty array when ensureConnection throws and cache is empty", async () => {
+  it("throws (not []) when ensureConnection fails and cache is empty (IMAP-012)", async () => {
     const svc = new SimpleIMAPService();
     vi.spyOn(svc as any, "ensureConnection").mockRejectedValue(new Error("no connection config"));
 
-    const folders = await svc.getFolders();
-
-    expect(folders).toEqual([]);
+    // An empty array would be indistinguishable from a real zero-folder account;
+    // surface the connection failure instead.
+    await expect(svc.getFolders()).rejects.toThrow(/Cannot list folders/);
   });
 
   it("returns cached folders when ensureConnection throws and cache has data", async () => {
@@ -1242,15 +1242,13 @@ describe("SimpleIMAPService.getFolders", () => {
     expect(folders[0].path).toBe("Sent");
   });
 
-  it("returns empty array when client is null after ensureConnection", async () => {
+  it("throws (not []) when client is null after ensureConnection and cache is empty (IMAP-012)", async () => {
     const svc = new SimpleIMAPService();
     // ensureConnection succeeds but client remains null
     vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
     (svc as any).client = null;
 
-    const folders = await svc.getFolders();
-
-    expect(folders).toEqual([]);
+    await expect(svc.getFolders()).rejects.toThrow(/Cannot list folders/);
   });
 
   it("fetches from IMAP when cache is empty and client is connected", async () => {
@@ -1286,6 +1284,46 @@ describe("SimpleIMAPService.getFolders", () => {
     (svc as any).client = mockClient;
 
     await expect(svc.getFolders()).rejects.toThrow("IMAP list failed");
+  });
+
+  it("one folder's STATUS rejection does not nuke the whole listing (allSettled)", async () => {
+    const svc = new SimpleIMAPService();
+    const mockClient = {
+      list: vi.fn().mockResolvedValue([
+        { path: "INBOX", name: "INBOX", delimiter: "/", flags: new Set(), specialUse: undefined },
+        { path: "Folders/Flaky", name: "Flaky", delimiter: "/", flags: new Set(), specialUse: undefined },
+      ]),
+      status: vi.fn().mockImplementation((path: string) =>
+        path === "Folders/Flaky"
+          ? Promise.reject(new Error("STATUS failed for this mailbox"))
+          : Promise.resolve({ messages: 7, unseen: 1 })),
+    };
+    vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
+    (svc as any).client = mockClient;
+
+    const folders = await svc.getFolders();
+
+    expect(folders).toHaveLength(2);
+    expect(folders.find(f => f.path === "INBOX")!.totalMessages).toBe(7);
+    // The flaky folder still appears, with safe 0 counts rather than dropping it.
+    const flaky = folders.find(f => f.path === "Folders/Flaky")!;
+    expect(flaky.totalMessages).toBe(0);
+    expect(flaky.unreadMessages).toBe(0);
+  });
+
+  it("classifies a folder named 'Junk' as system (SYSTEM_FOLDER_NAMES includes junk)", async () => {
+    const svc = new SimpleIMAPService();
+    const mockClient = {
+      list: vi.fn().mockResolvedValue([
+        { path: "Junk", name: "Junk", delimiter: "/", flags: new Set(), specialUse: undefined },
+      ]),
+      status: vi.fn().mockResolvedValue({ messages: 0, unseen: 0 }),
+    };
+    vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
+    (svc as any).client = mockClient;
+
+    const folders = await svc.getFolders();
+    expect(folders.find(f => f.path === "Junk")!.folderType).toBe("system");
   });
 
   it("uses 0 when status.messages and status.unseen are missing (lines 526-527)", async () => {

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -861,44 +861,61 @@ export class SimpleIMAPService {
       return cached;
     }
 
+    // On a connection failure, serve the last-known folders if we have them
+    // (degraded but truthful). With an EMPTY cache we must NOT return [] —
+    // that's indistinguishable from "this account has zero folders" (IMAP-012,
+    // same contract as getEmails). Throw so callers see the connection error.
+    const cachedOrThrow = (why: string): EmailFolder[] => {
+      if (this.folderCache.size > 0) {
+        logger.warn(`${why} — returning cached folders`, 'IMAPService');
+        const cached = Array.from(this.folderCache.values());
+        tags.resultCount = cached.length;
+        return cached;
+      }
+      throw new IMAPNotConnectedError(`Cannot list folders: ${why}`);
+    };
+
     try {
       await this.ensureConnection();
     } catch (error) {
-      logger.warn('IMAP not connected, returning cached folders', 'IMAPService');
-      const cached = Array.from(this.folderCache.values());
-      tags.resultCount = cached.length;
-      return cached;
+      return cachedOrThrow('IMAP not connected');
     }
 
     if (!this.client) {
-      logger.warn('IMAP client not available, returning cached folders', 'IMAPService');
-      const cached = Array.from(this.folderCache.values());
-      tags.resultCount = cached.length;
-      return cached;
+      return cachedOrThrow('IMAP client not available');
     }
 
     try {
       const folders = await this.client.list();
       const result: EmailFolder[] = [];
 
-      const SYSTEM_PATHS = new Set(['inbox','sent','drafts','trash','spam','archive','all mail','starred']);
-
       // IMAP-022: issue the per-folder STATUS probes concurrently. The previous
       // serial `await` loop cost one full round-trip per folder (30+ on a
       // label-heavy Proton account => >1s per cache miss). imapflow pipelines
-      // STATUS commands fine, so Promise.all collapses this to ~one round-trip.
+      // STATUS commands fine, so this collapses to ~one round-trip.
+      // allSettled (not all): one folder's STATUS rejecting — a transient
+      // per-mailbox error or a folder that vanished mid-list — must NOT nuke the
+      // entire listing. A failed probe yields a folder with 0/0 counts rather
+      // than dropping it or throwing.
       const client = this.client;
-      const statuses = await Promise.all(
+      const statuses = await Promise.allSettled(
         folders.map(folder => client.status(folder.path, { messages: true, unseen: true })),
       );
 
       folders.forEach((folder, i) => {
-        const status = statuses[i];
+        const settled = statuses[i];
+        const status = settled.status === 'fulfilled' ? settled.value : undefined;
+        if (!status) {
+          logger.warn(`STATUS probe failed for folder '${folder.path}' — reporting 0 counts`, 'IMAPService');
+        }
 
+        // specialUse is the authoritative system-mailbox signal (works for
+        // localised paths like `Papelera`); the name set is the fallback for
+        // servers that don't report it.
         let folderType: 'system' | 'user-folder' | 'label';
         if (folder.path.startsWith('Labels/')) {
           folderType = 'label';
-        } else if (folder.specialUse || SYSTEM_PATHS.has(folder.path.toLowerCase())) {
+        } else if (folder.specialUse || SimpleIMAPService.SYSTEM_FOLDER_NAMES.has(folder.path.toLowerCase())) {
           folderType = 'system';
         } else {
           folderType = 'user-folder';
@@ -907,8 +924,8 @@ export class SimpleIMAPService {
         const emailFolder: EmailFolder = {
           name: folder.name,
           path: folder.path,
-          totalMessages: status.messages || 0,
-          unreadMessages: status.unseen || 0,
+          totalMessages: status?.messages || 0,
+          unreadMessages: status?.unseen || 0,
           specialUse: folder.specialUse,
           folderType,
         };
@@ -2679,6 +2696,25 @@ export class SimpleIMAPService {
    * when missing (the COPY would otherwise target a nonexistent Labels/<name>,
    * which Bridge may silently no-op).
    */
+  /**
+   * Proton shares ONE namespace across `Folders/` and `Labels/`, so a leaf name
+   * is unique across both — creating `Labels/Tech` when `Folders/Tech` exists
+   * collides. Returns true if `folderName` (exact path) or its leaf already
+   * exists as a folder or label. The server reports this as ALREADYEXISTS /
+   * 409 Code=2500, but doesn't always pass the text through — this is the
+   * listing-based fallback verification shared by createFolder + renameFolder.
+   */
+  private async isNameInUse(folderName: string): Promise<boolean> {
+    const leaf = (folderName.split('/').pop() || '').trim().toLowerCase();
+    const folders = await this.getFolders();
+    return folders.some((f) => {
+      const p = f.path;
+      return p === folderName ||
+        ((p.startsWith('Folders/') || p.startsWith('Labels/')) &&
+          (p.split('/').pop() || '').trim().toLowerCase() === leaf);
+    });
+  }
+
   async ensureFolderExists(folderName: string): Promise<void> {
     this.validateFolderName(folderName);
     if (!this.isConnected || !this.client) throw new Error('IMAP client not connected');
@@ -2723,16 +2759,8 @@ export class SimpleIMAPService {
       // by listing (a folder/label leaf name is unique across both namespaces).
       let conflict = hay.includes('alreadyexists') || hay.includes('already exists') || hay.includes('code=2500');
       if (!conflict) {
-        try {
-          const leaf = (folderName.split('/').pop() || '').trim().toLowerCase();
-          const folders = await this.getFolders();
-          conflict = folders.some((f) => {
-            const p = f.path;
-            return p === folderName ||
-              ((p.startsWith('Folders/') || p.startsWith('Labels/')) &&
-                (p.split('/').pop() || '').trim().toLowerCase() === leaf);
-          });
-        } catch { /* listing failed — fall through to the raw error */ }
+        try { conflict = await this.isNameInUse(folderName); }
+        catch { /* listing failed — fall through to the raw error */ }
       }
       if (conflict) {
         logger.warn(`Folder/label name already in use: ${folderName}`, 'IMAPService');
@@ -2748,9 +2776,14 @@ export class SimpleIMAPService {
   private static readonly PROTECTED_SPECIAL_USE = new Set([
     '\\Inbox', '\\Sent', '\\Drafts', '\\Trash', '\\Junk', '\\Archive', '\\All', '\\Flagged',
   ]);
-  private static readonly PROTECTED_NAMES = new Set([
+  /** The one authoritative set of system-mailbox names (casefolded). Drives BOTH
+   *  folder classification (getFolders) AND destructive-op protection
+   *  (isProtectedFolder) so the two can't drift — `spam`/`junk` both map to
+   *  \Junk, so both are listed. */
+  private static readonly SYSTEM_FOLDER_NAMES = new Set([
     'inbox', 'sent', 'drafts', 'trash', 'spam', 'junk', 'archive', 'all mail', 'starred',
   ]);
+  private static readonly PROTECTED_NAMES = SimpleIMAPService.SYSTEM_FOLDER_NAMES;
 
   /**
    * IMAP-014: decide whether a folder is a protected system mailbox before a
@@ -2762,17 +2795,16 @@ export class SimpleIMAPService {
   private async isProtectedFolder(folderName: string): Promise<boolean> {
     const normalized = folderName.trim().toLowerCase();
     if (SimpleIMAPService.PROTECTED_NAMES.has(normalized)) return true;
-    try {
-      const folders = await this.getFolders();
-      const match = folders.find(f => f.path.trim().toLowerCase() === normalized);
-      if (match?.specialUse && SimpleIMAPService.PROTECTED_SPECIAL_USE.has(match.specialUse)) {
-        return true;
-      }
-    } catch (error) {
-      // Discovery failed — fall back to the name check already performed above.
-      logger.warn('Folder discovery failed during protected-folder check', 'IMAPService', error);
-    }
-    return false;
+    // A localised system mailbox (e.g. `Papelera` = \Trash) is only identifiable
+    // by its server-reported specialUse, which requires folder discovery. If
+    // discovery fails we CANNOT prove the target isn't a system mailbox, so we
+    // must fail CLOSED: let the error propagate and refuse the destructive op,
+    // never swallow-and-return-false (which would let INBOX/Trash be deleted on
+    // a transient blip). getFolders serves a warm cache when merely disconnected,
+    // so this only throws when there's genuinely no way to verify.
+    const folders = await this.getFolders();
+    const match = folders.find(f => f.path.trim().toLowerCase() === normalized);
+    return !!(match?.specialUse && SimpleIMAPService.PROTECTED_SPECIAL_USE.has(match.specialUse));
   }
 
   /**
@@ -2831,6 +2863,10 @@ export class SimpleIMAPService {
     if (await this.isProtectedFolder(oldName)) {
       throw new Error(`Cannot rename protected folder: ${oldName}`);
     }
+    // ...and don't let a folder be renamed INTO a reserved system-mailbox name.
+    if (SimpleIMAPService.PROTECTED_NAMES.has(newName.trim().toLowerCase())) {
+      throw new Error(`Cannot rename to a protected folder name: ${newName}`);
+    }
 
     try {
       logger.debug(`Renaming folder: ${oldName} -> ${newName}`, 'IMAPService');
@@ -2843,12 +2879,21 @@ export class SimpleIMAPService {
       logger.info(`Folder renamed: ${oldName} -> ${newName}`, 'IMAPService');
       return true;
     } catch (error: unknown) {
-      const rt = (error as { responseText?: string }).responseText;
-      if (rt?.includes('NONEXISTENT')) {
+      const rt = (error as { responseText?: string }).responseText || '';
+      const em = error instanceof Error ? error.message : String(error);
+      const hay = `${rt} ${em}`.toLowerCase();
+      if (hay.includes('nonexistent')) {
         throw new Error(`Folder '${oldName}' does not exist`);
       }
-      if (rt?.includes('ALREADYEXISTS')) {
-        throw new Error(`Folder '${newName}' already exists`);
+      // Same cross-namespace collision as createFolder: ALREADYEXISTS / 409
+      // Code=2500, with a listing-based fallback when the text isn't passed through.
+      let conflict = hay.includes('alreadyexists') || hay.includes('already exists') || hay.includes('code=2500');
+      if (!conflict) {
+        try { conflict = await this.isNameInUse(newName); }
+        catch { /* listing failed — fall through to the raw error */ }
+      }
+      if (conflict) {
+        throw new Error(`A folder or label named '${newName}' already exists. Proton shares one namespace across folders and labels, so the name can't be reused.`);
       }
       logger.error('Failed to rename folder', 'IMAPService', error);
       throw error;

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -2691,12 +2691,6 @@ export class SimpleIMAPService {
   }
 
   /**
-   * Create a mailbox if it does not already exist; no-op when it is present.
-   * Used by the label tools so "move/copy to label X" actually creates label X
-   * when missing (the COPY would otherwise target a nonexistent Labels/<name>,
-   * which Bridge may silently no-op).
-   */
-  /**
    * Proton shares ONE namespace across `Folders/` and `Labels/`, so a leaf name
    * is unique across both — creating `Labels/Tech` when `Folders/Tech` exists
    * collides. Returns true if `folderName` (exact path) or its leaf already
@@ -2715,6 +2709,12 @@ export class SimpleIMAPService {
     });
   }
 
+  /**
+   * Create a mailbox if it does not already exist; no-op when it is present.
+   * Used by the label tools so "move/copy to label X" actually creates label X
+   * when missing (the COPY would otherwise target a nonexistent Labels/<name>,
+   * which Bridge may silently no-op).
+   */
   async ensureFolderExists(folderName: string): Promise<void> {
     this.validateFolderName(folderName);
     if (!this.isConnected || !this.client) throw new Error('IMAP client not connected');

--- a/src/tools/folders.test.ts
+++ b/src/tools/folders.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import mod from "./folders.js";
+import type { ToolCallContext, ToolResult } from "./types.js";
+import type { EmailFolder } from "../types/index.js";
+
+/** Minimal ctx stub — folder handlers only touch imapService + the response helpers. */
+function makeCtx(over: Partial<ToolCallContext>): ToolCallContext {
+  const ok = (structured: Record<string, unknown>): ToolResult => ({
+    content: [{ type: "text", text: JSON.stringify(structured) }],
+    structuredContent: structured,
+  });
+  return { ok, ...over } as unknown as ToolCallContext;
+}
+
+describe("get_folders tool contract", () => {
+  const def = mod.defs.find((d) => d.name === "get_folders")!;
+
+  it("advertises specialUse + folderType in its outputSchema (capability discovery)", () => {
+    const props = (def.outputSchema as { properties: { folders: { items: { properties: Record<string, unknown>; required: string[] } } } })
+      .properties.folders.items;
+    expect(props.properties.specialUse).toBeDefined();
+    expect(props.properties.folderType).toBeDefined();
+    expect((props.properties.folderType as { enum: string[] }).enum)
+      .toEqual(["system", "user-folder", "label"]);
+    // The four always-present scalars stay required; the classification fields
+    // are optional (ordinary folders have no specialUse).
+    expect(props.required).toEqual(["name", "path", "totalMessages", "unreadMessages"]);
+    expect(props.required).not.toContain("specialUse");
+  });
+
+  it("description steers agents to specialUse over English-name matching", () => {
+    expect(def.description).toMatch(/specialUse/);
+    expect(def.description).toMatch(/All Mail|\\\\All/);
+  });
+
+  it("passes folderType + specialUse through to structuredContent", async () => {
+    const folders: EmailFolder[] = [
+      { name: "INBOX", path: "INBOX", totalMessages: 3, unreadMessages: 1, specialUse: "\\Inbox", folderType: "system" },
+      { name: "Trash", path: "Papelera", totalMessages: 0, unreadMessages: 0, specialUse: "\\Trash", folderType: "system" },
+      { name: "Work", path: "Labels/Work", totalMessages: 5, unreadMessages: 0, folderType: "label" },
+      { name: "Project", path: "Folders/Project", totalMessages: 2, unreadMessages: 0, folderType: "user-folder" },
+    ];
+    const ctx = makeCtx({ imapService: { getFolders: async () => folders } as unknown as ToolCallContext["imapService"] });
+    const res = await mod.handlers.get_folders(ctx);
+    const out = res.structuredContent as { folders: EmailFolder[] };
+    expect(out.folders).toHaveLength(4);
+    expect(out.folders[1]).toMatchObject({ path: "Papelera", specialUse: "\\Trash", folderType: "system" });
+    expect(out.folders[2]).toMatchObject({ folderType: "label" });
+    expect(out.folders[3]).toMatchObject({ folderType: "user-folder" });
+  });
+});

--- a/src/tools/folders.test.ts
+++ b/src/tools/folders.test.ts
@@ -22,9 +22,10 @@ describe("get_folders tool contract", () => {
     expect(props.properties.folderType).toBeDefined();
     expect((props.properties.folderType as { enum: string[] }).enum)
       .toEqual(["system", "user-folder", "label"]);
-    // The four always-present scalars stay required; the classification fields
-    // are optional (ordinary folders have no specialUse).
-    expect(props.required).toEqual(["name", "path", "totalMessages", "unreadMessages"]);
+    // folderType is always populated by the service, so the contract requires it;
+    // specialUse stays optional (ordinary folders have none).
+    expect(props.required).toEqual(["name", "path", "totalMessages", "unreadMessages", "folderType"]);
+    expect(props.required).toContain("folderType");
     expect(props.required).not.toContain("specialUse");
   });
 

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -22,7 +22,11 @@ export const defs: ToolDef[] = [
     name: "get_folders",
     title: "Get Folders",
     description:
-      "List all email folders with message counts. Labels appear as folders with the Labels/ prefix (e.g. Labels/Work).",
+      "List all email folders with message counts. Labels appear as folders with the Labels/ prefix (e.g. Labels/Work). " +
+      "Each folder reports `folderType` (system | user-folder | label) and, for system mailboxes, the IMAP `specialUse` " +
+      "attribute (\\Inbox \\Sent \\Drafts \\Trash \\Junk \\Archive \\All \\Flagged) — use these to identify the real " +
+      "Trash/Sent/Archive on a localised account rather than matching English names, and to avoid moving mail into the " +
+      "\\All (All Mail) union view.",
     annotations: { readOnlyHint: true, openWorldHint: true },
     inputSchema: { type: "object", properties: {} },
     outputSchema: {
@@ -37,7 +41,17 @@ export const defs: ToolDef[] = [
               path: { type: "string" },
               totalMessages: { type: "number" },
               unreadMessages: { type: "number" },
+              specialUse: {
+                type: "string",
+                description: "IMAP special-use attribute for system mailboxes (e.g. \\Trash, \\Sent, \\All). Absent for ordinary folders/labels.",
+              },
+              folderType: {
+                type: "string",
+                enum: ["system", "user-folder", "label"],
+                description: "Proton Bridge classification: system mailbox, user-created folder, or label (Labels/ prefix).",
+              },
             },
+            required: ["name", "path", "totalMessages", "unreadMessages"],
           },
         },
       },

--- a/src/tools/folders.ts
+++ b/src/tools/folders.ts
@@ -51,7 +51,7 @@ export const defs: ToolDef[] = [
                 description: "Proton Bridge classification: system mailbox, user-created folder, or label (Labels/ prefix).",
               },
             },
-            required: ["name", "path", "totalMessages", "unreadMessages"],
+            required: ["name", "path", "totalMessages", "unreadMessages", "folderType"],
           },
         },
       },


### PR DESCRIPTION
## Summary
Phase 1 of the Bridge-capability program (plan `crispy-wibbling-dusk`). Closes the folder-subsystem capability gap and fixes the defects the multi-agent ultra-review surfaced — including a **fail-open security hole**. Verdicts ledgered in `docs/quality-audit.md`.

## Capability gap
- `get_folders` `outputSchema` now advertises **`specialUse`** + **`folderType`** (`system | user-folder | label`). The service already computed them; the tool contract hid them. Description now steers agents to identify Trash/Sent/Archive by IMAP special-use (works on localised accounts) rather than English names, and to avoid moving into the `\All` (All Mail) union.

## Ultra-review rebuilds (9.5 gate)
`getFolders` scored **7.4** — two blockers + a security issue:
- **SECURITY — `isProtectedFolder` failed OPEN:** if `getFolders()` threw, it swallowed the error and returned `false`, letting `delete_folder`/`rename_folder` destroy a **localised** system mailbox (e.g. `Papelera` = `\Trash`) on a transient blip. Now **fails CLOSED** — discovery failure propagates and the destructive op refuses.
- **`Promise.all` → `Promise.allSettled`:** one folder's `STATUS` rejection no longer nukes the entire listing; a failed probe yields 0/0 counts and the folder still appears.
- **IMAP-012 consistency:** cold-cache + disconnect now throws `IMAPNotConnectedError` instead of returning `[]` (which was indistinguishable from a zero-folder account), matching `getEmails`.
- **Constant drift:** `SYSTEM_PATHS`/`PROTECTED_NAMES` unified into one `SYSTEM_FOLDER_NAMES` source of truth (classification now includes `junk`).

`renameFolder` (8.8): added the cross-namespace collision detection `createFolder` has — extracted to a shared `isNameInUse` helper; the listing fallback catches a `Folders/X`→`Labels/X` collision even when Bridge omits the ALREADYEXISTS text. Also refuses renaming a folder INTO a reserved system name.

`deleteFolder` (9.6) and `createFolder` (9.1, REBUILD not confirmed on adversarial verify) passed.

## BREAKING
`getFolders` now throws `IMAPNotConnectedError` (was `[]`) when disconnected with an empty cache.

## Test plan
- [x] preship gate PASS (incl. Greenmail E2E)
- [x] 2122 unit tests green (only the pre-existing live-Bridge `agent-harness` failure)
- [x] New tests: allSettled best-effort, junk classification, localised-mailbox protection, fail-closed-on-discovery-failure, rename cross-namespace collision, rename-into-reserved-name, get_folders schema/passthrough
- [ ] CI matrix + CodeQL

## Security checklist
- [x] Fixes a fail-open destructive-op gate (the headline change)
- [x] No secrets/credentials; no new external surface
- [x] Folder-name validation, namespace-collision, and protected-mailbox checks all preserved/strengthened

🤖 Generated with [Claude Code](https://claude.com/claude-code)