### PR TITLE
Release v3.0.76 — quieter security notifications + imapflow 1.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.76] — 2026-06-05
 
 ### Changed
 
 - **Quieter desktop notifications — new "Surface security messages" debug toggle** (`surfaceSecurityNotifications`, default off). The informational security toasts — post-decision grant lifecycle (approved / denied / **revoked** / expired) and a per-action notification for each non-read-only tool mailpouch runs (send / move / delete / …) — now go to the **debug log** by default instead of popping a toast. Enable the toggle (Settings → Setup, or `surfaceSecurityNotifications: true` in `~/.mailpouch.json`) to surface them as toasts for debugging. The actionable "agent awaiting approval" prompt is **not** gated by this — it always fires (subject to `desktopNotificationsEnabled`) so the human approval gate keeps working. Read-only tool calls and errored/no-op actions never notify. Gating logic is the pure, unit-tested `src/notifications/security-gate.ts`.
+
+### Dependencies
+
+- Bump `imapflow` 1.3.5 → 1.3.6 (patch, within range; 0 vulnerabilities).
 
 ## [3.0.75] — 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Quieter desktop notifications — new "Surface security messages" debug toggle** (`surfaceSecurityNotifications`, default off). The informational security toasts — post-decision grant lifecycle (approved / denied / **revoked** / expired) and a per-action notification for each non-read-only tool mailpouch runs (send / move / delete / …) — now go to the **debug log** by default instead of popping a toast. Enable the toggle (Settings → Setup, or `surfaceSecurityNotifications: true` in `~/.mailpouch.json`) to surface them as toasts for debugging. The actionable "agent awaiting approval" prompt is **not** gated by this — it always fires (subject to `desktopNotificationsEnabled`) so the human approval gate keeps working. Read-only tool calls and errored/no-op actions never notify. Gating logic is the pure, unit-tested `src/notifications/security-gate.ts`.
+
 ## [3.0.75] — 2026-06-05
 
 Foolproof install & authentication for AI agents — close the "an AI can't recognize, install, or connect this MCP server" gap surfaced in the field. The MCP server now describes itself on `initialize`, ships an always-available diagnostic, and exposes a non-interactive credential path so an agent can go from zero to connected without driving a browser.

