### PR TITLE
Phase 6: Drafts & Send — SMTP TLS unified, forward threading, ::1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Bridge-capability program (subsystem-by-subsystem TDD redesign + per-function ul
 - **`search_emails` `hasAttachment` no longer under-returns** below the requested limit — the local attachment filter now runs before the limit (with a bounded over-fetch) instead of after; per-folder failures and folder-cap truncation are logged instead of silent; `searchSingleFolder` validates its folder defensively.
 - **`fts_search` `sinceEpoch` is applied in SQL before `LIMIT`** (was a post-`LIMIT` filter that could return far fewer than the limit).
 - **Bridge `SEARCH BODY/TEXT` docs reconciled** — `body`/`text` search criteria are wired and exposed (the limitation note was pre-Phase-0 stale).
+- **SMTP now uses the shared `buildBridgeTlsConfig`** (no more 4th inline TLS copy that could diverge from the IMAP path's pinned-cert/insecure-fallback contract), which also fixes SMTP + the IMAP IDLE socket not recognizing IPv6 loopback `::1` as localhost.
+- **`forward_email` keeps the message in its thread** — it now carries the original `In-Reply-To`/`References` (parity with `reply_to_email`), CRLF-strips the embedded original From/To in the quoted header, and logs (instead of silently swallowing) a `$Forwarded`/`\Answered` flag-set failure.
 
 ## [3.0.73] — 2026-06-03
 

--- a/docs/quality-audit.md
+++ b/docs/quality-audit.md
@@ -138,6 +138,22 @@ All five flagged REBUILD; the search path had the most accumulated debt of any s
 - **`searchSingleFolder`** validates its folder name defensively (private, but a bad name must fail clearly, not via a cryptic lock error).
 - **FTS `sinceEpoch`:** was a post-`LIMIT` filter → under-returned. Pushed into the SQL `WHERE` (all three query paths) so the date floor applies before `LIMIT`.
 
+## Phase 6 — Drafts & Send (`refactor/phase6-drafts-send`)
+
+| Function | File | Avg | Verdict |
+|---|---|---|---|
+| `saveDraft` | simple-imap-service.ts | 9.5 | PASS |
+| `sendEmail` | smtp-service.ts | 9.3 | PASS |
+| SMTP connect/TLS | smtp-service.ts | 8.4 | REBUILT → PASS¹ |
+| `send_email`/`reply_to_email`/`forward_email` tools | sending.ts | 8.6 | REBUILT → PASS² |
+| reply/forward handlers | sending.ts | 6.8 | REBUILT → PASS² |
+
+**Scope-check — Proton-native scheduled-send (create/cancel):** OUT OF SCOPE. Creating/cancelling a Proton-NATIVE scheduled send requires Proton's private REST API (no public API — see [[project_proton_roadmap]]); Bridge IMAP/SMTP can't. mailpouch already covers future delivery correctly via its OWN scheduler (`schedule_email`/`cancel_scheduled_email`/`list_scheduled_emails`, deferred SMTP) plus read-only `list_proton_scheduled` (reads the "All Scheduled" IMAP folder). No build.
+
+¹ **Rebuilt — the Phase-0 follow-up + a real bug:** SMTP had a 4th inline copy of the Bridge-TLS decision tree that didn't reuse `buildBridgeTlsConfig`, AND it omitted IPv6 loopback `::1` from its localhost check (host `::1` → full-validation TLS against Bridge's self-signed cert → connection failure). Refactored `initializeTransporter` to call `buildBridgeTlsConfig` (kills the 4th copy + fixes `::1` in one move), preserving SMTP's deferred-init via try/catch. Also fixed the same `::1` omission in the IMAP IDLE socket path.
+
+² **Rebuilt:** `forward_email` dropped the original `inReplyTo`/`references` (broke thread continuity — `reply_to_email` carried them); now threaded. The embedded original From/To in the quoted header are CRLF-stripped. Both reply + forward now LOG a `setFlag` (`\Answered`/`$Forwarded`) failure instead of silently swallowing it.
+
 ### PR #192 reviewer fixes (CodeQL + Copilot)
 - `stripHtml` block-strip now matches `</script\s*>` / `</style\s*>` (trailing
   whitespace close tag could bypass the strip — CodeQL bad-HTML-filtering).

--- a/src/services/imap-helpers.test.ts
+++ b/src/services/imap-helpers.test.ts
@@ -117,6 +117,17 @@ describe("buildEmailMessage", () => {
     expect(buildEmailMessage(msg(8, ["\\Forwarded"]), parsed({}), "INBOX").isForwarded).toBe(true);
     expect(buildEmailMessage(msg(9, ["\\Forward"]), parsed({}), "INBOX").isForwarded).toBe(false);
   });
+
+  it("normalizes references to a string[] (mailparser returns a string for one ref)", () => {
+    // A single-reference message → mailparser yields a bare string; it MUST be
+    // normalized to an array so sendEmail's references.map() can't crash.
+    const single = buildEmailMessage(msg(10), parsed({ references: "<only@x.com>" as never }), "INBOX");
+    expect(single.references).toEqual(["<only@x.com>"]);
+    const multi = buildEmailMessage(msg(11), parsed({ references: ["<a@x.com>", "<b@x.com>"] as never }), "INBOX");
+    expect(multi.references).toEqual(["<a@x.com>", "<b@x.com>"]);
+    const none = buildEmailMessage(msg(12), parsed({}), "INBOX");
+    expect(none.references).toBeUndefined();
+  });
 });
 
 describe("stripHtml / truncateBody / normalizeAddressList (moved, unchanged)", () => {

--- a/src/services/imap-helpers.ts
+++ b/src/services/imap-helpers.ts
@@ -215,7 +215,13 @@ export function buildEmailMessage(
         )
       : undefined,
     inReplyTo: parsed.inReplyTo,
-    references: parsed.references,
+    // mailparser returns a single string for a one-reference message and an
+    // array for multiple. EmailMessage.references is string[], and sendEmail
+    // calls .map() on it — normalize so a single-reference forward/reply can't
+    // crash with "references.map is not a function".
+    references: parsed.references === undefined
+      ? undefined
+      : Array.isArray(parsed.references) ? parsed.references : [parsed.references],
     isAnswered: message.flags?.has("\\Answered") ?? false,
     // Bridge marks a forward with the `$Forwarded` keyword (what our own
     // forward setter writes) or the standard `\Forwarded` — NOT `\Forward`,

--- a/src/services/simple-imap-service.ts
+++ b/src/services/simple-imap-service.ts
@@ -3040,7 +3040,7 @@ export class SimpleIMAPService {
     // throws in the same situation. Mirror that contract here: if the
     // operator pinned a cert OR set localhost without an insecure opt-in,
     // refuse to bring up the IDLE socket downgraded.
-    const isLocalhost = cfg.host === 'localhost' || cfg.host === '127.0.0.1';
+    const isLocalhost = cfg.host === 'localhost' || cfg.host === '127.0.0.1' || cfg.host === '::1';
     const allowInsecure = cfg.allowInsecureBridge
       || process.env.MAILPOUCH_INSECURE_BRIDGE === '1';
     // Same TLS decision as connect(), but IDLE ABORTS (rather than throwing)

--- a/src/services/smtp-service.ts
+++ b/src/services/smtp-service.ts
@@ -4,11 +4,9 @@
  */
 
 import nodemailer from "nodemailer";
-import { readFileSync, statSync } from "fs";
-import { join as pathJoin } from "path";
 import { ProtonMailConfig, SendEmailOptions } from "../types/index.js";
 import { logger } from "../utils/logger.js";
-import { buildBridgeTlsOptions, readPinnedBridgeCert } from "./bridge-tls.js";
+import { buildBridgeTlsConfig } from "./bridge-tls.js";
 import { parseEmails, parseEmailsDetailed, isValidEmail, sanitizeForLog, validateAttachmentLimits } from "../utils/helpers.js";
 import { tracer } from "../utils/tracer.js";
 import { classifyError } from "../utils/error-classify.js";
@@ -84,10 +82,13 @@ export class SMTPService {
     this.transporter = null;
     this.insecureTls = false;
 
-    // Check if using localhost (Proton Bridge)
+    // Check if using localhost (Proton Bridge). Include IPv6 loopback ::1 to
+    // match the IMAP path + buildBridgeTlsConfig — otherwise host "::1" falls
+    // through to full-validation TLS against Bridge's self-signed cert and fails.
     const isLocalhost =
       this.config.smtp.host === "localhost" ||
-      this.config.smtp.host === "127.0.0.1";
+      this.config.smtp.host === "127.0.0.1" ||
+      this.config.smtp.host === "::1";
 
     // Prefer SMTP token over password for direct (non-Bridge) connections
     const authPassword = !isLocalhost && this.config.smtp.smtpToken
@@ -98,87 +99,33 @@ export class SMTPService {
       this.config.smtp.allowInsecureBridge === true ||
       process.env.MAILPOUCH_INSECURE_BRIDGE === "1";
 
-    // Build TLS options based on connection type
+    // TLS config via the SHARED bridge-tls decision (same as the IMAP path) so the
+    // pinned-cert / insecure-fallback contract can't diverge between transports.
+    // SMTP keeps its deferred-init semantics: a secure-config-impossible error is
+    // stashed (not thrown) so the MCP server stays up and sendEmail() surfaces it.
     let tlsOptions: Record<string, unknown>;
-    if (isLocalhost) {
-      const certPath = this.config.smtp.bridgeCertPath;
-      if (certPath) {
-        // If a directory was given, look for cert.pem inside it
-        let resolvedCertPath = certPath;
-        try {
-          if (statSync(certPath).isDirectory()) {
-            resolvedCertPath = pathJoin(certPath, "cert.pem");
-            logger.info(`SMTP: Directory given for cert path — resolved to ${resolvedCertPath}`, "SMTPService");
-          }
-        } catch { /* stat failed — let readFileSync produce the real error below */ }
-        // Load the exported Bridge certificate — proper trust without disabling validation
-        try {
-          const bridgeCert = readPinnedBridgeCert(resolvedCertPath);
-          tlsOptions = buildBridgeTlsOptions(bridgeCert);
-          logger.info(`SMTP: Using exported Bridge certificate for TLS trust (${resolvedCertPath})`, "SMTPService");
-        } catch (err: unknown) {
-          // Robust message extraction: if a non-Error is thrown (string,
-          // object, etc.), (err as Error).message yields undefined and the
-          // diagnostic reads "Underlying error: undefined".
-          const errMsg = err instanceof Error ? err.message : String(err);
-          if (!allowInsecure) {
-            // Deferred failure: stash an actionable message, log a loud
-            // warning, return without building a transporter. sendEmail()
-            // surfaces this to the caller; the MCP server stays up.
-            this.initError =
-              `SMTP: Bridge cert at "${resolvedCertPath}" could not be loaded and allowInsecureBridge is not set. ` +
-              `Fix the cert path in Settings → Connection, or set allowInsecureBridge: true ` +
-              `(or MAILPOUCH_INSECURE_BRIDGE=1) to opt into the legacy insecure behavior. ` +
-              `Underlying error: ${errMsg}`;
-            logger.warn(
-              `SMTP init deferred: ${this.initError} ` +
-              "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",
-              "SMTPService",
-            );
-            return;
-          }
-          logger.warn(
-            `SMTP: Failed to load Bridge cert at "${resolvedCertPath}" — running with TLS validation DISABLED (allowInsecureBridge is set). ` +
-            "Export a fresh cert from Bridge → Help → Export TLS Certificate and update Settings → Connection to re-secure.",
-            "SMTPService",
-            err
-          );
-          tlsOptions = { rejectUnauthorized: false, minVersion: "TLSv1.2" };
-          this.insecureTls = true;
-        }
-      } else if (this.config.smtp.username) {
-        // Credentials are loaded — this is a real connection attempt.
-        if (!allowInsecure) {
-          // Deferred failure — same rationale as the cert-load branch above.
-          this.initError =
-            "SMTP: No Bridge certificate configured. Export the cert from Bridge → Help → Export TLS Certificate " +
-            "and set 'bridgeCertPath' in Settings → Connection. To opt into the legacy behavior (TLS validation " +
-            "disabled for localhost), set allowInsecureBridge: true or launch with MAILPOUCH_INSECURE_BRIDGE=1.";
-          logger.warn(
-            `SMTP init deferred: ${this.initError} ` +
-            "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",
-            "SMTPService",
-          );
-          return;
-        }
-        logger.warn(
-          "SMTP: No Bridge certificate configured and allowInsecureBridge is set — " +
-          "TLS certificate validation DISABLED for localhost. Export the cert from Bridge → Help → " +
-          "Export TLS Certificate and clear the insecure flag to re-secure.",
-          "SMTPService"
-        );
-        tlsOptions = { rejectUnauthorized: false, minVersion: "TLSv1.2" };
-        this.insecureTls = true;
-      } else {
-        // Pre-config constructor call — credentials haven't loaded yet. Skip the hard
-        // check until reinitialize() runs after main() populates the config.
-        logger.debug("SMTP: transporter pre-initialized (no config loaded yet — reinitialize() will be called after config loads)", "SMTPService");
-        tlsOptions = { rejectUnauthorized: false, minVersion: "TLSv1.2" };
-        this.insecureTls = true;
-      }
+    if (isLocalhost && !this.config.smtp.bridgeCertPath && !this.config.smtp.username) {
+      // Pre-config constructor call — credentials haven't loaded yet. Soft insecure;
+      // reinitialize() runs the real check once main() populates the config.
+      logger.debug("SMTP: transporter pre-initialized (no config loaded yet — reinitialize() will be called after config loads)", "SMTPService");
+      tlsOptions = { rejectUnauthorized: false, minVersion: "TLSv1.2" };
+      this.insecureTls = true;
     } else {
-      // Non-localhost: full certificate validation required
-      tlsOptions = { minVersion: "TLSv1.2" };
+      try {
+        const cfg = buildBridgeTlsConfig(this.config.smtp.host, this.config.smtp.bridgeCertPath, allowInsecure);
+        tlsOptions = cfg.tlsOptions;
+        this.insecureTls = cfg.insecure;
+        for (const l of cfg.logs) logger[l.level](`SMTP: ${l.msg}`, "SMTPService");
+      } catch (err: unknown) {
+        // Deferred failure: stash the actionable message, keep the server up.
+        this.initError = `SMTP: ${err instanceof Error ? err.message : String(err)}`;
+        logger.warn(
+          `SMTP init deferred: ${this.initError} ` +
+          "Send attempts will fail with this message until the user fixes the config and reinitialize() runs.",
+          "SMTPService",
+        );
+        return;
+      }
     }
 
     // requireTLS forces nodemailer to issue STARTTLS and reject the

--- a/src/services/smtp-tls.test.ts
+++ b/src/services/smtp-tls.test.ts
@@ -133,6 +133,14 @@ describe("SMTPService TLS strict mode (no allowInsecureBridge)", () => {
     // Non-localhost never enters the bridge-cert branch; insecureTls must stay false.
     expect(svc.insecureTls).toBe(false);
   });
+
+  it("treats IPv6 loopback ::1 as localhost (Bridge), not a remote host", () => {
+    // With ::1 mistakenly treated as remote, this would skip the bridge-cert
+    // branch and defer no error; instead it must take the localhost path and
+    // (no cert, strict) record the "No Bridge certificate configured" deferral.
+    const svc = new SMTPService(baseConfig({ host: "::1" }));
+    expect(svc.initError).toMatch(/No Bridge certificate configured/);
+  });
 });
 
 describe("SMTPService TLS insecure opt-in", () => {

--- a/src/tools/sending.test.ts
+++ b/src/tools/sending.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import mod from "./sending.js";
+import type { ToolCallContext, ToolResult } from "./types.js";
+import type { EmailMessage } from "../types/index.js";
+
+function makeCtx(over: Partial<ToolCallContext>): ToolCallContext {
+  const actionOk = (messageId?: string): ToolResult => ({
+    content: [{ type: "text", text: "Done." }], structuredContent: { success: true, messageId },
+  });
+  return {
+    actionOk,
+    MAX_SUBJECT_LENGTH: 998,
+    MAX_BODY_LENGTH: 25 * 1024 * 1024,
+    ...over,
+  } as unknown as ToolCallContext;
+}
+
+function original(over: Partial<EmailMessage> = {}): EmailMessage {
+  return {
+    id: "42", from: "Alice <alice@x.com>", to: ["bob@x.com"], subject: "Hello",
+    body: "original body", isHtml: false, date: new Date("2026-01-01T00:00:00Z"),
+    folder: "INBOX", isRead: true, isStarred: false, hasAttachment: false,
+    inReplyTo: "<parent@x.com>", references: "<root@x.com> <parent@x.com>",
+    ...over,
+  } as EmailMessage;
+}
+
+describe("forward_email", () => {
+  it("carries the original threading headers (inReplyTo/references) onto the forward", async () => {
+    const sendEmail = vi.fn().mockResolvedValue({ success: true, messageId: "<new@x.com>" });
+    const ctx = makeCtx({
+      args: { emailId: "42", to: "carol@x.com" },
+      imapService: { getEmailById: async () => original(), setFlag: vi.fn().mockResolvedValue(true) } as unknown as ToolCallContext["imapService"],
+      smtpService: { sendEmail } as unknown as ToolCallContext["smtpService"],
+    });
+    await mod.handlers.forward_email(ctx);
+    const sent = sendEmail.mock.calls[0][0];
+    expect(sent.inReplyTo).toBe("<parent@x.com>");
+    expect(sent.references).toBe("<root@x.com> <parent@x.com>");
+  });
+
+  it("strips control chars from the embedded original From/To in the quoted header", async () => {
+    const sendEmail = vi.fn().mockResolvedValue({ success: true, messageId: "<n@x.com>" });
+    const ctx = makeCtx({
+      args: { emailId: "42", to: "carol@x.com" },
+      imapService: {
+        getEmailById: async () => original({ from: "Evil\r\nBcc: leak@e.com <evil@x.com>", to: ["x@y.com\r\nInjected: 1"] }),
+        setFlag: vi.fn().mockResolvedValue(true),
+      } as unknown as ToolCallContext["imapService"],
+      smtpService: { sendEmail } as unknown as ToolCallContext["smtpService"],
+    });
+    await mod.handlers.forward_email(ctx);
+    const body = sendEmail.mock.calls[0][0].body as string;
+    // No raw CRLF-injected header lines survive in the quoted block.
+    expect(body).not.toMatch(/\r\nBcc:/);
+    expect(body).not.toMatch(/\r\nInjected:/);
+    expect(body).toContain("Forwarded message");
+  });
+
+  it("sets $Forwarded on success and does not throw if the flag set fails", async () => {
+    const sendEmail = vi.fn().mockResolvedValue({ success: true, messageId: "<n@x.com>" });
+    const setFlag = vi.fn().mockRejectedValue(new Error("flag failed"));
+    const ctx = makeCtx({
+      args: { emailId: "42", to: "carol@x.com" },
+      imapService: { getEmailById: async () => original(), setFlag } as unknown as ToolCallContext["imapService"],
+      smtpService: { sendEmail } as unknown as ToolCallContext["smtpService"],
+    });
+    // Flag failure is logged, not thrown — the forward still succeeds.
+    await expect(mod.handlers.forward_email(ctx)).resolves.toBeDefined();
+    expect(setFlag).toHaveBeenCalledWith("42", "$Forwarded");
+  });
+});

--- a/src/tools/sending.test.ts
+++ b/src/tools/sending.test.ts
@@ -20,7 +20,7 @@ function original(over: Partial<EmailMessage> = {}): EmailMessage {
     id: "42", from: "Alice <alice@x.com>", to: ["bob@x.com"], subject: "Hello",
     body: "original body", isHtml: false, date: new Date("2026-01-01T00:00:00Z"),
     folder: "INBOX", isRead: true, isStarred: false, hasAttachment: false,
-    inReplyTo: "<parent@x.com>", references: "<root@x.com> <parent@x.com>",
+    inReplyTo: "<parent@x.com>", references: ["<root@x.com>", "<parent@x.com>"],
     ...over,
   } as EmailMessage;
 }
@@ -36,7 +36,7 @@ describe("forward_email", () => {
     await mod.handlers.forward_email(ctx);
     const sent = sendEmail.mock.calls[0][0];
     expect(sent.inReplyTo).toBe("<parent@x.com>");
-    expect(sent.references).toBe("<root@x.com> <parent@x.com>");
+    expect(sent.references).toEqual(["<root@x.com>", "<parent@x.com>"]);
   });
 
   it("strips control chars from the embedded original From/To in the quoted header", async () => {

--- a/src/tools/sending.ts
+++ b/src/tools/sending.ts
@@ -8,6 +8,7 @@
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { isValidEmail, optionalFolderHint, validateAttachments, sanitizeAttachments, requireNumericEmailId } from "../utils/helpers.js";
+import { logger } from "../utils/logger.js";
 import { escapeHtml } from "../services/smtp-service.js";
 import type { ToolDef, ToolHandler, ToolModule } from "./types.js";
 
@@ -225,7 +226,8 @@ export const handlers: Record<string, ToolHandler> = {
       return { content: [{ type: "text" as const, text: "Email delivery failed" }], isError: true };
     }
     if (result.success) {
-      await imapService.setFlag(emailId, '\\Answered').catch(() => {});
+      await imapService.setFlag(emailId, '\\Answered').catch((err) =>
+        logger.warn(`reply_to_email: failed to set \\Answered on ${emailId}: ${err instanceof Error ? err.message : String(err)}`, 'Sending'));
     }
     return actionOk(result.messageId);
   },
@@ -249,12 +251,15 @@ export const handlers: Record<string, ToolHandler> = {
       ? fwdSubjectRaw.slice(0, MAX_SUBJECT_LENGTH)
       : fwdSubjectRaw;
 
+    // Strip control chars from the embedded original From/To so a CRLF in a
+    // display name can't break the quoted header block's visual structure.
+    const stripCtl = (s: string) => s.replace(/[\r\n\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
     const fwdHeader = [
       "---------- Forwarded message ----------",
-      `From: ${fwdOriginal.from}`,
+      `From: ${stripCtl(fwdOriginal.from)}`,
       `Date: ${fwdOriginal.date.toISOString()}`,
       `Subject: ${fwdCleanSubject}`,
-      `To: ${(fwdOriginal.to ?? []).join(", ")}`,
+      `To: ${stripCtl((fwdOriginal.to ?? []).join(", "))}`,
       "",
     ].join("\n");
 
@@ -277,13 +282,18 @@ export const handlers: Record<string, ToolHandler> = {
       subject: fwdSubject,
       body: fwdBody,
       isHtml: fwdOriginal.isHtml,
+      // Keep the forward in the original thread (parity with reply_to_email).
+      inReplyTo: fwdOriginal.inReplyTo,
+      references: fwdOriginal.references,
     });
 
     if (!fwdResult.success) {
       return { content: [{ type: "text" as const, text: "Forward failed" }], isError: true };
     }
     if (fwdResult.success) {
-      await imapService.setFlag(fwdId, '$Forwarded').catch(() => {});
+      // Best-effort flag; log (don't fail the send) so a flag-set failure isn't invisible.
+      await imapService.setFlag(fwdId, '$Forwarded').catch((err) =>
+        logger.warn(`forward_email: failed to set $Forwarded on ${fwdId}: ${err instanceof Error ? err.message : String(err)}`, 'Sending'));
     }
     return actionOk(fwdResult.messageId);
   },


### PR DESCRIPTION
## Summary
Phase 6 of the Bridge-capability program (plan `crispy-wibbling-dusk`). Drafts/send ultra-review (`docs/quality-audit.md`): `saveDraft` (9.5) + `sendEmail` (9.3) PASS; SMTP TLS + reply/forward rebuilt.

## Scope-check — Proton-native scheduled send
Creating/cancelling a **Proton-native** scheduled send needs Proton's private REST API (no public API) — out of reach via Bridge IMAP/SMTP. mailpouch already covers future delivery the right way: its own `schedule_email`/`cancel_scheduled_email`/`list_scheduled_emails` (deferred SMTP) + read-only `list_proton_scheduled`. No build.

## Ultra-review rebuilds (9.5 gate)
**SMTP connect/TLS (8.4) — the Phase-0 follow-up + a real bug:**
- SMTP had a **4th inline copy** of the Bridge-TLS decision tree that didn't reuse `buildBridgeTlsConfig`, risking divergence from the IMAP path's pinned-cert/insecure-fallback contract. Refactored `initializeTransporter` to call the shared helper (preserving SMTP's deferred-init via try/catch — the error substrings match, so all TLS tests pass unchanged).
- **`::1` bug:** SMTP's localhost check omitted IPv6 loopback `::1`, so host `::1` fell through to full-validation TLS against Bridge's self-signed cert and failed. The shared helper already handles `::1`; also fixed the same omission in the **IMAP IDLE socket** path.

**reply/forward (6.8) + send tools (8.6):**
- `forward_email` **dropped the original `In-Reply-To`/`References`** (broke thread continuity — `reply_to_email` carried them). Now threaded.
- The embedded original From/To in the forwarded quoted header are CRLF-stripped.
- reply + forward now **log** a `setFlag` (`\Answered`/`$Forwarded`) failure instead of silently swallowing it.

## Test plan
- [x] preship gate PASS (incl. Greenmail E2E)
- [x] 2147 unit tests green (all existing SMTP TLS tests pass through the refactor — behavior parity)
- [x] New tests: SMTP `::1` localhost, forward threading-header passthrough, forward quoted-header CRLF strip, forward flag-failure-is-logged-not-thrown
- [ ] CI matrix + CodeQL

## Security checklist
- [x] SMTP TLS now shares the IMAP pinned-cert/insecure-fallback contract (no divergence)
- [x] CRLF/header-injection hygiene preserved + extended (forward quoted header)
- [x] No secrets/credentials; attachment caps + address validation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)