### PR TITLE
Phase 2: Read & fetch — pagination boundary, $Forwarded flag, attachment size guard

### DIFF
--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -62,6 +62,30 @@ Tests added in `search-input.test.ts`.
 - **Constant drift**: `SYSTEM_PATHS`/`PROTECTED_NAMES` unified into one `SYSTEM_FOLDER_NAMES` source of truth (classification now includes `junk`).
 Tests: allSettled best-effort, junk classification, localised-mailbox protection, fail-closed-on-discovery-failure.
 
+## Phase 2 — Read & fetch (`refactor/phase2-read-fetch`)
+
+| Function | File | Job | Simpl | Eleg | Sec | Focus | Avg | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| `fetchEmailFullSource` | simple-imap-service.ts | 8.5 | — | — | — | — | 8.5 | PASS¹ |
+| `getEmailById` | simple-imap-service.ts | 8 | — | — | — | — | 8.0 | PASS¹ |
+| `getEmails` | simple-imap-service.ts | 7 | 8 | 8 | 9 | 9 | 8.2 | REBUILT → PASS² |
+| `get_emails`/`get_email_by_id`/`download_attachment`/`get_thread` tool | tools/reading.ts | 8 | — | — | — | — | 8.0 | REBUILT → PASS³ |
+| `downloadAttachment` | simple-imap-service.ts | 6 | 8 | 7 | 5 | 9 | 7.0 | REBUILT → PASS⁴ |
+
+¹ First reviewer flagged REBUILD; adversarial verifier did not confirm a genuine defect (the getEmailById per-folder-scan is a documented correctness-over-speed tradeoff mitigated by caching) — PASS.
+
+² **Rebuilt — pagination boundary + flag bug:**
+- **Pagination:** `offset >= total` returned a clamped message #1 (`Math.max(1,…)` collapsed start=end=1) instead of an empty page. Now an explicit `offset >= total` guard returns `[]` before the clamp.
+- **`$Forwarded` flag:** the list view read the non-existent `\Forward` (never matched) while the forward setter writes `$Forwarded` — every message read back as not-forwarded. Now reads `$Forwarded` || `\Forwarded`.
+
+³ Covered by the getEmails/downloadAttachment rebuilds; tool defs reviewed, no separate defect.
+
+⁴ **Rebuilt — security (memory) + correctness:**
+- **Size-guard bypass:** the oversize check read STALE cached `att.size` (which is `?? 0` from bodyStructure) before the re-fetch and never re-checked the fetched bytes — a large attachment with understated/0 cached size could OOM. Now guards on the ACTUAL resolved byte length right before the base64 expansion.
+- **Attachment-order drift:** the index came from a bodyStructure-ordered list view but the re-fetch uses mailparser order; on a mismatch `downloadAttachment` now re-maps by filename so it returns the file the caller selected, not the drifted index.
+- Also fixed the `\Forward` flag in `buildEmailMessage` (shared by getEmailById).
+Tests: pagination empty-page, $Forwarded read (list + buildEmailMessage), oversize-on-refetch guard, filename re-map on order drift.
+
 ### PR #192 reviewer fixes (CodeQL + Copilot)
 - `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
   whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -103,7 +103,7 @@ describe("buildEmailMessage", () => {
 
   it("maps attachments + hasAttachment, and reads answered/forwarded flags", () => {
     const e = buildEmailMessage(
-      msg(7, ["\\Answered", "\\Forward"]),
+      msg(7, ["\\Answered", "$Forwarded"]),
       parsed({ attachments: [{ filename: "a.pdf", contentType: "application/pdf", size: 10, content: Buffer.from("x"), cid: "c1" } as never] }),
       "INBOX",
     );
@@ -111,6 +111,11 @@ describe("buildEmailMessage", () => {
     expect(e.attachments?.[0]).toMatchObject({ filename: "a.pdf", contentType: "application/pdf", size: 10, contentId: "c1" });
     expect(e.isAnswered).toBe(true);
     expect(e.isForwarded).toBe(true);
+  });
+
+  it("reads the standard \\Forwarded flag too (not the bogus \\Forward)", () => {
+    expect(buildEmailMessage(msg(8, ["\\Forwarded"]), parsed({}), "INBOX").isForwarded).toBe(true);
+    expect(buildEmailMessage(msg(9, ["\\Forward"]), parsed({}), "INBOX").isForwarded).toBe(false);
   });
 });
 

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -217,7 +217,10 @@ export function buildEmailMessage(
     inReplyTo: parsed.inReplyTo,
     references: parsed.references,
     isAnswered: message.flags?.has("\\Answered") ?? false,
-    isForwarded: message.flags?.has("\\Forward") ?? false,
+    // Bridge marks a forward with the `$Forwarded` keyword (what our own
+    // forward setter writes) or the standard `\Forwarded` — NOT `\Forward`,
+    // which never matches and made every message read back as not-forwarded.
+    isForwarded: message.flags?.has("$Forwarded") || message.flags?.has("\\Forwarded") || false,
     isSignedPGP: ctStr.includes("multipart/signed") && ctStr.includes("application/pgp-signature"),
     isEncryptedPGP: ctStr.includes("multipart/encrypted") && ctStr.includes("application/pgp-encrypted"),
     protonId: typeof pmId === "string" ? pmId.trim() : undefined,

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -1493,6 +1493,48 @@ describe("SimpleIMAPService.getEmails", () => {
     expect(emails).toHaveLength(0);
   });
 
+  it("returns [] (not a clamped message #1) when offset is at/beyond the message count", async () => {
+    const svc = new SimpleIMAPService();
+    vi.spyOn(svc as any, "validateFolderName").mockImplementation(() => {});
+    vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
+    vi.spyOn(svc as any, "checkAndUpdateUidValidity").mockImplementation(() => {});
+
+    const fetch = vi.fn();
+    (svc as any).client = {
+      getMailboxLock: vi.fn().mockResolvedValue(makeLock()),
+      mailbox: { exists: 5 },
+      fetch,
+    };
+
+    // offset (5) == total (5): an empty page, not message #1.
+    expect(await svc.getEmails("INBOX", 50, 5)).toEqual([]);
+    // offset beyond total too.
+    expect(await svc.getEmails("INBOX", 50, 100)).toEqual([]);
+    // The Math.max(1,…) clamp must never reach a FETCH for an out-of-range page.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("reads $Forwarded in the list view (not the bogus \\Forward)", async () => {
+    const svc = new SimpleIMAPService();
+    vi.spyOn(svc as any, "validateFolderName").mockImplementation(() => {});
+    vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
+    vi.spyOn(svc as any, "checkAndUpdateUidValidity").mockImplementation(() => {});
+    vi.spyOn(svc as any, "countAttachments").mockReturnValue(0);
+
+    const mockMsg = {
+      uid: 7, envelope: { subject: "Fwd", from: [{ address: "a@x.com" }], date: new Date() },
+      flags: new Set(["$Forwarded"]), bodyParts: new Map([["1", Buffer.from("hi")]]), bodyStructure: {},
+    };
+    (svc as any).client = {
+      getMailboxLock: vi.fn().mockResolvedValue(makeLock()),
+      mailbox: { exists: 1 },
+      fetch: vi.fn().mockReturnValue(asyncMessages([mockMsg])),
+    };
+
+    const emails = await svc.getEmails("INBOX");
+    expect(emails[0].isForwarded).toBe(true);
+  });
+
   it("throws when fetch() rejects", async () => {
     const svc = new SimpleIMAPService();
     vi.spyOn(svc as any, "validateFolderName").mockImplementation(() => {});

--- a/src/services/simple-imap-service.newfeatures.test.ts
+++ b/src/services/simple-imap-service.newfeatures.test.ts
@@ -236,6 +236,60 @@ describe("SimpleIMAPService.downloadAttachment", () => {
     const result = await svc.downloadAttachment("777", 0);
     expect(result).toBeNull();
   });
+
+  it("rejects an oversize re-fetched attachment even when cached size was understated (PARSE-014)", async () => {
+    const svc = new SimpleIMAPService();
+    vi.spyOn(svc as any, "validateEmailId").mockImplementation(() => {});
+    // Cached metadata claims a tiny size (or 0) so the metadata guard passes...
+    (svc as any).emailCache.set("INBOX:555", {
+      email: {
+        id: "555", from: "a@b.com", to: [], subject: "T", body: "", isHtml: false,
+        date: new Date(), folder: "INBOX", isRead: false, isStarred: false, hasAttachment: true,
+        attachments: [{ filename: "sneaky.bin", contentType: "application/octet-stream", size: 0 }],
+      },
+      cachedAt: Date.now(),
+    });
+    // ...but the actual re-fetched buffer is 26 MB (> 25 MB cap).
+    const huge = Buffer.alloc(26 * 1024 * 1024);
+    vi.spyOn(svc as any, "fetchEmailFullSource").mockResolvedValue({
+      id: "555", from: "a@b.com", to: [], subject: "T", body: "", isHtml: false,
+      date: new Date(), folder: "INBOX", isRead: false, isStarred: false, hasAttachment: true,
+      attachments: [{ filename: "sneaky.bin", contentType: "application/octet-stream", size: huge.length, content: huge }],
+    });
+
+    await expect(svc.downloadAttachment("555", 0)).rejects.toThrow(/too large/i);
+  });
+
+  it("re-maps by filename when the re-fetch attachment order drifts from cached order", async () => {
+    const svc = new SimpleIMAPService();
+    vi.spyOn(svc as any, "validateEmailId").mockImplementation(() => {});
+    // Cached order: [a.txt, b.txt]; caller asks for index 0 = a.txt.
+    (svc as any).emailCache.set("INBOX:444", {
+      email: {
+        id: "444", from: "a@b.com", to: [], subject: "T", body: "", isHtml: false,
+        date: new Date(), folder: "INBOX", isRead: false, isStarred: false, hasAttachment: true,
+        attachments: [
+          { filename: "a.txt", contentType: "text/plain", size: 1 },
+          { filename: "b.txt", contentType: "text/plain", size: 1 },
+        ],
+      },
+      cachedAt: Date.now(),
+    });
+    // Re-fetch returns the REVERSED order: index 0 is now b.txt.
+    vi.spyOn(svc as any, "fetchEmailFullSource").mockResolvedValue({
+      id: "444", from: "a@b.com", to: [], subject: "T", body: "", isHtml: false,
+      date: new Date(), folder: "INBOX", isRead: false, isStarred: false, hasAttachment: true,
+      attachments: [
+        { filename: "b.txt", contentType: "text/plain", size: 1, content: Buffer.from("BBB") },
+        { filename: "a.txt", contentType: "text/plain", size: 1, content: Buffer.from("AAA") },
+      ],
+    });
+
+    const result = await svc.downloadAttachment("444", 0);
+    // Must return a.txt (by name), not b.txt (the drifted index-0).
+    expect(result!.filename).toBe("a.txt");
+    expect(Buffer.from(result!.content, "base64").toString("utf8")).toBe("AAA");
+  });
 });
 
 // ─── saveDraft tests ──────────────────────────────────────────────────────────

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -988,10 +988,19 @@ export class SimpleIMAPService {
 
         const mailbox = this.client.mailbox;
         const total = (mailbox && typeof mailbox !== 'boolean' ? mailbox.exists : 0) || 0;
+
+        // An offset at/beyond the message count is an empty page. This MUST be
+        // checked before the Math.max(1,…) clamps below — otherwise start and
+        // end both collapse to 1 and the function wrongly returns message #1 for
+        // an out-of-range page (e.g. total=100, offset=100 → start=end=1).
+        if (total === 0 || offset >= total) {
+          return [];
+        }
+
         const start = Math.max(1, total - offset - limit + 1);
         const end = Math.max(1, total - offset);
 
-        if (start > end || total === 0) {
+        if (start > end) {
           return [];
         }
 
@@ -1066,7 +1075,8 @@ export class SimpleIMAPService {
               hasAttachment: attachmentCount > 0,
               attachments: attachmentMeta,
               isAnswered: message.flags?.has('\\Answered') ?? false,
-              isForwarded: message.flags?.has('\\Forward') ?? false,
+              // `$Forwarded` (our setter) or standard `\Forwarded` — not `\Forward`.
+              isForwarded: message.flags?.has('$Forwarded') || message.flags?.has('\\Forwarded') || false,
             };
 
             // GAP 2.4: do NOT cache list-view emails — they only have a preview body
@@ -1396,6 +1406,12 @@ export class SimpleIMAPService {
     }
 
     let att = emailMeta.attachments[idx];
+    // The index the caller passed came from a list/metadata view whose
+    // attachment ordering (bodyStructure walk) is not guaranteed identical to
+    // the mailparser ordering used by the re-fetch below. Remember the selected
+    // attachment's filename so we can re-map by name if the orders drift, rather
+    // than silently returning the wrong file.
+    const wantedName = att.filename;
 
     // PARSE-014: downloading re-fetches the full RFC822 source then base64-
     // encodes the whole attachment in memory (~raw + ~1.33x base64 + parser
@@ -1413,12 +1429,34 @@ export class SimpleIMAPService {
     if (!att.content) {
       logger.debug('Attachment content not in cache, re-fetching full email source', 'IMAPService', { emailId, attachmentIndex });
       const fresh = await this.fetchEmailFullSource(emailId, emailMeta.folder);
-      const freshAtt = fresh?.attachments?.[idx];
+      let freshAtt = fresh?.attachments?.[idx];
+      // If the indexed attachment doesn't match the name the caller selected,
+      // the metadata/parse orderings drifted — re-map by filename so we return
+      // the file the caller actually asked for.
+      if (wantedName && freshAtt?.filename !== wantedName) {
+        const byName = fresh?.attachments?.find(a => a.filename === wantedName && !!a.content);
+        if (byName) freshAtt = byName;
+      }
       if (!freshAtt?.content) {
         logger.warn('Attachment content unavailable after re-fetch', 'IMAPService', { emailId, attachmentIndex });
         return null;
       }
       att = freshAtt;
+    }
+
+    // PARSE-014 (hardened): the metadata guard above can be bypassed — cached
+    // bodyStructure size is `?? 0` (extractAttachmentMeta) and a re-fetch could
+    // report a larger attachment than the stale metadata claimed. Guard on the
+    // ACTUAL resolved byte length right before we base64-expand it (~1.33x),
+    // so an oversize attachment can't OOM regardless of what the metadata said.
+    const rawBytes = Buffer.isBuffer(att.content)
+      ? att.content.length
+      : Buffer.byteLength(att.content as string, 'base64');
+    if (rawBytes > SimpleIMAPService.MAX_ATTACHMENT_DOWNLOAD_BYTES) {
+      throw new Error(
+        `Attachment is too large to download (${Math.round(rawBytes / (1024 * 1024))} MB; ` +
+        `limit ${Math.round(SimpleIMAPService.MAX_ATTACHMENT_DOWNLOAD_BYTES / (1024 * 1024))} MB).`,
+      );
     }
 
     let content: string;


### PR DESCRIPTION
## Summary
Phase 2 of the Bridge-capability program (plan `crispy-wibbling-dusk`). The read/fetch ultra-review (verdicts in `docs/quality-audit.md`) confirmed three real defects — a memory-safety hole and two correctness bugs.

## Ultra-review rebuilds (9.5 gate)

### `downloadAttachment` (7.0) — security + correctness
- **Size-guard bypass (memory):** the oversize check read STALE cached `att.size` (which is `?? 0` from bodyStructure) *before* the re-fetch and never re-checked the fetched bytes. A large attachment with an understated/0 cached size could slip past the guard and OOM during base64 expansion. Now guards on the **actual resolved byte length** right before the ~1.33× base64 expansion.
- **Attachment-order drift:** the index came from a bodyStructure-ordered list view, but the re-fetch uses mailparser order. On a mismatch, `downloadAttachment` now **re-maps by filename** so it returns the file the caller selected, not the drifted index.

### `getEmails` (8.2) — pagination + flag
- **Pagination boundary:** `offset >= total` returned a clamped message #1 (`Math.max(1,…)` collapsed start=end=1) instead of an empty page. An explicit `offset >= total` guard now returns `[]` before the clamp.
- **`$Forwarded` flag:** the list view read the non-existent `\Forward` (never matched) while the forward setter writes `$Forwarded` — every message read back as not-forwarded. Now reads `$Forwarded` || `\Forwarded` (same fix in shared `buildEmailMessage`).

`getEmailById` (8.0) and `fetchEmailFullSource` (8.5) flagged but **not confirmed** on adversarial verify — the per-folder All-Mail-last scan is a documented correctness-over-speed tradeoff mitigated by caching.

## BREAKING
Messages flagged with the bogus `\Forward` no longer read as forwarded (that flag never existed); `$Forwarded`/`\Forwarded` are honored.

## Test plan
- [x] preship gate PASS (incl. Greenmail E2E)
- [x] 2127 unit tests green (only the pre-existing live-Bridge `agent-harness` failure)
- [x] New tests: pagination empty-page (no FETCH), `$Forwarded` read (list + buildEmailMessage), oversize-on-refetch guard, filename re-map on order drift, standard `\Forwarded`
- [ ] CI matrix + CodeQL

## Security checklist
- [x] Closes an unbounded-memory attachment-download path (the headline)
- [x] No secrets/credentials; emailId/folder/index validation preserved
- [x] No new external surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)