### PR TITLE
Release v3.0.74 — Bridge-capability program (Phases 0–7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.74] — 2026-06-04
 
-Bridge-capability program (subsystem-by-subsystem TDD redesign + per-function ultra-review to a 9.5 quality bar; see `docs/quality-audit.md`).
+Bridge-capability program — a subsystem-by-subsystem TDD redesign with a per-function multi-agent ultra-review to a 9.5 quality bar (8 phases, `docs/quality-audit.md`). Adds the gated `empty_trash` and `mark_answered`/`mark_forwarded` capabilities and fixes a fail-open folder-delete protection hole, an attachment-download OOM bypass, two search under-return bugs, the `$Forwarded` write/read asymmetry, the SMTP TLS divergence + IPv6 `::1` handling, and the multi-account keychain credential shadow.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.73-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.74-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.73",
+  "version": "3.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.73",
+      "version": "3.0.74",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.73",
+  "version": "3.0.74",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Cuts **v3.0.74**, releasing the 8-phase Bridge-capability program (Phases 0–7, already merged to main). Version bump (package.json/lock, README badge) + CHANGELOG `[Unreleased]` → `[3.0.74]`.

## What's in 3.0.74
- **New capabilities:** gated `empty_trash` (permanent Trash-only purge, `{confirmed:true}`), `mark_answered` / `mark_forwarded`.
- **Security/correctness fixes:** fail-open folder-delete protection, attachment-download OOM bypass, search IMAP-012 (empty-on-failure) + `hasAttachment` under-return, FTS `sinceEpoch` under-return, the `$Forwarded` write/read asymmetry, SMTP TLS divergence + IPv6 `::1`, a latent `references.map` crash, the multi-account keychain credential shadow, and multi-account IDLE.
- Every function scored against a 9.5 rubric via multi-agent ultra-review; verdicts in `docs/quality-audit.md`.

## Test plan
- [x] preship gate PASS (version-sync + Greenmail E2E)
- [x] ~2150 unit tests green
- [ ] CI matrix + CodeQL

## Security checklist
- [x] No secrets committed; npm token stays in ~/.npmrc
- [x] Net effect is a security improvement (fail-open hole closed, OOM bypass closed, credential isolation strengthened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)