### PR TITLE
fix(onboarding): resolve PR #203 review (redaction leak + npx -y)

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -27,7 +27,7 @@ Practical how-tos for every feature. For API reference see [README_FIRST_AI.md](
 ## 1. Quick Start
 
 ```bash
-npx mailpouch-settings      # opens the settings UI in your browser (no install needed)
+npx -y mailpouch-settings      # opens the settings UI in your browser (no install needed)
 ```
 
 **Three things you need before Claude can read your mail:**
@@ -38,7 +38,7 @@ npx mailpouch-settings      # opens the settings UI in your browser (no install 
 
 Fill these in on the Setup tab, click **Save Configuration**, then **Test Connections**. Green means ready.
 
-Prefer the command line? `npx mailpouch setup --username you@proton.me --password-stdin` writes the same config, and `npx mailpouch doctor` verifies it.
+Prefer the command line? `npx -y mailpouch setup --username you@proton.me --password-stdin` writes the same config, and `npx -y mailpouch doctor` verifies it.
 
 **Wire up Claude Desktop** — this form works whether or not mailpouch is globally installed:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 d
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29+-green.svg)](https://github.com/modelcontextprotocol/sdk)
-[![Tests](https://img.shields.io/badge/tests-2%2C179%20passing-brightgreen.svg)](#development)
+[![Tests](https://img.shields.io/badge/tests-2%2C180%20passing-brightgreen.svg)](#development)
 
 **Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — over stdio or remote HTTP — with human-controlled permissions.**
 
@@ -56,11 +56,11 @@ Prereq: [Proton Bridge](https://proton.me/mail/bridge) installed, running, and s
    ```
 
 2. **Configure Bridge credentials** — either path writes `~/.mailpouch.json` (+ OS keychain):
-   - Interactive wizard: `npx mailpouch-settings`
-   - Non-interactive (scriptable / agent-driven): `npx mailpouch setup --username you@proton.me --password-stdin`
+   - Interactive wizard: `npx -y mailpouch-settings`
+   - Non-interactive (scriptable / agent-driven): `npx -y mailpouch setup --username you@proton.me --password-stdin`
      (paste the Proton **Bridge** password — Bridge → Settings → IMAP/SMTP → Password — **not** your Proton login password)
 
-3. **Verify:** `npx mailpouch doctor` — prints the exact next step until it reports `ready`. (Agents can call the always-available `setup_status` tool for the same diagnosis.)
+3. **Verify:** `npx -y mailpouch doctor` — prints the exact next step until it reports `ready`. (Agents can call the always-available `setup_status` tool for the same diagnosis.)
 
 4. **Approve the agent.** On first connect, every client is gated behind a one-time human Approve/Deny — open the settings UI (`http://localhost:8766/#/agents`) and click Approve. This is expected, not an error.
 
@@ -86,7 +86,7 @@ That's it. The sections below cover everything in depth.
 - **Multi-account** — configure more than one Proton / IMAP account; hot-swap the active account from the Settings UI with no server restart. Tools accept an optional `account_id` argument to route a single call to a specific account. See [`src/accounts/`](src/accounts/).
 - **Per-agent grants** — each MCP client (identified by its OAuth `client_id`) is gated by its own approvable grant, with optional folder allowlists, IP pins, per-tool rate caps, expiry, and account binding. Separate from the global preset and the escalation flow. See [`src/agents/`](src/agents/).
 - **Live notifications** — desktop toasts (no extra deps) and outbound webhooks (CloudEvents / Slack / Discord, HMAC-signed, retried) fire on grant-state changes. See [`src/notifications/`](src/notifications/).
-- **2,179 tests passing** (Vitest); minimal `any` usage in production source (private Node.js readline internals only).
+- **2,180 tests passing** (Vitest); minimal `any` usage in production source (private Node.js readline internals only).
 
 **Documentation:** [HELP.md](HELP.md) (task-oriented how-tos) · [README_FIRST_AI.md](README_FIRST_AI.md) (agent API reference) · [docs/index.md](docs/index.md) (full index)
 
@@ -190,7 +190,7 @@ Tools in unconfigured groups return a clean configuration error rather than fail
 Run the settings server to complete first-time setup:
 
 ```bash
-npx mailpouch-settings
+npx -y mailpouch-settings
 # Then open http://localhost:8766
 ```
 
@@ -211,10 +211,10 @@ When a browser/TUI wizard isn't an option, configure credentials from the comman
 
 ```bash
 # password from stdin (keeps the secret out of the process list)
-printf '%s' "$BRIDGE_PASSWORD" | npx mailpouch setup --username you@proton.me --password-stdin
+printf '%s' "$BRIDGE_PASSWORD" | npx -y mailpouch setup --username you@proton.me --password-stdin
 
 # or from a file, or inline; optional non-default ports / cert
-npx mailpouch setup --username you@proton.me --password-file ./bridge.pw \
+npx -y mailpouch setup --username you@proton.me --password-file ./bridge.pw \
   [--imap-host 127.0.0.1 --imap-port 1143 --smtp-host 127.0.0.1 --smtp-port 1025] \
   [--bridge-cert /path/cert.pem | --insecure]
 ```
@@ -222,8 +222,8 @@ npx mailpouch setup --username you@proton.me --password-file ./bridge.pw \
 Then check the install end-to-end:
 
 ```bash
-npx mailpouch doctor          # human-readable diagnosis + next step; exit 0 when ready
-npx mailpouch doctor --json   # structured output for scripts
+npx -y mailpouch doctor          # human-readable diagnosis + next step; exit 0 when ready
+npx -y mailpouch doctor --json   # structured output for scripts
 ```
 
 `doctor` reports the same state machine the always-available `setup_status` MCP tool returns: `unconfigured` → `bridge-unreachable` → `pending-approval` → `ready`, each with the exact action to advance.
@@ -481,7 +481,7 @@ The escalation system lets an agent request broader permissions without permanen
 - CSRF-protected: the approval API requires a session token embedded only in the rendered HTML page
 - Rate-limited: max 5 escalation requests per hour, max 1 pending at a time
 - Audit trail: every request, approval, and denial is appended to `~/.mailpouch.audit.jsonl`
-- Approve from another device: `npx mailpouch-settings --lan`
+- Approve from another device: `npx -y mailpouch-settings --lan`
 
 ---
 
@@ -492,13 +492,13 @@ The settings UI starts automatically on `http://localhost:8766` whenever your MC
 To run the settings UI standalone (useful for initial setup, headless / SSH systems, or a dedicated remote-mode host):
 
 ```bash
-npx mailpouch-settings           # auto-detects display; opens browser if available
-npx mailpouch-settings --port 9000   # custom port (default: 8766)
-npx mailpouch-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
-npx mailpouch-settings --browser     # force browser UI even if no display detected
-npx mailpouch-settings --tui         # force interactive terminal UI
-npx mailpouch-settings --plain       # plain readline menus (no ANSI colors/escapes)
-npx mailpouch-settings --no-open     # start server but don't auto-open browser
+npx -y mailpouch-settings           # auto-detects display; opens browser if available
+npx -y mailpouch-settings --port 9000   # custom port (default: 8766)
+npx -y mailpouch-settings --lan         # bind to 0.0.0.0 (approve from phone/other device)
+npx -y mailpouch-settings --browser     # force browser UI even if no display detected
+npx -y mailpouch-settings --tui         # force interactive terminal UI
+npx -y mailpouch-settings --plain       # plain readline menus (no ANSI colors/escapes)
+npx -y mailpouch-settings --no-open     # start server but don't auto-open browser
 ```
 
 The same standalone behaviour is available from the main binary via `mailpouch --settings-only`: it starts only the settings UI + tray (no MCP transport, no Bridge connect) and stays running until you quit it from the tray or with Ctrl-C. Unlike a bare `mailpouch`, it is safe to launch detached (autostart / `nohup` / a wrapper) — it does not tie its lifetime to stdin.
@@ -638,7 +638,7 @@ Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), 
 - Confirm the `mcpServers` block is valid JSON (no trailing commas).
 - Fully quit and reopen Claude Desktop.
 - Check MCP logs: **Help → Show Logs**.
-- Verify the server starts manually: `npx mailpouch` — it should stay running silently.
+- Verify the server starts manually: `npx -y mailpouch` — it should stay running silently.
 
 ### Analytics show zero or empty data
 
@@ -656,7 +656,7 @@ npm install
 
 npm run build          # compile TypeScript to dist/
 npm run dev            # watch mode (recompiles on save)
-npm run test           # run test suite (Vitest, 2,179 tests)
+npm run test           # run test suite (Vitest, 2,180 tests)
 npm run test:coverage  # coverage report
 npm run lint           # TypeScript type check (tsc --noEmit)
 npm run settings       # start standalone settings UI (after build)

--- a/README_FIRST_AI.md
+++ b/README_FIRST_AI.md
@@ -13,7 +13,7 @@ If mail tools are failing or you're not sure the server is set up, **call `setup
 
 | `state` | What it means | What to do |
 |---|---|---|
-| `unconfigured` | No credentials on the machine | Ask the user to run `npx mailpouch setup --username <addr> --password-stdin` (the Proton **Bridge** password, not the login password) or `npx mailpouch-settings`. You cannot do this for them. |
+| `unconfigured` | No credentials on the machine | Ask the user to run `npx -y mailpouch setup --username <addr> --password-stdin` (the Proton **Bridge** password, not the login password) or `npx -y mailpouch-settings`. You cannot do this for them. |
 | `bridge-unreachable` | Proton Bridge isn't running | Ask the user to start the Proton Bridge app, signed in (IMAP `127.0.0.1:1143`, SMTP `127.0.0.1:1025`). |
 | `pending-approval` | **Expected on first connect** — you're registered but not yet approved | Ask the user to open `http://localhost:8766/#/agents` and click Approve, then retry. This is not an error; you cannot approve yourself. |
 | `ready` | Good to go | Call `get_connection_status` to confirm live auth, then use the tools below. |

--- a/llms.txt
+++ b/llms.txt
@@ -15,12 +15,12 @@ Get connected in this exact order. The server's own MCP `initialize` instruction
    ```
 
 2. **Call `setup_status` FIRST.** It is always available — even before credentials are set or this agent is approved — and returns the single next action. Its `state` is one of:
-   - `unconfigured` — credentials aren't set. Run `npx mailpouch setup --username <you@proton.me> --password-stdin` (the Proton **Bridge** password — Bridge app → Settings → IMAP/SMTP → Password — **not** the Proton login password), or ask the user to run `npx mailpouch-settings` for the interactive wizard.
+   - `unconfigured` — credentials aren't set. Run `npx -y mailpouch setup --username <you@proton.me> --password-stdin` (the Proton **Bridge** password — Bridge app → Settings → IMAP/SMTP → Password — **not** the Proton login password), or ask the user to run `npx -y mailpouch-settings` for the interactive wizard.
    - `bridge-unreachable` — ask the user to start the Proton Bridge desktop app (signed in). Bridge listens on **127.0.0.1** (IMAP 1143, SMTP 1025).
    - `pending-approval` — **expected on first connect, not an error.** Every agent is gated behind a human Approve/Deny. Ask the user to open the settings UI (default `http://localhost:8766/#/agents`) and click Approve, then retry. You cannot approve yourself.
    - `ready` — call `get_connection_status` to confirm live auth, then use the mail tools.
 
-3. **`npx mailpouch doctor`** prints the same diagnosis from a shell and exits non-zero until the install is `ready` — useful for scripted setup.
+3. **`npx -y mailpouch doctor`** prints the same diagnosis from a shell and exits non-zero until the install is `ready` — useful for scripted setup.
 
 Credentials are entered on the user's machine and stored in the OS keychain (or `~/.mailpouch.json`, mode 0600); never ask the user to paste their password into the chat — the server injects it.
 

--- a/src/diagnostics/setup-status.test.ts
+++ b/src/diagnostics/setup-status.test.ts
@@ -79,6 +79,18 @@ describe("computeSetupStatus", () => {
     expect(r.summary).not.toContain("/home/u/.mailpouch.json");
   });
 
+  it("redacts the config path even when the config file does not exist yet (first-run leak)", () => {
+    const r = computeSetupStatus(base({
+      configExists: false,
+      username: "",
+      hasPassword: false,
+      grant: { status: "pending" },
+    }));
+    // A pending caller on a fresh box must not receive the absolute home path.
+    expect(r.configPath).toBe("~/.mailpouch.json");
+    expect(r.summary).not.toContain("/home/u/.mailpouch.json");
+  });
+
   it("does NOT redact for an active grant or when there is no grant gate", () => {
     expect(computeSetupStatus(base({ grant: { status: "active" } })).username).toBe("me@proton.me");
     expect(computeSetupStatus(base()).configPath).toBe("/home/u/.mailpouch.json");

--- a/src/diagnostics/setup-status.ts
+++ b/src/diagnostics/setup-status.ts
@@ -63,10 +63,10 @@ export interface SetupStatusResult {
 }
 
 const SETUP_HINT =
-  "Run:  npx mailpouch setup --username <you@proton.me> --password-stdin\n" +
+  "Run:  npx -y mailpouch setup --username <you@proton.me> --password-stdin\n" +
   "  (paste your Proton BRIDGE password — Bridge app -> Settings -> IMAP/SMTP -> Password — " +
   "NOT your Proton login password.)\n" +
-  "  Or launch the interactive wizard:  npx mailpouch-settings";
+  "  Or launch the interactive wizard:  npx -y mailpouch-settings";
 
 /** Mask an email's local part so it isn't disclosed to an unapproved caller. */
 function maskEmail(email: string): string {
@@ -157,7 +157,10 @@ export function computeSetupStatus(input: SetupStatusInput): SetupStatusResult {
     configured,
     bridgeReachable,
     configExists: input.configExists,
-    configPath: input.configExists ? displayConfigPath : input.configPath,
+    // Always go through displayConfigPath — never the raw absolute path — so a
+    // pending/unapproved caller can't read the home dir (and OS username) even
+    // on first run when the config file doesn't exist yet.
+    configPath: displayConfigPath,
     username: displayUsername || null,
     credentialStorage: input.credentialStorage,
     imap: input.imap,

--- a/src/index.ts
+++ b/src/index.ts
@@ -520,8 +520,8 @@ const SERVER_INSTRUCTIONS =
   "1. Call `setup_status` FIRST. It is always available (even before approval) and tells you exactly " +
   "what is wrong and the single next step.\n" +
   "2. If it reports `unconfigured`: credentials must be set on the user's machine. Either run " +
-  "`npx mailpouch setup --username <you@proton.me> --password-stdin` (the Proton BRIDGE password, not " +
-  "the Proton login password), or ask the user to run `npx mailpouch-settings` for the interactive wizard.\n" +
+  "`npx -y mailpouch setup --username <you@proton.me> --password-stdin` (the Proton BRIDGE password, not " +
+  "the Proton login password), or ask the user to run `npx -y mailpouch-settings` for the interactive wizard.\n" +
   "3. If it reports `bridge-unreachable`: ask the user to start the Proton Bridge app (signed in). " +
   "Bridge listens on 127.0.0.1 — IMAP :1143, SMTP :1025.\n" +
   "4. If it reports `pending-approval`: this is EXPECTED on first connect, not an error. Every agent is " +

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -35,7 +35,7 @@ export const defs: ToolDef[] = [
         configured: { type: "boolean", description: "A username and Bridge password are configured." },
         bridgeReachable: { type: "boolean", description: "Both IMAP and SMTP Bridge ports accept TCP connections." },
         configExists: { type: "boolean" },
-        configPath: { type: "string", description: "Absolute path to ~/.mailpouch.json." },
+        configPath: { type: "string", description: "Path to the config file (~/.mailpouch.json); redacted to '~/.mailpouch.json' for callers whose grant is not yet active." },
         username: { type: ["string", "null"] },
         credentialStorage: { type: ["string", "null"], enum: ["keychain", "encrypted-file", "config", null] },
         imap: {

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -35,7 +35,7 @@ export const defs: ToolDef[] = [
         configured: { type: "boolean", description: "A username and Bridge password are configured." },
         bridgeReachable: { type: "boolean", description: "Both IMAP and SMTP Bridge ports accept TCP connections." },
         configExists: { type: "boolean" },
-        configPath: { type: "string", description: "Path to the config file (~/.mailpouch.json); redacted to '~/.mailpouch.json' for callers whose grant is not yet active." },
+        configPath: { type: "string", description: "Path to the config file (default ~/.mailpouch.json; overridable via the MAILPOUCH_CONFIG env var). Redacted to '~/.mailpouch.json' for callers whose grant is not yet active." },
         username: { type: ["string", "null"] },
         credentialStorage: { type: ["string", "null"], enum: ["keychain", "encrypted-file", "config", null] },
         imap: {


### PR DESCRIPTION
Follow-up to #203, resolving the Copilot review comments that landed after that PR merged.

## Fixes
- **Disclosure bug (real):** `setup_status` redacted the config path only when the config file existed, so a pending/unapproved caller on a **fresh** machine still received the absolute home path (leaking the OS username). Redaction now always routes through `displayConfigPath`, regardless of `configExists`. (`src/diagnostics/setup-status.ts`)
- **Non-interactive npx:** `SERVER_INSTRUCTIONS`, the `setup_status` hint, and all docs now use `npx -y …` so an agent following the guidance never hits an npx install-confirmation prompt. (`src/index.ts`, docs)
- **Schema accuracy:** `setup_status` `configPath` description now notes it may be the redacted `~/.mailpouch.json`. (`src/tools/diagnostics.ts`)
- **Regression test:** added the `configExists: false` redaction case.

## Test plan
- [x] `npm run preship` (full) PASS — Bridge E2E skipped via `PRESHIP_NO_BRIDGE=1`; Greenmail E2E green
- [x] 2,180 unit tests pass

## Security checklist
- [x] Closes the first-run config-path disclosure to unapproved callers
- [x] No secrets committed; no new attack surface; dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)