### PR TITLE
Release v3.0.75 — foolproof install & auth for AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.75] — 2026-06-05
 
 Foolproof install & authentication for AI agents — close the "an AI can't recognize, install, or connect this MCP server" gap surfaced in the field. The MCP server now describes itself on `initialize`, ships an always-available diagnostic, and exposes a non-interactive credential path so an agent can go from zero to connected without driving a browser.
 

--- a/LICENSES.json
+++ b/LICENSES.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "2026-06-05",
-  "rootPackage": "mailpouch@3.0.74",
+  "rootPackage": "mailpouch@3.0.75",
   "deps": [
     {
       "name": "@hono/node-server",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.74-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.75-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.74",
+  "version": "3.0.75",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.74",
+      "version": "3.0.75",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.74",
+  "version": "3.0.75",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release PR: bump **3.0.74 → 3.0.75** and date the CHANGELOG.

Ships the onboarding arc already merged to main in #203/#204:
- MCP server `instructions` on `initialize` (identity + connect lifecycle)
- Always-available, ungated `setup_status` diagnostic (state machine + next step; redacts identity for unapproved callers)
- Non-interactive `mailpouch setup` (writes the authoritative per-account keychain key) and `mailpouch doctor` CLIs
- One canonical `npx -y mailpouch` config across all docs; README_FIRST_AI.md + llms.txt now ship in the tarball

## Release checklist
- [x] `package.json` + both `package-lock.json` version fields → 3.0.75
- [x] CHANGELOG `[Unreleased]` → `[3.0.75] — 2026-06-05`
- [x] npm version badge → v3.0.75
- [x] `npm run preship:release` PASS (Bridge E2E skipped via PRESHIP_NO_BRIDGE=1; Greenmail E2E green; changelog-has-entry / git-tag-free / npm-version-free all ✓)
- [ ] After merge: tag `v3.0.75`, `npm publish`, verify `npm view mailpouch version`

## Security checklist
- [x] No secrets committed (version-only changes)
- [x] No new attack surface; dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)