### PR TITLE
Phase 4: Flags — mark_answered/mark_forwarded + bulkStar cache fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bridge-capability program (subsystem-by-subsystem TDD redesign + per-function ul
 
 ### Added
 
+- **`mark_answered` / `mark_forwarded` tools** — set/clear the IMAP `\Answered` flag and the `$Forwarded` keyword (the marker the forward tool writes and the readers now honour). Both thread `sourceFolder` and wrap the existing `setFlag`.
 - **`empty_trash` tool** — the one sanctioned permanent-delete path. PERMANENTLY EXPUNGEs the Trash mailbox (resolved by server `\Trash` special-use, so localised names like `Papelera` work) and **only** Trash — it can never be pointed at live mail. Gated by `{ confirmed: true }` like the other destructive tools; short-circuits an already-empty Trash. Everywhere else, delete still means move-to-Trash. Scored 10/10 on the ultra-review.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The pitch in one line: if you picked Proton Mail because you didn't want a third party reading your inbox, you don't suddenly want to hand a chatbot OAuth access to that same inbox so it can triage on your behalf. The usual "connect your email" integrations route everything through someone else's servers and ask for blanket scopes. Hand-rolled IMAP inside the agent is worse — no permission boundary, no audit trail, and the model holds your credentials in its context window. Neither option respects why you chose the provider in the first place.
 
-`mailpouch` runs locally and speaks to Proton Bridge over a TLS socket on your own machine; nothing leaves the box unless you asked it to. 71 tools across reading, sending, drafts, folders, search, analytics, aliases, Proton Pass, and system control, tiered into `core` / `extended` / `complete` so an agent that only reads doesn't burn context on Bridge lifecycle tools it will never call. Every connecting client gets its own grant with folder allowlists, IP pins, per-tool rate caps, expiry, and account binding — all hashed-args in the audit log, never the values. Delete, trash, spam, and alias removal round-trip through MCP elicitation for human confirmation before they execute. That last part sounds like theatre until you watch an agent try to empty a folder and get blocked mid-call.
+`mailpouch` runs locally and speaks to Proton Bridge over a TLS socket on your own machine; nothing leaves the box unless you asked it to. 73 tools across reading, sending, drafts, folders, search, analytics, aliases, Proton Pass, and system control, tiered into `core` / `extended` / `complete` so an agent that only reads doesn't burn context on Bridge lifecycle tools it will never call. Every connecting client gets its own grant with folder allowlists, IP pins, per-tool rate caps, expiry, and account binding — all hashed-args in the audit log, never the values. Delete, trash, spam, and alias removal round-trip through MCP elicitation for human confirmation before they execute. That last part sounds like theatre until you watch an agent try to empty a folder and get blocked mid-call.
 
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
@@ -47,7 +47,7 @@ Your emails are decrypted on your own machine by Proton Bridge. This server neve
 
 ## Key Features
 
-- **71 tools** across 11 categories — reading, search, analytics, sending, drafts, scheduling, follow-up reminders, folder management, bulk actions, deletion, Bridge/server lifecycle, plus optional companion services (SimpleLogin aliases, Proton Pass, local FTS5 search). See [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS`, `TOOL_CATEGORIES`) for the canonical inventory.
+- **73 tools** across 11 categories — reading, search, analytics, sending, drafts, scheduling, follow-up reminders, folder management, bulk actions, deletion, Bridge/server lifecycle, plus optional companion services (SimpleLogin aliases, Proton Pass, local FTS5 search). See [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS`, `TOOL_CATEGORIES`) for the canonical inventory.
 - **Two transports** — stdio (default, Claude Desktop) and HTTP (remote / self-host). HTTP is OAuth-only: `authorization_code` + PKCE-S256 for interactive agents and `client_credentials` for headless service accounts, with RFC 7591 Dynamic Client Registration, RFC 8414 authorization-server metadata, and RFC 9728 protected-resource metadata. Per-caller token-bucket rate limiting on every endpoint.
 - **Progressive tool tiering** — `core` / `extended` / `complete` controls how many tools land in the client's `ListTools` response, so context isn't burned on tools you don't use. Configurable via `toolTier` or `MAILPOUCH_TIER`.
 - **Destructive-tool confirmation** — uses MCP elicitation when the client supports it (Claude Desktop, Cline) so the user sees a prompt before any delete / trash / spam / `alias_delete` / `pass_get` runs. Falls back to a required `{ confirmed: true }` argument for clients without elicitation.
@@ -341,7 +341,7 @@ Configuration is stored in `~/.mailpouch.json` and managed via the settings UI �
 
 ## Available Tools
 
-**71 tools across 11 categories.** This README lists categories and counts; see [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS` and `TOOL_CATEGORIES`) for the canonical, machine-checkable inventory.
+**73 tools across 11 categories.** This README lists categories and counts; see [`src/config/schema.ts`](src/config/schema.ts) (`ALL_TOOLS` and `TOOL_CATEGORIES`) for the canonical, machine-checkable inventory.
 
 | Category | Tools | Default tier | Risk | Permission required |
 |---|---:|---|---|---|
@@ -600,7 +600,7 @@ npm run settings       # start standalone settings UI (after build)
 
 ```
 src/
-  index.ts                    # Unified daemon: MCP server (71 tools, resources, prompts) + settings + tray
+  index.ts                    # Unified daemon: MCP server (73 tools, resources, prompts) + settings + tray
   settings-main.ts            # Standalone settings UI CLI (for headless/SSH environments)
   # (Tray moved to native/tray/ — napi-rs binding around tauri-apps/tray-icon)
   config/

--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -101,6 +101,22 @@ Tests: pagination empty-page, $Forwarded read (list + buildEmailMessage), oversi
 
 ¹ **Rebuilt:** `bulkCopyToFolder` omitted the `folder` field from its verify jobs (and used a 1-arg error callback), so copy-failure messages lost the source folder that `bulkMoveEmails` includes — a multi-source copy failure was undebuggable. Now matches the move path: `folder` threaded through, `(uid, src)` error message. Test asserts `from <source>` appears in the failure.
 
+## Phase 4 — Flags + `mark_answered`/`mark_forwarded` (`refactor/phase4-flags`)
+
+| Function | File | Job | Simpl | Eleg | Sec | Focus | Avg | Verdict |
+|---|---|---|---|---|---|---|---|---|
+| `setFlag` | simple-imap-service.ts | 10 | 10 | 10 | 10 | 10 | 10.0 | PASS |
+| `markEmailRead` | simple-imap-service.ts | 9.8 | — | — | — | — | 9.8 | PASS |
+| `starEmail` | simple-imap-service.ts | 9.5 | — | — | — | — | 9.5 | PASS¹ |
+| `mark_email_read`/`star_email`/`mark_answered`/`mark_forwarded` tools | tools/actions.ts | 9.2 | — | — | — | — | 9.2 | PASS |
+| `bulkMarkRead` + `bulkStar` | simple-imap-service.ts | 7 | 9 | 8 | 10 | 8 | 8.4 | REBUILT → PASS² |
+
+**New capability — `mark_answered` / `mark_forwarded`** (the plan's flag gap): wrap `setFlag` with `\Answered` and `$Forwarded` respectively (`$Forwarded` is the keyword the forward tool writes and the Phase-2-fixed readers honour). Both thread `sourceFolder`; registered in `ALL_TOOLS` + the email-actions preset.
+
+¹ `starEmail` (single) had the same missing-cache-clear bug as `bulkStar` (the verifier noted it); fixed alongside ².
+
+² **Rebuilt:** `bulkStar` (and single `starEmail`) toggled `\Flagged` — which changes the Starred system-folder count — but did NOT `clearFolderCache()`, so `get_folders` returned stale starred counts until the TTL expired (`bulkMarkRead`/`markEmailRead` correctly clear on the `\Seen` path). Both now clear the cache on success. Tests assert a star refetches folder counts.
+
 ### PR #192 reviewer fixes (CodeQL + Copilot)
 - `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
   whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -15,8 +15,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 71 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(71);
+  it("has exactly 73 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(73);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -20,7 +20,7 @@ export const ALL_TOOLS = [
   // Folder management
   "get_folders", "sync_folders", "create_folder", "delete_folder", "rename_folder",
   // Email actions
-  "mark_email_read", "star_email", "move_email", "archive_email",
+  "mark_email_read", "star_email", "mark_answered", "mark_forwarded", "move_email", "archive_email",
   "move_to_trash", "move_to_spam", "move_to_folder",
   "bulk_mark_read", "bulk_star", "bulk_move_emails",
   "move_to_label", "bulk_move_to_label",
@@ -90,7 +90,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     label: "Email Actions",
     description: "Mark read/unread, star, move, label, and bulk operations",
     tools: [
-      "mark_email_read", "star_email", "move_email", "archive_email",
+      "mark_email_read", "star_email", "mark_answered", "mark_forwarded", "move_email", "archive_email",
       "move_to_trash", "move_to_spam", "move_to_folder",
       "bulk_mark_read", "bulk_star", "bulk_move_emails",
       "move_to_label", "bulk_move_to_label",

--- a/src/services/imap-operations.test.ts
+++ b/src/services/imap-operations.test.ts
@@ -2934,6 +2934,26 @@ describe("SimpleIMAPService folder-count cache invalidation (#2)", () => {
     await svc.syncFolders();
     expect(status.mock.calls.length).toBeGreaterThan(n);
   });
+
+  it("starEmail invalidates the folder cache (Starred \\Flagged count changes)", async () => {
+    const { svc, client, status } = svcWithFolders();
+    await svc.getFolders();
+    const afterFirst = status.mock.calls.length;
+    seedUids(client, "INBOX", [1]);
+    await svc.starEmail("1", true, "INBOX");
+    await svc.getFolders();
+    expect(status.mock.calls.length).toBeGreaterThan(afterFirst); // refetched after the star
+  });
+
+  it("bulkStar invalidates the folder cache on success (parity with bulkMarkRead)", async () => {
+    const { svc, client, status } = svcWithFolders();
+    await svc.getFolders();
+    const afterFirst = status.mock.calls.length;
+    seedUids(client, "INBOX", [1, 2]);
+    await svc.bulkStar(["1", "2"], true, "INBOX");
+    await svc.getFolders();
+    expect(status.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
 });
 
 // ─── empty_trash: gated permanent purge, Trash-only ───────────────────────────

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1804,6 +1804,7 @@ export class SimpleIMAPService {
         }
 
         logger.info(`Email ${emailId} ${isStarred ? 'starred' : 'unstarred'}`, 'IMAPService');
+        this.clearFolderCache(); // Starred (\Flagged) folder count changed → next get_folders refetches
         return true;
       } finally {
         lock.release();
@@ -2558,6 +2559,7 @@ export class SimpleIMAPService {
       } finally { lock.release(); }
     }
     tags.successCount = results.success; tags.failCount = results.failed;
+    if (results.success > 0) this.clearFolderCache(); // Starred (\Flagged) count changed → next get_folders refetches
     logger.info(`Bulk star completed: ${results.success}/${results.failed}`, 'IMAPService');
     return results;
     }); // end tracer.span('imap.bulkStar')

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -37,6 +37,13 @@ describe("mark_answered / mark_forwarded tools (Phase 4 flag gap)", () => {
     expect(setFlag).toHaveBeenCalledWith("99", "$Forwarded", true, undefined);
   });
 
+  it("mark_forwarded can CLEAR the keyword and threads sourceFolder", async () => {
+    const setFlag = vi.fn().mockResolvedValue(true);
+    const ctx = makeCtx({ args: { emailId: "8", forwarded: false, sourceFolder: "Labels/Foo" }, imapService: { setFlag } as unknown as ToolCallContext["imapService"] });
+    await mod.handlers.mark_forwarded(ctx);
+    expect(setFlag).toHaveBeenCalledWith("8", "$Forwarded", false, "Labels/Foo");
+  });
+
   it("rejects a non-boolean answered/forwarded", async () => {
     const ctx = makeCtx({ args: { emailId: "1", answered: "yes" }, imapService: { setFlag: vi.fn() } as unknown as ToolCallContext["imapService"] });
     await expect(mod.handlers.mark_answered(ctx)).rejects.toThrow(/must be a boolean/);

--- a/src/tools/actions.test.ts
+++ b/src/tools/actions.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import mod from "./actions.js";
+import { ALL_TOOLS } from "../config/schema.js";
+import type { ToolCallContext, ToolResult } from "./types.js";
+
+function makeCtx(over: Partial<ToolCallContext>): ToolCallContext {
+  const actionOk = (): ToolResult => ({ content: [{ type: "text", text: "Done." }], structuredContent: { success: true } });
+  return { actionOk, ...over } as unknown as ToolCallContext;
+}
+
+describe("mark_answered / mark_forwarded tools (Phase 4 flag gap)", () => {
+  it("both tools are registered in defs and ALL_TOOLS", () => {
+    expect(mod.defs.some((d) => d.name === "mark_answered")).toBe(true);
+    expect(mod.defs.some((d) => d.name === "mark_forwarded")).toBe(true);
+    expect(ALL_TOOLS).toContain("mark_answered");
+    expect(ALL_TOOLS).toContain("mark_forwarded");
+  });
+
+  it("mark_answered sets the \\Answered flag via setFlag (defaults answered=true)", async () => {
+    const setFlag = vi.fn().mockResolvedValue(true);
+    const ctx = makeCtx({ args: { emailId: "42" }, imapService: { setFlag } as unknown as ToolCallContext["imapService"] });
+    await mod.handlers.mark_answered(ctx);
+    expect(setFlag).toHaveBeenCalledWith("42", "\\Answered", true, undefined);
+  });
+
+  it("mark_answered can CLEAR the flag and threads sourceFolder", async () => {
+    const setFlag = vi.fn().mockResolvedValue(true);
+    const ctx = makeCtx({ args: { emailId: "7", answered: false, sourceFolder: "Folders/Work" }, imapService: { setFlag } as unknown as ToolCallContext["imapService"] });
+    await mod.handlers.mark_answered(ctx);
+    expect(setFlag).toHaveBeenCalledWith("7", "\\Answered", false, "Folders/Work");
+  });
+
+  it("mark_forwarded sets the $Forwarded keyword (the flag readers honour)", async () => {
+    const setFlag = vi.fn().mockResolvedValue(true);
+    const ctx = makeCtx({ args: { emailId: "99" }, imapService: { setFlag } as unknown as ToolCallContext["imapService"] });
+    await mod.handlers.mark_forwarded(ctx);
+    expect(setFlag).toHaveBeenCalledWith("99", "$Forwarded", true, undefined);
+  });
+
+  it("rejects a non-boolean answered/forwarded", async () => {
+    const ctx = makeCtx({ args: { emailId: "1", answered: "yes" }, imapService: { setFlag: vi.fn() } as unknown as ToolCallContext["imapService"] });
+    await expect(mod.handlers.mark_answered(ctx)).rejects.toThrow(/must be a boolean/);
+    const ctx2 = makeCtx({ args: { emailId: "1", forwarded: 1 }, imapService: { setFlag: vi.fn() } as unknown as ToolCallContext["imapService"] });
+    await expect(mod.handlers.mark_forwarded(ctx2)).rejects.toThrow(/must be a boolean/);
+  });
+});

--- a/src/tools/actions.ts
+++ b/src/tools/actions.ts
@@ -79,6 +79,40 @@ export const defs: ToolDef[] = [
     outputSchema: ACTION_RESULT_SCHEMA,
   },
   {
+    name: "mark_answered",
+    title: "Mark Email Answered",
+    description:
+      "Set or clear the \\Answered flag on an email (the IMAP 'replied to' marker). answered defaults to true. Pass sourceFolder whenever the UID came from a folder other than INBOX.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        emailId: { type: "string" },
+        answered: { type: "boolean", default: true },
+        sourceFolder: SOURCE_FOLDER_SCHEMA,
+      },
+      required: ["emailId"],
+    },
+    outputSchema: ACTION_RESULT_SCHEMA,
+  },
+  {
+    name: "mark_forwarded",
+    title: "Mark Email Forwarded",
+    description:
+      "Set or clear the $Forwarded keyword on an email (the 'has been forwarded' marker the forward tool writes). forwarded defaults to true. Pass sourceFolder whenever the UID came from a folder other than INBOX.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        emailId: { type: "string" },
+        forwarded: { type: "boolean", default: true },
+        sourceFolder: SOURCE_FOLDER_SCHEMA,
+      },
+      required: ["emailId"],
+    },
+    outputSchema: ACTION_RESULT_SCHEMA,
+  },
+  {
     name: "move_email",
     title: "Move Email",
     description:
@@ -316,6 +350,31 @@ export const handlers: Record<string, ToolHandler> = {
     const isStarred = args.isStarred !== undefined ? (args.isStarred as boolean) : true;
     const seSourceFolder = optionalSourceFolder(args.sourceFolder);
     await imapService.starEmail(seEmailId, isStarred, seSourceFolder);
+    return actionOk();
+  },
+
+  mark_answered: async (ctx) => {
+    const { args, imapService, actionOk } = ctx;
+    const maEmailId = requireNumericEmailId(args.emailId);
+    if (args.answered !== undefined && typeof args.answered !== "boolean") {
+      throw new McpError(ErrorCode.InvalidParams, "'answered' must be a boolean when provided.");
+    }
+    const answered = args.answered !== undefined ? (args.answered as boolean) : true;
+    const maSourceFolder = optionalSourceFolder(args.sourceFolder);
+    await imapService.setFlag(maEmailId, "\\Answered", answered, maSourceFolder);
+    return actionOk();
+  },
+
+  mark_forwarded: async (ctx) => {
+    const { args, imapService, actionOk } = ctx;
+    const mfEmailId = requireNumericEmailId(args.emailId);
+    if (args.forwarded !== undefined && typeof args.forwarded !== "boolean") {
+      throw new McpError(ErrorCode.InvalidParams, "'forwarded' must be a boolean when provided.");
+    }
+    const forwarded = args.forwarded !== undefined ? (args.forwarded as boolean) : true;
+    const mfSourceFolder = optionalSourceFolder(args.sourceFolder);
+    // $Forwarded is the keyword the forward tool writes and the readers honour.
+    await imapService.setFlag(mfEmailId, "$Forwarded", forwarded, mfSourceFolder);
     return actionOk();
   },
 


### PR DESCRIPTION
## Summary
Phase 4 of the Bridge-capability program (plan `crispy-wibbling-dusk`). Closes the flag-subsystem capability gap and fixes the defect the ultra-review surfaced. Verdicts in `docs/quality-audit.md` (4/5 PASS, `setFlag` 10/10).

## Capability gap — `mark_answered` / `mark_forwarded`
Two new tools wrapping the existing `setFlag`:
- `mark_answered` → sets/clears the IMAP `\Answered` flag (the "replied-to" marker).
- `mark_forwarded` → sets/clears the **`$Forwarded`** keyword — the exact marker the forward tool writes and the readers honour (fixed in Phase 2; previously readers checked a non-existent `\Forward`). So forwarded state now round-trips end to end.

Both thread `sourceFolder`, validate the boolean arg, and are registered in `ALL_TOOLS` (now 73) + the email-actions permission preset.

## Ultra-review rebuild
`bulkStar` / `starEmail` (8.4): toggling `\Flagged` changes the **Starred** system-folder count, but neither method called `clearFolderCache()` — so `get_folders` returned stale starred counts until the 5-min TTL expired (the `\Seen` path in `markEmailRead`/`bulkMarkRead` correctly clears). Both now clear the cache on success. The verifier flagged that single `starEmail` had the same bug, fixed alongside the bulk path.

`setFlag` (10/10), `markEmailRead` (9.8), `starEmail` (9.5), and the flag tools (9.2) all passed.

## Docs (same commit)
- README tool count 71 → 73.
- `CHANGELOG.md` `[Unreleased]`: lists the new flag tools.

## Test plan
- [x] preship gate PASS (Greenmail E2E passed on retry — first run hit the known transient container-restart flake; 13/14 files passed, unit suite 100% green)
- [x] 2140 unit tests green
- [x] New tests: mark_answered/mark_forwarded (correct flag string, clear, sourceFolder, boolean validation), starEmail + bulkStar invalidate folder cache
- [ ] CI matrix + CodeQL

## Security checklist
- [x] No new permanent-delete or destructive surface (flag toggles are non-destructive, idempotent)
- [x] emailId/folder validation preserved (wraps setFlag's pre-flight existence check)
- [x] No secrets/credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)