--- a/HELP.md
+++ b/HELP.md
@@ -154,6 +154,15 @@ Platforms: `osascript` (macOS), `notify-send` (Linux), `powershell.exe` (Windows
 
 Disable if you prefer to poll the **Agents tab** manually, or if you're running headless.
 
+### Surface security messages (debug)
+
+A second toggle, **Surface security messages** (off by default), controls the *informational* security toasts:
+
+- post-decision grant changes — agent **approved / denied / revoked / expired**, and
+- a per-action notification for each non-read-only tool mailpouch runs (send, move, delete, …).
+
+By default these are routed to the **debug log** only, so your desktop isn't peppered with "token revoked" / per-action toasts. Turn the toggle on (or set `surfaceSecurityNotifications: true` in `~/.mailpouch.json`) to surface them as toasts while debugging what an agent is doing. The **"agent awaiting approval"** prompt is never affected by this toggle — it always shows so the approval gate keeps working. Read-only tool calls and failed/no-op actions never notify.
+
 ---
 
 ## 6. Full-Text Search

--- a/LICENSES.json
+++ b/LICENSES.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "2026-06-06",
-  "rootPackage": "mailpouch@3.0.75",
+  "rootPackage": "mailpouch@3.0.76",
   "deps": [
     {
       "name": "@hono/node-server",

--- a/LICENSES.json
+++ b/LICENSES.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-05",
+  "generatedAt": "2026-06-06",
   "rootPackage": "mailpouch@3.0.75",
   "deps": [
     {
@@ -394,7 +394,7 @@
     },
     {
       "name": "imapflow",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT"
     },
     {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.75-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.76-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2012,9 +2012,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/imapflow": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.5.tgz",
-      "integrity": "sha512-1cWnj9V8eJuYizxfb4nzD2C+cE27pUOIg571d/U9pg046bJnz/d+rnp2HzXKqX9bYmkvxoQqw2w3TMGpmfiBoA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.3.6.tgz",
+      "integrity": "sha512-Phjp//d2LKu3UcwhFD5q/BAOdZ7T+pW221TLmu2pZhTK2IvUj0A8rY/LyYsg8CbVUJ1/csE5t3ZZLyRWsHU/Dw==",
       "license": "MIT",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.75",
+  "version": "3.0.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.75",
+      "version": "3.0.76",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.75",
+  "version": "3.0.76",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -397,6 +397,17 @@ export interface ServerConfig {
   /** Fire native OS notifications on new pending grants (default true). */
   desktopNotificationsEnabled?: boolean;
   /**
+   * Debug aid ("Surface security messages"). Default false. When false, the
+   * informational/security desktop toasts — post-decision grant lifecycle
+   * (approved/denied/revoked/expired) and per-action notifications for the
+   * non-read-only tools mailpouch runs — are routed to the DEBUG log instead of
+   * popping a toast. When true, they surface as desktop notifications for
+   * debugging. The actionable "agent awaiting approval" prompt is NOT gated by
+   * this — it always fires (subject to desktopNotificationsEnabled) so the human
+   * approval gate keeps working.
+   */
+  surfaceSecurityNotifications?: boolean;
+  /**
    * Auto-open the Settings UI Agents tab in the browser when a new remote agent
    * registers, so the user can approve/deny the connection immediately
    * (default true). Skipped on headless hosts (no display). Set false on a

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ import { tracer } from "./utils/tracer.js";
 import { allToolDefs, allHandlers, escalationHandlers, describeRequestEscalation } from "./tools/registry.js";
 import type { ToolCallContext, ToolSharedState } from "./tools/types.js";
 import { gatherSetupStatus } from "./diagnostics/setup-status.js";
+import { shouldSurfaceGrantToast, shouldSurfaceActionToast } from "./notifications/security-gate.js";
 
 // ─── Service Initialization ───────────────────────────────────────────────────
 // All credentials and connection settings are loaded from ~/.mailpouch.json
@@ -316,9 +317,16 @@ agentNotifications.subscribe((ev) => {
     };
     const title = titleByKind[ev.kind] ?? "mailpouch";
     const body = `${ev.grant.clientName}`;
-    // Fire-and-forget — notifier failures never touch the caller.
-    void desktopNotifier.notify({ title, body, sound: ev.kind === "grant-created" ? "Glass" : undefined })
-      .catch(() => { /* logged inside notifier */ });
+    // "grant-created" is the actionable approval gate — always surface it. The
+    // post-decision events (approved/denied/revoked/expired) are informational;
+    // route them to the debug log unless "Surface security messages" is enabled.
+    if (shouldSurfaceGrantToast(ev.kind, cfg ?? {})) {
+      // Fire-and-forget — notifier failures never touch the caller.
+      void desktopNotifier.notify({ title, body, sound: ev.kind === "grant-created" ? "Glass" : undefined })
+        .catch(() => { /* logged inside notifier */ });
+    } else {
+      logger.debug(`Security notification (toast suppressed; enable "Surface security messages" to show): ${ev.kind} — ${body}`, "Notifications");
+    }
   }
   // Webhooks: dispatch to every enabled endpoint in parallel.
   const endpoints = cfg?.webhooks ?? [];
@@ -559,6 +567,38 @@ function activeToolTier(): ReturnType<typeof parseToolTier> {
   if (envTier) return parseToolTier(envTier);
   const cfg = loadConfig();
   return parseToolTier(cfg?.toolTier);
+}
+
+// Tools annotated read-only never fire a per-action security toast — reads
+// (get_emails, search, status, …) would be pure noise. Built once from the
+// registry so it tracks the annotations automatically.
+const READONLY_TOOLS: ReadonlySet<string> = new Set(
+  allToolDefs()
+    .filter((d) => (d.annotations as { readOnlyHint?: boolean } | undefined)?.readOnlyHint === true)
+    .map((d) => d.name),
+);
+
+/**
+ * Per-action security notification (debug aid). Always debug-logs the action;
+ * surfaces a desktop toast ONLY for a successful, non-read-only tool call when
+ * "Surface security messages" (surfaceSecurityNotifications) is enabled and
+ * desktop notifications aren't disabled. Fire-and-forget.
+ */
+function notifyActionPerformed(
+  tool: string,
+  caller: CallerContext | undefined,
+  result: { isError?: boolean },
+  cfg: { surfaceSecurityNotifications?: boolean; desktopNotificationsEnabled?: boolean },
+): void {
+  // Guard the noisy cases up front; reads and errored/no-op calls never notify.
+  if (result.isError === true || READONLY_TOOLS.has(tool)) return;
+  const who = caller?.clientName ? ` · ${caller.clientName}` : "";
+  logger.debug(`Action performed: ${tool}${who}`, "Notifications");
+  if (shouldSurfaceActionToast({ isReadOnly: false, isError: false, cfg })) {
+    void desktopNotifier
+      .notify({ title: "mailpouch — action", body: `${tool}${who}` })
+      .catch(() => { /* logged inside notifier */ });
+  }
 }
 
 function registerHandlers(server: Server): void {
@@ -955,7 +995,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       MAX_SUBJECT_LENGTH,
       state: sharedState,
     };
-    return await handler(ctx);
+    const result = await handler(ctx);
+    // Per-action security notification (debug aid) — debug-logs always; toasts
+    // only when "Surface security messages" is enabled. Uses the one config
+    // snapshot already loaded for this call's gate chain.
+    notifyActionPerformed(name, caller, result, configSnapshot);
+    return result;
   } catch (error: unknown) {
     logger.error(`Tool failed: ${name}`, "MCPServer", error);
     const msg = safeErrorMessage(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -579,10 +579,12 @@ const READONLY_TOOLS: ReadonlySet<string> = new Set(
 );
 
 /**
- * Per-action security notification (debug aid). Always debug-logs the action;
- * surfaces a desktop toast ONLY for a successful, non-read-only tool call when
- * "Surface security messages" (surfaceSecurityNotifications) is enabled and
- * desktop notifications aren't disabled. Fire-and-forget.
+ * Per-action security notification (debug aid). Read-only tools and
+ * errored/no-op calls are ignored entirely (they would be pure noise). For a
+ * successful, non-read-only tool call it writes a DEBUG log line, and
+ * additionally surfaces a desktop toast when "Surface security messages"
+ * (surfaceSecurityNotifications) is enabled and desktop notifications aren't
+ * disabled. Fire-and-forget.
  */
 function notifyActionPerformed(
   tool: string,
@@ -996,9 +998,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       state: sharedState,
     };
     const result = await handler(ctx);
-    // Per-action security notification (debug aid) — debug-logs always; toasts
-    // only when "Surface security messages" is enabled. Uses the one config
-    // snapshot already loaded for this call's gate chain.
+    // Per-action security notification (debug aid) — debug-logs a successful
+    // non-read-only action; also toasts it when "Surface security messages" is
+    // enabled. Uses the one config snapshot already loaded for this gate chain.
     notifyActionPerformed(name, caller, result, configSnapshot);
     return result;
   } catch (error: unknown) {

--- a/src/notifications/security-gate.test.ts
+++ b/src/notifications/security-gate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldSurfaceGrantToast,
+  shouldSurfaceActionToast,
+  INFORMATIONAL_GRANT_EVENTS,
+  type GrantEventKind,
+} from "./security-gate.js";
+
+describe("shouldSurfaceGrantToast", () => {
+  it("always surfaces grant-created (the approval gate), regardless of the debug toggle", () => {
+    expect(shouldSurfaceGrantToast("grant-created", {})).toBe(true);
+    expect(shouldSurfaceGrantToast("grant-created", { surfaceSecurityNotifications: false })).toBe(true);
+  });
+
+  it("suppresses informational events by default (debug-log only)", () => {
+    for (const kind of INFORMATIONAL_GRANT_EVENTS) {
+      expect(shouldSurfaceGrantToast(kind, {})).toBe(false);
+    }
+  });
+
+  it("surfaces informational events when the debug toggle is on", () => {
+    for (const kind of INFORMATIONAL_GRANT_EVENTS) {
+      expect(shouldSurfaceGrantToast(kind, { surfaceSecurityNotifications: true })).toBe(true);
+    }
+  });
+
+  it("the master switch (desktopNotificationsEnabled:false) silences everything, even grant-created", () => {
+    const off = { desktopNotificationsEnabled: false, surfaceSecurityNotifications: true };
+    expect(shouldSurfaceGrantToast("grant-created", off)).toBe(false);
+    expect(shouldSurfaceGrantToast("grant-revoked", off)).toBe(false);
+  });
+
+  it("token-revoked specifically: silent by default, shown with the toggle", () => {
+    expect(shouldSurfaceGrantToast("grant-revoked", {})).toBe(false);
+    expect(shouldSurfaceGrantToast("grant-revoked", { surfaceSecurityNotifications: true })).toBe(true);
+  });
+});
+
+describe("shouldSurfaceActionToast", () => {
+  const on = { surfaceSecurityNotifications: true };
+
+  it("never toasts read-only actions", () => {
+    expect(shouldSurfaceActionToast({ isReadOnly: true, isError: false, cfg: on })).toBe(false);
+  });
+
+  it("never toasts errored/no-op actions", () => {
+    expect(shouldSurfaceActionToast({ isReadOnly: false, isError: true, cfg: on })).toBe(false);
+  });
+
+  it("does not toast a successful mutating action when the toggle is off", () => {
+    expect(shouldSurfaceActionToast({ isReadOnly: false, isError: false, cfg: {} })).toBe(false);
+  });
+
+  it("toasts a successful mutating action only when the toggle is on", () => {
+    expect(shouldSurfaceActionToast({ isReadOnly: false, isError: false, cfg: on })).toBe(true);
+  });
+
+  it("the master switch overrides the toggle", () => {
+    expect(shouldSurfaceActionToast({
+      isReadOnly: false, isError: false,
+      cfg: { surfaceSecurityNotifications: true, desktopNotificationsEnabled: false },
+    })).toBe(false);
+  });
+});
+
+// Guard: the informational set must never include grant-created (would break the gate).
+describe("INFORMATIONAL_GRANT_EVENTS", () => {
+  it("excludes grant-created", () => {
+    expect(INFORMATIONAL_GRANT_EVENTS.has("grant-created" as GrantEventKind)).toBe(false);
+  });
+});

--- a/src/notifications/security-gate.ts
+++ b/src/notifications/security-gate.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure decision logic for the "Surface security messages" debug aid.
+ *
+ * mailpouch fires desktop toasts for two kinds of security-relevant events:
+ *   1. agent grant-lifecycle transitions (created/approved/denied/revoked/expired)
+ *   2. each non-read-only tool action it performs (send, move, delete, …)
+ *
+ * By default these are noise, so they go to the DEBUG log only. When the
+ * operator enables `surfaceSecurityNotifications`, they surface as toasts to
+ * help debug what an agent is doing. The single exception is `grant-created`
+ * ("agent awaiting approval") — that's the actionable human gate, so it always
+ * surfaces (subject only to the desktopNotificationsEnabled master switch).
+ *
+ * Kept dependency-free and pure so the gating is unit-tested directly; index.ts
+ * does the actual logging/notifying.
+ */
+
+export type GrantEventKind =
+  | "grant-created"
+  | "grant-approved"
+  | "grant-denied"
+  | "grant-revoked"
+  | "grant-expired";
+
+export interface SecurityNotifyConfig {
+  /** Master switch for all desktop notifications (default on). */
+  desktopNotificationsEnabled?: boolean;
+  /** Debug aid: surface informational security/action toasts (default off). */
+  surfaceSecurityNotifications?: boolean;
+}
+
+/** Post-decision grant events — informational, gated behind the debug toggle. */
+export const INFORMATIONAL_GRANT_EVENTS: ReadonlySet<GrantEventKind> = new Set<GrantEventKind>([
+  "grant-approved",
+  "grant-denied",
+  "grant-revoked",
+  "grant-expired",
+]);
+
+/**
+ * Should a grant-lifecycle event pop a desktop toast?
+ * `grant-created` always does (the approval gate); the informational events
+ * only when `surfaceSecurityNotifications` is on. Both honor the master switch.
+ */
+export function shouldSurfaceGrantToast(kind: GrantEventKind, cfg: SecurityNotifyConfig): boolean {
+  if (cfg.desktopNotificationsEnabled === false) return false;
+  if (kind === "grant-created") return true;
+  return cfg.surfaceSecurityNotifications === true;
+}
+
+/**
+ * Should a completed tool call pop a per-action toast?
+ * Only a successful, non-read-only action, only when the debug toggle is on and
+ * the master switch isn't off. (Read-only tools and errored/no-op calls never
+ * toast — they'd be pure noise.)
+ */
+export function shouldSurfaceActionToast(opts: {
+  isReadOnly: boolean;
+  isError: boolean;
+  cfg: SecurityNotifyConfig;
+}): boolean {
+  if (opts.isError || opts.isReadOnly) return false;
+  return opts.cfg.surfaceSecurityNotifications === true && opts.cfg.desktopNotificationsEnabled !== false;
+}

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -895,6 +895,9 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
         if (typeof body.desktopNotificationsEnabled === "boolean") {
           current.desktopNotificationsEnabled = body.desktopNotificationsEnabled;
         }
+        if (typeof body.surfaceSecurityNotifications === "boolean") {
+          current.surfaceSecurityNotifications = body.surfaceSecurityNotifications;
+        }
         if (typeof body.autoOpenApprovalWindow === "boolean") {
           current.autoOpenApprovalWindow = body.autoOpenApprovalWindow;
         }

--- a/src/settings/shell.ts
+++ b/src/settings/shell.ts
@@ -1357,6 +1357,8 @@ ${buildStyles(cspNonce)}
     if (confirmEl) confirmEl.checked = c.requireDestructiveConfirm !== false;
     var desktopNotifEl = document.getElementById('desktop-notifications');
     if (desktopNotifEl) desktopNotifEl.checked = c.desktopNotificationsEnabled !== false;
+    var surfaceSecEl = document.getElementById('surface-security-notifications');
+    if (surfaceSecEl) surfaceSecEl.checked = c.surfaceSecurityNotifications === true;
     var autoOpenEl = document.getElementById('auto-open-approval');
     if (autoOpenEl) autoOpenEl.checked = c.autoOpenApprovalWindow !== false;
     set('sl-api-key',        cn.simpleloginApiKey  ? '••••••••' : '');
@@ -1460,6 +1462,7 @@ ${buildStyles(cspNonce)}
         },
         requireDestructiveConfirm: !!(document.getElementById('require-destructive-confirm') && document.getElementById('require-destructive-confirm').checked),
         desktopNotificationsEnabled: !!(document.getElementById('desktop-notifications') && document.getElementById('desktop-notifications').checked),
+        surfaceSecurityNotifications: !!(document.getElementById('surface-security-notifications') && document.getElementById('surface-security-notifications').checked),
         autoOpenApprovalWindow: !!(document.getElementById('auto-open-approval') && document.getElementById('auto-open-approval').checked),
         settingsPort: (function(){ var p = parseInt(get('settings-port'), 10); return isNaN(p) ? 8766 : p; })(),
       };

--- a/src/settings/tabs/setup.ts
+++ b/src/settings/tabs/setup.ts
@@ -174,6 +174,19 @@ export function buildSetupHtml(p: SetupParams): string {
         </div>
         <div class="field" style="margin-top:6px">
           <label class="toggle-wrap" style="width:fit-content">
+            <span class="toggle"><input type="checkbox" id="surface-security-notifications"><span class="slider"></span></span>
+            <span>Surface security messages (debug)</span>
+          </label>
+          <div class="hint" style="margin-top:4px">
+            Off by default. When on, mailpouch also pops a toast for security/action events it
+            performs — post-decision grant changes (approved / denied / <strong>revoked</strong> / expired)
+            and each non-read-only tool action (send, move, delete, …). Useful for debugging what an
+            agent is doing; otherwise these go only to the debug log. The "agent awaiting approval"
+            prompt always shows regardless of this setting.
+          </div>
+        </div>
+        <div class="field" style="margin-top:6px">
+          <label class="toggle-wrap" style="width:fit-content">
             <span class="toggle"><input type="checkbox" id="auto-open-approval" checked><span class="slider"></span></span>
             <span>Auto-open the approval window when an agent connects</span>
           </label>


### PR DESCRIPTION
## Summary

Two things, shipped as **3.0.76**:

1. **"Surface security messages" debug toggle** (`surfaceSecurityNotifications`, default off). The informational security toasts — post-decision grant lifecycle (approved / denied / **revoked** / expired) and a per-action notification for each non-read-only tool mailpouch runs (send / move / delete / …) — now go to the **debug log** by default instead of popping a toast. Enable the toggle to surface them while debugging. The actionable **"agent awaiting approval"** prompt is *not* gated — it always fires so the human approval gate keeps working. Read-only calls and errored/no-op actions never notify.
2. **Dependency:** `imapflow` 1.3.5 → 1.3.6 (patch, within range; 0 vulnerabilities).

## Design
- Pure, unit-tested gating in `src/notifications/security-gate.ts` (grant + per-action decisions).
- Per-action filter keys off each tool's `readOnlyHint` annotation, so reads never toast.
- Config + UI toggle (Settings → Setup), settings-server accept, CHANGELOG + HELP docs.

## Test plan
- [x] `npm run preship:release` PASS (Bridge E2E skipped via PRESHIP_NO_BRIDGE=1; Greenmail E2E green; changelog-has-entry / git-tag-free / npm-version-free ✓)
- [x] 2,191 unit tests pass (incl. 11 new gate tests covering token-revoked, per-action read-only filtering, and the master-switch override)
- [ ] After merge: tag `v3.0.76`, `npm publish`, update global install

## Security checklist
- [x] No secrets committed
- [x] No new attack surface — notifications are output-only; the change *reduces* what's surfaced by default
- [x] Approval gate ("awaiting approval") intentionally NOT gated by the new toggle
- [x] Dependency bump reviewed (patch, 0 vulns, LICENSES.json regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)