### PR TITLE
Phase 5: Search — IMAP-012, hasAttachment under-return, FTS sinceEpoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Bridge-capability program (subsystem-by-subsystem TDD redesign + per-function ul
 - **Forwarded flag:** reads `$Forwarded`/`\Forwarded` (the setter's flag) instead of the non-existent `\Forward`, which always read back as not-forwarded.
 - **`download_attachment` memory safety:** the oversize guard now checks the actual resolved byte length (the stale-metadata path could OOM); re-maps by filename if the re-fetch attachment order drifts.
 - **`bulk_copy` failure messages** now carry the source folder, matching `bulk_move`.
+- **`search_emails` no longer returns `[]` on a connection failure** (IMAP-012) — it throws, so a connection drop is distinguishable from "no matches".
+- **`search_emails` `hasAttachment` no longer under-returns** below the requested limit — the local attachment filter now runs before the limit (with a bounded over-fetch) instead of after; per-folder failures and folder-cap truncation are logged instead of silent; `searchSingleFolder` validates its folder defensively.
+- **`fts_search` `sinceEpoch` is applied in SQL before `LIMIT`** (was a post-`LIMIT` filter that could return far fewer than the limit).
+- **Bridge `SEARCH BODY/TEXT` docs reconciled** — `body`/`text` search criteria are wired and exposed (the limitation note was pre-Phase-0 stale).
 
 ## [3.0.73] — 2026-06-03
 

--- a/docs/proton-bridge-imap.md
+++ b/docs/proton-bridge-imap.md
@@ -183,9 +183,9 @@ Bridge implements standard IMAP SEARCH. The MCP server uses the following search
 | `FLAGGED` | `options.isStarred` |
 | `UID <range>` | Used internally for all UID-based operations |
 
+**Body / full-text search:** `options.body` → IMAP `SEARCH BODY` and `options.text` → `SEARCH TEXT` (header + body) ARE now mapped in the MCP server's search criteria (`buildSearchCriteria`) and exposed on `search_emails`. Both are sanitized (CRLF/quote-stripped, length-capped). Server-side effectiveness depends on the Bridge/Gluon build's `SEARCH BODY/TEXT` support; the local **FTS index** (`fts_search`) remains the more reliable, ranked full-text path when the index is populated.
+
 **Limitations:**
-- `BODY` (full-text search) is not implemented in the MCP server's search criteria
-- `TEXT` (header + body) search is not implemented
 - `X-GM-LABELS` (Gmail extension) is not supported by Bridge
 - Search results are limited to the first N UIDs fetched; results are then enriched by individual `getEmailById` calls
 - Multi-folder search works by searching each folder sequentially and merging results, capped at 20 folders

--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -117,6 +117,27 @@ Tests: pagination empty-page, $Forwarded read (list + buildEmailMessage), oversi
 
 ² **Rebuilt:** `bulkStar` (and single `starEmail`) toggled `\Flagged` — which changes the Starred system-folder count — but did NOT `clearFolderCache()`, so `get_folders` returned stale starred counts until the TTL expired (`bulkMarkRead`/`markEmailRead` correctly clear on the `\Seen` path). Both now clear the cache on success. Tests assert a star refetches folder counts.
 
+## Phase 5 — Search (IMAP SEARCH incl. BODY/TEXT + FTS) (`refactor/phase5-search`)
+
+All five flagged REBUILD; the search path had the most accumulated debt of any subsystem.
+
+| Function | File | Verdict |
+|---|---|---|
+| `searchEmails` | simple-imap-service.ts | REBUILT → PASS |
+| `searchSingleFolder` | simple-imap-service.ts | REBUILT → PASS |
+| `validateSearchInput`/`buildSearchCriteria` | search-input.ts / imap-helpers.ts | PASS (criteria already 10/10 in Phase 0; doc reconciled) |
+| FTS `search` | fts-service.ts | REBUILT → PASS |
+| `search_emails`/`fts_search` tool | reading.ts | PASS (covered by the service fixes) |
+
+**Capability note:** the plan's "IMAP `SEARCH BODY/TEXT`" gap was already wired in Phase 0 (`buildSearchCriteria` maps `c.body`/`c.text`, exposed on `search_emails`). The Bridge doc still carried the pre-Phase-0 "not implemented" note — **reconciled** (body/text are wired + sanitized; FTS remains the reliable ranked full-text path).
+
+**Rebuilt defects:**
+- **IMAP-012:** `searchEmails` returned `[]` on a connection failure (indistinguishable from "no matches") — now throws `IMAPNotConnectedError`, matching `getFolders`/`getEmails`.
+- **`hasAttachment` under-return:** the local filter ran AFTER the limit slice (both single + multi-folder), so an attachment query could return far fewer than `limit`. Now filters before the limit with a bounded per-folder over-fetch (200) when the filter is active.
+- **Silent failures surfaced:** per-folder `Promise.allSettled` rejections and the 20-folder cap truncation are now logged (were invisible).
+- **`searchSingleFolder`** validates its folder name defensively (private, but a bad name must fail clearly, not via a cryptic lock error).
+- **FTS `sinceEpoch`:** was a post-`LIMIT` filter → under-returned. Pushed into the SQL `WHERE` (all three query paths) so the date floor applies before `LIMIT`.
+
 ### PR #192 reviewer fixes (CodeQL + Copilot)
 - `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
   whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).

--- a/src/services/fts-service.test.ts
+++ b/src/services/fts-service.test.ts
@@ -108,6 +108,20 @@ describeMaybe("FtsIndexService", () => {
     expect(hits.map(h => h.id)).toEqual(["new"]);
   });
 
+  it("applies sinceEpoch BEFORE the limit (no under-return)", () => {
+    const base = 1_700_000_000;
+    // 5 old (excluded) then 5 recent (included). With the date floor applied
+    // post-LIMIT, a limit of 5 would fill with the 5 old rows and then filter to
+    // ZERO. Applied in the WHERE (pre-LIMIT), it must return the 5 recent ones.
+    svc.upsertMany([
+      ...Array.from({ length: 5 }, (_, i) => sampleRecord({ id: `old${i}`, dateEpoch: base, body: `ping ${i}` })),
+      ...Array.from({ length: 5 }, (_, i) => sampleRecord({ id: `new${i}`, dateEpoch: base + 10_000, body: `ping ${i}` })),
+    ]);
+    const hits = svc.search({ query: "ping", sinceEpoch: base + 5_000, limit: 5 });
+    expect(hits).toHaveLength(5);
+    expect(hits.every(h => h.id.startsWith("new"))).toBe(true);
+  });
+
   it("respects the limit cap (1-200)", () => {
     const many = Array.from({ length: 30 }, (_, i) => sampleRecord({ id: `m${i}`, body: `ping ${i}` }));
     svc.upsertMany(many);

--- a/src/services/fts-service.ts
+++ b/src/services/fts-service.ts
@@ -148,12 +148,15 @@ export class FtsIndexService {
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       ),
       remove: this.db.prepare(`DELETE FROM messages WHERE id = ?`),
+      // `date_epoch >= ?` lives in the WHERE so the date floor is applied BEFORE
+      // the LIMIT (a post-LIMIT filter under-returns). Binding 0 when no
+      // sinceEpoch is supplied matches everything (epochs are non-negative).
       searchAll: this.db.prepare(
         `SELECT id, subject, "from", "to", folder, body, date_epoch,
                 bm25(messages) AS score,
                 snippet(messages, 5, '[[', ']]', '…', 12) AS snippet
            FROM messages
-          WHERE messages MATCH ?
+          WHERE messages MATCH ? AND date_epoch >= ?
           ORDER BY score
           LIMIT ?`,
       ),
@@ -162,7 +165,7 @@ export class FtsIndexService {
                 bm25(messages) AS score,
                 snippet(messages, 5, '[[', ']]', '…', 12) AS snippet
            FROM messages
-          WHERE messages MATCH ? AND folder = ?
+          WHERE messages MATCH ? AND folder = ? AND date_epoch >= ?
           ORDER BY score
           LIMIT ?`,
       ),
@@ -245,6 +248,9 @@ export class FtsIndexService {
   search(opts: FtsSearchOptions): FtsHit[] {
     const limit = Math.min(Math.max(1, opts.limit ?? 20), 200);
     const folder = opts.folder?.trim();
+    // Date floor pushed into every query's WHERE (not a post-LIMIT filter, which
+    // would under-return). 0 = no floor (epochs are non-negative).
+    const sinceFloor = typeof opts.sinceEpoch === "number" ? opts.sinceEpoch : 0;
     // Folder allowlist short-circuit: an explicit empty array means "the
     // caller has no folder grants" — return zero hits without touching SQL.
     if (Array.isArray(opts.allowedFolders) && opts.allowedFolders.length === 0) {
@@ -271,21 +277,22 @@ export class FtsIndexService {
                 bm25(messages) AS score,
                 snippet(messages, 5, '[[', ']]', '…', 12) AS snippet
            FROM messages
-          WHERE messages MATCH ? AND folder COLLATE NOCASE IN (${placeholders})${single}
+          WHERE messages MATCH ? AND folder COLLATE NOCASE IN (${placeholders})${single} AND date_epoch >= ?
           ORDER BY score
           LIMIT ?`;
       const stmt = this.db.prepare(sql);
       const params: unknown[] = [opts.query, ...opts.allowedFolders];
       if (folder) params.push(folder);
+      params.push(sinceFloor);
       params.push(limit);
       hits = this.runMatch(stmt, params);
     } else {
       hits = folder
-        ? this.runMatch(this.stmts.searchFolder, [opts.query, folder, limit])
-        : this.runMatch(this.stmts.searchAll, [opts.query, limit]);
+        ? this.runMatch(this.stmts.searchFolder, [opts.query, folder, sinceFloor, limit])
+        : this.runMatch(this.stmts.searchAll, [opts.query, sinceFloor, limit]);
     }
     const rows = hits as Array<Record<string, unknown>>;
-    let mapped: FtsHit[] = rows.map(r => ({
+    const mapped: FtsHit[] = rows.map(r => ({
       id: String(r.id ?? ""),
       subject: String(r.subject ?? ""),
       from: String(r.from ?? ""),
@@ -296,9 +303,7 @@ export class FtsIndexService {
       score: typeof r.score === "number" ? r.score : Number(r.score ?? 0),
       snippet: String(r.snippet ?? ""),
     }));
-    if (typeof opts.sinceEpoch === "number") {
-      mapped = mapped.filter(h => h.dateEpoch >= (opts.sinceEpoch ?? 0));
-    }
+    // sinceEpoch now applied in SQL WHERE (before LIMIT) — no post-filter.
     return mapped;
   }
 

--- a/src/services/simple-imap-service.newfeatures.test.ts
+++ b/src/services/simple-imap-service.newfeatures.test.ts
@@ -806,21 +806,20 @@ describe("SimpleIMAPService.searchEmails (multi-folder)", () => {
     expect(mockClient.getMailboxLock).toHaveBeenCalledTimes(2);
   });
 
-  it("returns [] when ensureConnection throws", async () => {
+  it("throws (not []) when ensureConnection fails (IMAP-012)", async () => {
     const svc = new SimpleIMAPService();
     vi.spyOn(svc as any, "ensureConnection").mockRejectedValue(new Error("no config"));
 
-    const results = await svc.searchEmails({ folder: "INBOX" });
-    expect(results).toEqual([]);
+    // A connection failure must not masquerade as "no matches".
+    await expect(svc.searchEmails({ folder: "INBOX" })).rejects.toThrow(/Cannot search emails/);
   });
 
-  it("returns [] when client is null after ensureConnection", async () => {
+  it("throws (not []) when client is null after ensureConnection (IMAP-012)", async () => {
     const svc = new SimpleIMAPService();
     vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
     (svc as any).client = null;
 
-    const results = await svc.searchEmails({ folder: "INBOX" });
-    expect(results).toEqual([]);
+    await expect(svc.searchEmails({ folder: "INBOX" })).rejects.toThrow(/Cannot search emails/);
   });
 
   it("applies hasAttachment filter to single-folder results", async () => {
@@ -864,6 +863,30 @@ describe("SimpleIMAPService.searchEmails (multi-folder)", () => {
     // Multi-folder search with hasAttachment=false filter — email 100 has hasAttachment=true, so filtered out
     const results = await svc.searchEmails({ folders: ["INBOX", "Sent"], hasAttachment: false });
     expect(results).toEqual([]);
+  });
+
+  it("does not under-return below limit when hasAttachment filters early matches (over-fetch)", async () => {
+    const svc = new SimpleIMAPService();
+    vi.spyOn(svc as any, "ensureConnection").mockResolvedValue(undefined);
+    const lockObj = { release: vi.fn() };
+    // SEARCH returns 6 UIDs; the first 4 have NO attachment, the last 2 do.
+    const mockClient = {
+      getMailboxLock: vi.fn().mockResolvedValue(lockObj),
+      search: vi.fn().mockResolvedValue([1, 2, 3, 4, 5, 6]),
+    };
+    (svc as any).client = mockClient;
+    for (const uid of [1, 2, 3, 4, 5, 6]) {
+      (svc as any).setCacheEntry(String(uid), {
+        id: String(uid), folder: "INBOX", from: "a@b.com", to: [], subject: "S",
+        body: "B", date: new Date(), isRead: false, isStarred: false,
+        hasAttachment: uid >= 5, isHtml: false,
+      });
+    }
+    // limit=2, hasAttachment=true. The OLD code limited the IMAP window to 2
+    // (UIDs 1,2 — both attachment-less) then filtered to ZERO. The over-fetch
+    // must instead return the 2 attachment-bearing messages.
+    const results = await svc.searchEmails({ folder: "INBOX", hasAttachment: true, limit: 2 });
+    expect(results.map(e => e.id).sort()).toEqual(["5", "6"]);
   });
 
   it("re-throws when searchSingleFolder throws (outer catch block)", async () => {

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -1200,6 +1200,10 @@ export class SimpleIMAPService {
    */
   private async searchSingleFolder(folder: string, options: SearchEmailOptions, limit: number): Promise<EmailMessage[]> {
     if (!this.client) return [];
+    // Defensive: searchEmails validates folders, but this is private and could be
+    // reached by a future caller — a bad name must fail clearly, not via a cryptic
+    // getMailboxLock error (or a path-traversal/CRLF reaching the IMAP wire).
+    this.validateFolderName(folder);
     const lock = await this.client.getMailboxLock(folder);
 
     try {
@@ -1296,30 +1300,40 @@ export class SimpleIMAPService {
     return tracer.span('imap.searchEmails', tags, async () => {
     logger.debug('Searching emails', 'IMAPService', options);
 
+    // IMAP-012: a connection failure must NOT be reported as an empty result set
+    // (indistinguishable from "no matches"). Throw, matching getFolders/getEmails.
     try {
       await this.ensureConnection();
     } catch (error) {
-      logger.warn('IMAP not connected', 'IMAPService');
-      return [];
+      throw new IMAPNotConnectedError('Cannot search emails: IMAP connection unavailable');
     }
-
     if (!this.client) {
-      logger.warn('IMAP client not available', 'IMAPService');
-      return [];
+      throw new IMAPNotConnectedError('Cannot search emails: IMAP client not available');
     }
 
     const limit = Math.min(Math.max(1, options.limit || 100), 200);
+    const FOLDER_CAP = 20;
+    // hasAttachment is a LOCAL post-filter (IMAP SEARCH can't express it). To
+    // avoid grossly under-returning below `limit`, over-fetch the per-folder
+    // candidate window when it's set, then filter, then slice to `limit`.
+    const perFolderLimit = options.hasAttachment !== undefined ? 200 : limit;
+    const applyAttachmentFilter = (xs: EmailMessage[]): EmailMessage[] =>
+      options.hasAttachment !== undefined ? xs.filter(e => e.hasAttachment === options.hasAttachment) : xs;
 
     // Determine which folders to search
     let foldersToSearch: string[];
     if (options.folders && options.folders.length > 0) {
       if (options.folders[0] === '*' || options.folders[0] === 'all') {
-        // Search all available folders (capped at 20 to prevent abuse)
         const allFolders = await this.getFolders();
-        foldersToSearch = allFolders.slice(0, 20).map(f => f.path);
+        foldersToSearch = allFolders.slice(0, FOLDER_CAP).map(f => f.path);
+        if (allFolders.length > FOLDER_CAP) {
+          logger.warn(`Search across all folders truncated to the first ${FOLDER_CAP} of ${allFolders.length} — results may be incomplete`, 'IMAPService');
+        }
       } else {
-        // Cap at 20 explicit folders
-        foldersToSearch = options.folders.slice(0, 20);
+        if (options.folders.length > FOLDER_CAP) {
+          logger.warn(`Search folder list truncated to the first ${FOLDER_CAP} of ${options.folders.length} requested`, 'IMAPService');
+        }
+        foldersToSearch = options.folders.slice(0, FOLDER_CAP);
       }
     } else {
       // Single folder — original behaviour (defaults to INBOX)
@@ -1333,32 +1347,31 @@ export class SimpleIMAPService {
 
     try {
       if (foldersToSearch.length === 1) {
-        // Fast path: no merging needed
-        const results = await this.searchSingleFolder(foldersToSearch[0], options, limit);
-        const filtered = options.hasAttachment !== undefined
-          ? results.filter(e => e.hasAttachment === options.hasAttachment)
-          : results;
+        // Fast path: no merging needed. Filter BEFORE the limit slice so an
+        // attachment filter can't silently under-return.
+        const results = await this.searchSingleFolder(foldersToSearch[0], options, perFolderLimit);
+        const filtered = applyAttachmentFilter(results).slice(0, limit);
         tags.resultCount = filtered.length;
         logger.info(`Search found ${filtered.length} emails`, 'IMAPService');
         return filtered;
       }
 
-      // Multi-folder: search each, merge, sort by date desc, apply limit
+      // Multi-folder: search each, merge, sort by date desc, filter, then limit.
       const settled = await Promise.allSettled(
-        foldersToSearch.map(f => this.searchSingleFolder(f, options, limit))
+        foldersToSearch.map(f => this.searchSingleFolder(f, options, perFolderLimit))
       );
 
       const merged: EmailMessage[] = [];
-      for (const r of settled) {
+      settled.forEach((r, i) => {
         if (r.status === 'fulfilled') merged.push(...r.value);
-      }
+        // Don't silently swallow a per-folder failure — surface which folder failed.
+        else logger.warn(`Search failed for folder '${foldersToSearch[i]}': ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`, 'IMAPService');
+      });
 
       merged.sort((a, b) => b.date.getTime() - a.date.getTime());
 
-      const limited = merged.slice(0, limit);
-      const filtered = options.hasAttachment !== undefined
-        ? limited.filter(e => e.hasAttachment === options.hasAttachment)
-        : limited;
+      // Filter by attachment BEFORE applying the limit (was sliced first → under-return).
+      const filtered = applyAttachmentFilter(merged).slice(0, limit);
 
       tags.resultCount = filtered.length;
       logger.info(`Multi-folder search found ${filtered.length} emails across ${foldersToSearch.length} folders`, 'IMAPService');


### PR DESCRIPTION
## Summary
Phase 5 of the Bridge-capability program (plan `crispy-wibbling-dusk`). The search path carried the most accumulated debt of any subsystem — the ultra-review flagged **all five** functions REBUILD. Verdicts in `docs/quality-audit.md`.

## Capability note — BODY/TEXT search
The plan's "IMAP `SEARCH BODY/TEXT`" gap was already wired in Phase 0 (`buildSearchCriteria` maps `c.body`/`c.text`; exposed + sanitized on `search_emails`). The Bridge doc still carried the pre-Phase-0 "not implemented" note — **reconciled** here (FTS remains the reliable ranked full-text path).

## Ultra-review rebuilds (9.5 gate)
**`searchEmails` / `searchSingleFolder`:**
- **IMAP-012:** returned `[]` on a connection failure — indistinguishable from "no matches". Now throws `IMAPNotConnectedError`, matching `getFolders`/`getEmails`.
- **`hasAttachment` under-return:** the local attachment filter ran AFTER the limit slice (both single + multi-folder), so an attachment query could return far fewer than `limit`. Now filters **before** the limit, with a bounded per-folder over-fetch (200) when the filter is active.
- **Silent failures surfaced:** per-folder `Promise.allSettled` rejections and the 20-folder-cap truncation are now logged (were invisible).
- **`searchSingleFolder`** validates its folder name defensively (private, but a bad name must fail clearly, not via a cryptic lock error).

**`fts_search`:**
- **`sinceEpoch`** was a post-`LIMIT` filter → under-returned. Pushed into the SQL `WHERE` (all three query paths) so the date floor applies before `LIMIT`.

## BREAKING
`search_emails` throws on a connection failure instead of returning `[]`.

## Test plan
- [x] preship gate PASS (incl. Greenmail E2E)
- [x] 2143 unit tests green
- [x] New tests: IMAP-012 throw (search), hasAttachment over-fetch (no under-return), FTS sinceEpoch applied before LIMIT
- [ ] CI matrix + CodeQL

## Security checklist
- [x] SEARCH injection sanitization (CRLF/quote), header field-name grammar, length caps all preserved
- [x] FTS folder allowlist + parameterized IN-clause preserved; `sinceEpoch` bound, not interpolated
- [x] No secrets/credentials; folder validation strengthened

🤖 Generated with [Claude Code](https://claude.com/claude-code)