### PR TITLE
Release v3.0.77 — print-and-exit CLI + mailpouch status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.77] — 2026-06-06
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The CLI no longer boots a second server when you run an unrecognized command.** `mailpouch status`, `mailpouch --help`, and typos used to fall through and start a full MCP server in the foreground — it hung until killed (exit 143) and spawned a transient instance beside the real daemon. Invocation is now resolved up front (`src/cli/invocation.ts`): known subcommands and `--help`/`--version` print and exit; an unknown command errors with usage and exits 2; only a bare or flag-only invocation (the MCP stdio child a client spawns) starts the server.
+
+### Added
+
+- **`mailpouch status [--json]`** — fast, read-only operational view that never starts a server: whether an instance is already running (PID from the singleton lock + a probe of its `/api/status`), its connection state and approved-agent counts, Bridge reachability, and the config/log paths.
+- **`mailpouch --help` / `-h`** — usage listing every subcommand and flag, the PATH-proof `npx -y mailpouch <command>` form, and the resolved config/log paths.
+- `GET /api/status` now includes `version`, `connected`, `account`, `pendingCount`, `activeCount` (backward-compatible — the load-bearing `hasConfig` field is unchanged) so `status` can read a running instance's authoritative live state.
+
 ## [3.0.76] — 2026-06-05
 
 ### Changed

--- a/HELP.md
+++ b/HELP.md
@@ -40,6 +40,21 @@ Fill these in on the Setup tab, click **Save Configuration**, then **Test Connec
 
 Prefer the command line? `npx -y mailpouch setup --username you@proton.me --password-stdin` writes the same config, and `npx -y mailpouch doctor` verifies it.
 
+### CLI commands
+
+Run any of these as `npx -y mailpouch <command>` — the `npx -y` form works even when the global `mailpouch` bin isn't on your `PATH`, and these commands **print and exit** (they never start a server):
+
+| Command | What it does |
+|---|---|
+| `mailpouch --help` / `-h` | List all commands + flags; prints the config and log file paths |
+| `mailpouch status [--json]` | Is mailpouch running (PID, ports), connection state, approved-agent counts, Bridge reachability — read-only |
+| `mailpouch doctor [--json]` | Diagnose the install/connection and print the next step (exit 0 when ready) |
+| `mailpouch setup …` | Configure Bridge credentials non-interactively |
+| `mailpouch agent <issue\|list\|revoke>` | Manage headless service accounts |
+| `mailpouch daemon [--host H] [--port P]` | Run the shared HTTP daemon (forces HTTP transport) |
+
+Running `mailpouch` with **no command** starts the MCP server on stdio — that's what an MCP client (e.g. Claude Desktop) spawns; you don't run it by hand. An unrecognized command prints an error and exits rather than starting a server.
+
 **Wire up Claude Desktop** — this form works whether or not mailpouch is globally installed:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.76-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.77-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29+-green.svg)](https://github.com/modelcontextprotocol/sdk)
-[![Tests](https://img.shields.io/badge/tests-2%2C180%20passing-brightgreen.svg)](#development)
+[![Tests](https://img.shields.io/badge/tests-2%2C205%20passing-brightgreen.svg)](#development)
 
 **Read, compose, and manage your encrypted Proton Mail inbox from any AI assistant — over stdio or remote HTTP — with human-controlled permissions.**
 
@@ -86,7 +86,7 @@ That's it. The sections below cover everything in depth.
 - **Multi-account** — configure more than one Proton / IMAP account; hot-swap the active account from the Settings UI with no server restart. Tools accept an optional `account_id` argument to route a single call to a specific account. See [`src/accounts/`](src/accounts/).
 - **Per-agent grants** — each MCP client (identified by its OAuth `client_id`) is gated by its own approvable grant, with optional folder allowlists, IP pins, per-tool rate caps, expiry, and account binding. Separate from the global preset and the escalation flow. See [`src/agents/`](src/agents/).
 - **Live notifications** — desktop toasts (no extra deps) and outbound webhooks (CloudEvents / Slack / Discord, HMAC-signed, retried) fire on grant-state changes. See [`src/notifications/`](src/notifications/).
-- **2,180 tests passing** (Vitest); minimal `any` usage in production source (private Node.js readline internals only).
+- **2,205 tests passing** (Vitest); minimal `any` usage in production source (private Node.js readline internals only).
 
 **Documentation:** [HELP.md](HELP.md) (task-oriented how-tos) · [README_FIRST_AI.md](README_FIRST_AI.md) (agent API reference) · [docs/index.md](docs/index.md) (full index)
 
@@ -658,7 +658,7 @@ npm install
 
 npm run build          # compile TypeScript to dist/
 npm run dev            # watch mode (recompiles on save)
-npm run test           # run test suite (Vitest, 2,180 tests)
+npm run test           # run test suite (Vitest, 2,205 tests)
 npm run test:coverage  # coverage report
 npm run lint           # TypeScript type check (tsc --noEmit)
 npm run settings       # start standalone settings UI (after build)

--- a/README.md
+++ b/README.md
@@ -224,9 +224,11 @@ Then check the install end-to-end:
 ```bash
 npx -y mailpouch doctor          # human-readable diagnosis + next step; exit 0 when ready
 npx -y mailpouch doctor --json   # structured output for scripts
+npx -y mailpouch status          # is it running? ports, connection, approved agents (read-only)
+npx -y mailpouch --help          # all commands + flags + the config/log paths
 ```
 
-`doctor` reports the same state machine the always-available `setup_status` MCP tool returns: `unconfigured` → `bridge-unreachable` → `pending-approval` → `ready`, each with the exact action to advance.
+`doctor` reports the same state machine the always-available `setup_status` MCP tool returns: `unconfigured` → `bridge-unreachable` → `pending-approval` → `ready`, each with the exact action to advance. These commands **print and exit** — they never start a server, so they're safe to run alongside a live daemon. (Running `mailpouch` with no command starts the MCP stdio server, which is what your MCP client spawns.)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.76",
+  "version": "3.0.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.76",
+      "version": "3.0.77",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.76",
+  "version": "3.0.77",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli/invocation.test.ts
+++ b/src/cli/invocation.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { resolveInvocation } from "./invocation.js";
+
+// Helper: build a full process.argv (node + script + the rest).
+const argv = (...rest: string[]) => ["node", "/x/dist/index.js", ...rest];
+
+describe("resolveInvocation", () => {
+  it("bare invocation → server (the MCP stdio child)", () => {
+    expect(resolveInvocation(argv())).toEqual({ kind: "server" });
+  });
+
+  it("flag-only invocations → server (MCP child with options)", () => {
+    expect(resolveInvocation(argv("--no-tray")).kind).toBe("server");
+    expect(resolveInvocation(argv("--settings-only")).kind).toBe("server");
+    expect(resolveInvocation(argv("--no-settings-ui", "--no-tray")).kind).toBe("server");
+  });
+
+  it("--help / -h → help", () => {
+    expect(resolveInvocation(argv("--help"))).toEqual({ kind: "help" });
+    expect(resolveInvocation(argv("-h"))).toEqual({ kind: "help" });
+  });
+
+  it("--version / -v → version (wins over a subcommand)", () => {
+    expect(resolveInvocation(argv("--version"))).toEqual({ kind: "version" });
+    expect(resolveInvocation(argv("-v"))).toEqual({ kind: "version" });
+  });
+
+  it("known subcommands resolve", () => {
+    for (const name of ["setup", "doctor", "status", "agent", "daemon"] as const) {
+      expect(resolveInvocation(argv(name))).toEqual({ kind: "subcommand", name });
+    }
+  });
+
+  it("subcommand with its own args still resolves to the subcommand", () => {
+    expect(resolveInvocation(argv("agent", "issue", "--name", "cron"))).toEqual({ kind: "subcommand", name: "agent" });
+    expect(resolveInvocation(argv("doctor", "--json"))).toEqual({ kind: "subcommand", name: "doctor" });
+    expect(resolveInvocation(argv("status", "--json"))).toEqual({ kind: "subcommand", name: "status" });
+  });
+
+  it("daemon value-flags don't get mistaken for a positional", () => {
+    expect(resolveInvocation(argv("daemon", "--port", "9000"))).toEqual({ kind: "subcommand", name: "daemon" });
+    expect(resolveInvocation(argv("daemon", "--host", "127.0.0.1", "--port", "8788"))).toEqual({ kind: "subcommand", name: "daemon" });
+    // `--port 9000` without a subcommand must NOT treat "9000" as a command.
+    expect(resolveInvocation(argv("--port", "9000")).kind).toBe("server");
+  });
+
+  it("REGRESSION: an unknown positional is 'unknown' — NEVER 'server' (no rogue instance)", () => {
+    expect(resolveInvocation(argv("bogus"))).toEqual({ kind: "unknown", arg: "bogus" });
+    expect(resolveInvocation(argv("staus"))).toEqual({ kind: "unknown", arg: "staus" }); // typo of status
+    expect(resolveInvocation(argv("start"))).toEqual({ kind: "unknown", arg: "start" });
+    // The whole point: these must not boot a server.
+    for (const bad of ["bogus", "staus", "start"]) {
+      expect(resolveInvocation(argv(bad)).kind).not.toBe("server");
+    }
+  });
+});

--- a/src/cli/invocation.ts
+++ b/src/cli/invocation.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure CLI dispatch resolution for `mailpouch`.
+ *
+ * The bare `mailpouch` (no positional subcommand) is the MCP stdio server that
+ * Claude Desktop spawns — it must keep booting the full server. But a human
+ * inspecting the install types `mailpouch status` / `mailpouch --help` and used
+ * to get a *second* full server booted in the foreground (it hung until SIGTERM
+ * and spawned a transient instance beside the real daemon), because anything
+ * unrecognized fell through to the server start.
+ *
+ * This resolver makes the surface explicit: known subcommands and --help/--version
+ * are handled and exit; an UNKNOWN positional command is an error (never the
+ * server); only a bare or flag-only invocation reaches the server. Kept pure and
+ * dependency-free so it's unit-tested directly; main() switches on the result.
+ */
+
+export const KNOWN_SUBCOMMANDS = ["setup", "doctor", "status", "agent", "daemon"] as const;
+export type KnownSubcommand = (typeof KNOWN_SUBCOMMANDS)[number];
+
+/** Flags that consume the following token as their value (so it isn't mistaken
+ *  for a positional subcommand). Only the daemon's --host/--port do this. */
+const VALUE_FLAGS: ReadonlySet<string> = new Set(["--host", "--port"]);
+
+export type Invocation =
+  | { kind: "help" }
+  | { kind: "version" }
+  | { kind: "subcommand"; name: KnownSubcommand }
+  | { kind: "server" }
+  | { kind: "unknown"; arg: string };
+
+/**
+ * Resolve a full `process.argv` (argv[0]=node, argv[1]=script, argv[2..]=args)
+ * into the intended action. --help/--version win over everything (mirrors the
+ * pre-existing --version short-circuit).
+ */
+export function resolveInvocation(argv: string[]): Invocation {
+  const args = argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) return { kind: "help" };
+  if (args.includes("--version") || args.includes("-v")) return { kind: "version" };
+
+  // Find the first POSITIONAL token, skipping flags and any value a flag consumes.
+  let positional: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("-")) {
+      if (VALUE_FLAGS.has(a)) i++; // skip the flag's value (e.g. `--port 9000`)
+      continue;
+    }
+    positional = a;
+    break;
+  }
+
+  if (positional === undefined) return { kind: "server" }; // bare or flag-only → MCP stdio server
+  if ((KNOWN_SUBCOMMANDS as readonly string[]).includes(positional)) {
+    return { kind: "subcommand", name: positional as KnownSubcommand };
+  }
+  return { kind: "unknown", arg: positional };
+}
+
+export const USAGE = `mailpouch — MCP server for Proton Mail / IMAP via Proton Bridge.
+
+For one-off commands, the PATH-proof form (no global install needed) is:
+  npx -y mailpouch <command>
+
+Commands:
+  (no command)        Run the MCP server on stdio. This is what an MCP client
+                      (e.g. Claude Desktop) spawns; not meant to run by hand.
+  setup               Configure Bridge credentials non-interactively
+                        --username <addr> (--password-stdin | --password-file <p> | --password <pw>)
+                        [--imap-host/--imap-port/--smtp-host/--smtp-port] [--bridge-cert <p> | --insecure]
+  doctor [--json]     Diagnose the install/connection; prints the next step, exits
+  status [--json]     Show whether mailpouch is running, its ports, connection, and
+                      approved agents — read-only, exits (does not start a server)
+  agent <issue|list|revoke …>   Manage headless service accounts
+  daemon [--host H] [--port P]  Run the shared HTTP daemon (forces HTTP transport)
+
+Flags:
+  -h, --help          Show this help and exit
+  -v, --version       Print the version and exit
+  --settings-only     Run only the settings UI + tray (no MCP transport)
+  --no-tray           Don't start the system tray icon
+  --no-settings-ui    Don't start the settings UI server`;

--- a/src/cli/status-cli.test.ts
+++ b/src/cli/status-cli.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { runStatusCli } from "./status-cli.js";
+import { invalidateConfigCache } from "../config/loader.js";
+import type { SetupStatusResult } from "../diagnostics/setup-status.js";
+import { homedir } from "os";
+import { join } from "path";
+import { randomBytes } from "crypto";
+
+// Isolate from the real ~/.mailpouch.json (loadConfig is called directly).
+const prev = process.env.MAILPOUCH_CONFIG;
+function isolateConfig(): void {
+  process.env.MAILPOUCH_CONFIG = join(homedir(), `.mailpouch-status-test-${randomBytes(6).toString("hex")}.json`);
+  invalidateConfigCache();
+}
+afterEach(() => {
+  if (prev === undefined) delete process.env.MAILPOUCH_CONFIG;
+  else process.env.MAILPOUCH_CONFIG = prev;
+  invalidateConfigCache();
+});
+
+function diag(overrides: Partial<SetupStatusResult> = {}): SetupStatusResult {
+  return {
+    state: "ready", configured: true, bridgeReachable: true,
+    configExists: true, configPath: "/home/u/.mailpouch.json",
+    username: "me@proton.me", credentialStorage: "keychain",
+    imap: { host: "127.0.0.1", port: 1143, reachable: true },
+    smtp: { host: "127.0.0.1", port: 1025, reachable: true },
+    insecureTls: false, grantStatus: null, nextStep: "ok", summary: "ok",
+    ...overrides,
+  };
+}
+
+function harness(opts: {
+  pid?: number | null;
+  payload?: Record<string, unknown> | null;
+  diag?: SetupStatusResult;
+  counts?: { pending: number; active: number };
+}) {
+  const out: string[] = [];
+  const err: string[] = [];
+  const deps = {
+    out: (l: string) => out.push(l),
+    err: (l: string) => err.push(l),
+    readPid: () => opts.pid ?? null,
+    probe: async () => opts.payload ?? null,
+    gather: async () => opts.diag ?? diag(),
+    grantCounts: () => opts.counts ?? { pending: 0, active: 0 },
+  };
+  return { out, err, deps };
+}
+
+describe("mailpouch status CLI", () => {
+  it("reports a RUNNING, connected instance from the live /api/status payload (exit 0)", async () => {
+    isolateConfig();
+    const h = harness({
+      pid: 4242,
+      payload: { hasConfig: true, version: "3.0.76", connected: true, account: "me@proton.me", pendingCount: 1, activeCount: 3 },
+    });
+    const code = await runStatusCli([], h.deps);
+    expect(code).toBe(0);
+    const text = h.out.join("\n");
+    expect(text).toMatch(/RUNNING \(pid 4242\)/);
+    expect(text).toMatch(/connected/);
+    expect(text).toMatch(/3 active, 1 pending/);
+  });
+
+  it("reports NOT RUNNING and falls back to persisted grant counts", async () => {
+    isolateConfig();
+    const h = harness({ pid: null, payload: null, diag: diag({ state: "ready" }), counts: { pending: 2, active: 0 } });
+    const code = await runStatusCli([], h.deps);
+    expect(code).toBe(0); // diagnosis ready → 0 even when no instance is up
+    const text = h.out.join("\n");
+    expect(text).toMatch(/NOT RUNNING/);
+    expect(text).toMatch(/0 active, 2 pending/);
+  });
+
+  it("exits 1 when not running and the install isn't ready", async () => {
+    isolateConfig();
+    const h = harness({ pid: null, payload: null, diag: diag({ state: "unconfigured", connected: undefined }) });
+    const code = await runStatusCli([], h.deps);
+    expect(code).toBe(1);
+    expect(h.out.join("\n")).toMatch(/mailpouch doctor/);
+  });
+
+  it("--json emits a parseable structured result", async () => {
+    isolateConfig();
+    const h = harness({ pid: 99, payload: { hasConfig: true, connected: true, pendingCount: 0, activeCount: 1 } });
+    const code = await runStatusCli(["--json"], h.deps);
+    expect(code).toBe(0);
+    const parsed = JSON.parse(h.out.join("\n"));
+    expect(parsed.running).toBe(true);
+    expect(parsed.instance.pid).toBe(99);
+    expect(parsed.agents).toEqual({ pending: 0, active: 1 });
+    expect(parsed.diagnosis.state).toBe("ready");
+  });
+
+  it("rejects unknown arguments with exit code 2", async () => {
+    isolateConfig();
+    const h = harness({});
+    const code = await runStatusCli(["--bogus"], h.deps);
+    expect(code).toBe(2);
+    expect(h.err.join("\n")).toMatch(/unknown argument/);
+  });
+
+  it("a live lock PID alone (UI not answering) still reports RUNNING", async () => {
+    isolateConfig();
+    const h = harness({ pid: 555, payload: null, diag: diag() });
+    const code = await runStatusCli([], h.deps);
+    expect(h.out.join("\n")).toMatch(/RUNNING \(pid 555\)/);
+    expect(h.out.join("\n")).toMatch(/settings UI not answering/);
+    expect(code).toBe(0); // diagnosis ready
+  });
+});

--- a/src/cli/status-cli.test.ts
+++ b/src/cli/status-cli.test.ts
@@ -76,7 +76,7 @@ describe("mailpouch status CLI", () => {
 
   it("exits 1 when not running and the install isn't ready", async () => {
     isolateConfig();
-    const h = harness({ pid: null, payload: null, diag: diag({ state: "unconfigured", connected: undefined }) });
+    const h = harness({ pid: null, payload: null, diag: diag({ state: "unconfigured" }) });
     const code = await runStatusCli([], h.deps);
     expect(code).toBe(1);
     expect(h.out.join("\n")).toMatch(/mailpouch doctor/);

--- a/src/cli/status-cli.ts
+++ b/src/cli/status-cli.ts
@@ -1,0 +1,199 @@
+/**
+ * `mailpouch status` — fast, read-only operational view. Exits immediately;
+ * NEVER starts a server (the bug this command exists to avoid: typing a
+ * status check used to boot a second full MCP server in the foreground).
+ *
+ * Reports what you'd otherwise assemble by hand from ps/ss/log/json:
+ *   - is a mailpouch instance already running (PID from the singleton lock),
+ *     and on which settings port — confirmed by probing its GET /api/status,
+ *   - the live connection + approved-agent counts from that running instance,
+ *   - plus the offline diagnosis (config path, Bridge reachability, next step)
+ *     and the config/log file locations.
+ *
+ * Reuses gatherSetupStatus (src/diagnostics/setup-status.ts), the singleton-lock
+ * path (src/utils/singleton-lock.ts), and the home-path helper. `--json` for scripts.
+ */
+
+import http from "http";
+import { readFileSync } from "fs";
+import { loadConfig, getConfigPath } from "../config/loader.js";
+import { getLogFilePath } from "../utils/logger.js";
+import { lockPathForAccount } from "../utils/singleton-lock.js";
+import { homeFile } from "../utils/home-path.js";
+import { gatherSetupStatus, type SetupStatusResult } from "../diagnostics/setup-status.js";
+
+export interface RunningInstance {
+  pid: number | null;
+  reachable: boolean;
+  version?: string;
+  connected?: boolean;
+  account?: string;
+  pendingCount?: number;
+  activeCount?: number;
+}
+
+export interface StatusResult {
+  running: boolean;
+  instance: RunningInstance;
+  settingsPort: number;
+  configPath: string;
+  logPath: string;
+  agents: { pending: number; active: number };
+  diagnosis: SetupStatusResult;
+}
+
+export interface StatusCliDeps {
+  out?: (line: string) => void;
+  err?: (line: string) => void;
+  /** Probe a running instance's GET /api/status. Injectable for tests. */
+  probe?: (port: number) => Promise<Record<string, unknown> | null>;
+  /** Resolve the live PID from the singleton lock. Injectable for tests. */
+  readPid?: (accountIdentity: string | undefined) => number | null;
+  /** Offline diagnosis. Injectable for tests. */
+  gather?: typeof gatherSetupStatus;
+  /** Persisted agent-grant counts (used when no instance is running). */
+  grantCounts?: () => { pending: number; active: number };
+}
+
+const USAGE = `Usage:
+  mailpouch status [--json]`;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    return (e as NodeJS.ErrnoException).code === "EPERM"; // exists, other user
+  }
+}
+
+/** Read the live holder PID from this account's singleton lock, or null. */
+function readLockPid(accountIdentity: string | undefined): number | null {
+  try {
+    const pid = parseInt(readFileSync(lockPathForAccount(accountIdentity), "utf-8").trim(), 10);
+    return Number.isInteger(pid) && pid > 0 && isPidAlive(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** GET /api/status on a running instance; null if nothing valid answers. */
+function probeApiStatus(port: number): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, path: "/api/status", method: "GET", timeout: 750 },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (c: string) => { body += c; if (body.length > 4096) { res.destroy(); resolve(null); } });
+        res.on("end", () => {
+          try {
+            const j = JSON.parse(body) as Record<string, unknown>;
+            resolve(typeof j.hasConfig === "boolean" ? j : null);
+          } catch { resolve(null); }
+        });
+        res.on("error", () => resolve(null));
+      },
+    );
+    req.on("error", () => resolve(null));
+    req.on("timeout", () => { req.destroy(); resolve(null); });
+    req.end();
+  });
+}
+
+/** Count persisted grants by status without instantiating the live store. */
+function readGrantCounts(): { pending: number; active: number } {
+  try {
+    const path = homeFile("MAILPOUCH_AGENTS", ".mailpouch-agents.json");
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as { grants?: Array<{ status?: string }> };
+    const grants = Array.isArray(parsed.grants) ? parsed.grants : [];
+    return {
+      pending: grants.filter((g) => g.status === "pending").length,
+      active: grants.filter((g) => g.status === "active").length,
+    };
+  } catch {
+    return { pending: 0, active: 0 };
+  }
+}
+
+export async function runStatusCli(argv: string[], deps: StatusCliDeps = {}): Promise<number> {
+  const out = deps.out ?? ((l: string) => process.stdout.write(l + "\n"));
+  const err = deps.err ?? ((l: string) => process.stderr.write(l + "\n"));
+  const probe = deps.probe ?? probeApiStatus;
+  const readPid = deps.readPid ?? readLockPid;
+  const gather = deps.gather ?? gatherSetupStatus;
+  const grantCounts = deps.grantCounts ?? readGrantCounts;
+
+  const json = argv.includes("--json");
+  const unknown = argv.find((a) => a !== "--json");
+  if (unknown) { err(`error: unknown argument '${unknown}'.`); err(USAGE); return 2; }
+
+  const cfg = loadConfig();
+  const accountIdentity = cfg?.connection.username || "";
+  const settingsPort = cfg?.settingsPort ?? 8766;
+
+  const pid = readPid(accountIdentity);
+  const payload = await probe(settingsPort);
+  const diagnosis = await gather();
+
+  const reachable = payload !== null;
+  const running = pid !== null || reachable;
+  const instance: RunningInstance = {
+    pid,
+    reachable,
+    ...(payload
+      ? {
+          version: typeof payload.version === "string" ? payload.version : undefined,
+          connected: typeof payload.connected === "boolean" ? payload.connected : undefined,
+          account: typeof payload.account === "string" ? payload.account : undefined,
+          pendingCount: typeof payload.pendingCount === "number" ? payload.pendingCount : undefined,
+          activeCount: typeof payload.activeCount === "number" ? payload.activeCount : undefined,
+        }
+      : {}),
+  };
+
+  // Live counts from the running instance when available; else the persisted store.
+  const agents = payload && typeof payload.pendingCount === "number" && typeof payload.activeCount === "number"
+    ? { pending: payload.pendingCount as number, active: payload.activeCount as number }
+    : grantCounts();
+
+  const result: StatusResult = {
+    running,
+    instance,
+    settingsPort,
+    configPath: getConfigPath(),
+    logPath: getLogFilePath(),
+    agents,
+    diagnosis,
+  };
+
+  if (json) {
+    out(JSON.stringify(result, null, 2));
+  } else {
+    const runLine = running
+      ? `RUNNING${pid ? ` (pid ${pid})` : ""}${reachable ? ` · settings http://localhost:${settingsPort}` : " · settings UI not answering"}`
+      : "NOT RUNNING (no live instance for this account)";
+    out(`mailpouch status: ${runLine}`);
+    out("");
+    if (reachable) {
+      // An instance that predates /api/status enrichment omits these fields —
+      // report "unknown" rather than a misleading "NOT connected".
+      const older = " (older instance — restart to populate)";
+      out(`  version       : ${instance.version ?? `unknown${older}`}`);
+      out(`  connection    : ${instance.connected === undefined ? `unknown${older}` : instance.connected ? "connected" : "NOT connected"}`);
+      out(`  account       : ${instance.account || diagnosis.username || "(not set)"}`);
+    }
+    out(`  agents        : ${agents.active} active, ${agents.pending} pending`);
+    out(`  Bridge IMAP   : ${diagnosis.imap.host}:${diagnosis.imap.port} ${diagnosis.imap.reachable ? "reachable" : "UNREACHABLE"}`);
+    out(`  Bridge SMTP   : ${diagnosis.smtp.host}:${diagnosis.smtp.port} ${diagnosis.smtp.reachable ? "reachable" : "UNREACHABLE"}`);
+    out(`  config file   : ${result.configPath}`);
+    out(`  log file      : ${result.logPath}`);
+    if (diagnosis.state !== "ready") {
+      out("");
+      out(`Setup not complete (${diagnosis.state}). Run \`mailpouch doctor\` for the next step.`);
+    }
+  }
+
+  // Exit 0 when a running instance reports connected, or the offline diagnosis is ready.
+  return (reachable && instance.connected) || diagnosis.state === "ready" ? 0 : 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ import { acquireSingletonLock, releaseSingletonLock } from "./utils/singleton-lo
 import { isValidEmail, validateTargetFolder, requireNumericEmailId } from "./utils/helpers.js";
 import { classifyError, ConnectionStateError } from "./utils/error-classify.js";
 import { permissions } from "./permissions/manager.js";
-import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain, loadAuxiliaryCredentialsFromKeychain } from "./config/loader.js";
+import { loadConfig, defaultConfig, migrateCredentials, loadCredentialsFromKeychain, loadAuxiliaryCredentialsFromKeychain, getConfigPath } from "./config/loader.js";
 import type { ToolName } from "./config/schema.js";
 import {
   DESTRUCTIVE_TOOLS,
@@ -134,6 +134,7 @@ import { allToolDefs, allHandlers, escalationHandlers, describeRequestEscalation
 import type { ToolCallContext, ToolSharedState } from "./tools/types.js";
 import { gatherSetupStatus } from "./diagnostics/setup-status.js";
 import { shouldSurfaceGrantToast, shouldSurfaceActionToast } from "./notifications/security-gate.js";
+import { resolveInvocation, USAGE } from "./cli/invocation.js";
 
 // ─── Service Initialization ───────────────────────────────────────────────────
 // All credentials and connection settings are loaded from ~/.mailpouch.json
@@ -2023,6 +2024,14 @@ async function _startSettingsServerDaemon(): Promise<void> {
         const { scheme, stop } = await startSettingsServer(port, false, true /* quiet */, {
           onRestartRequested: () => setImmediate(() => gracefulShutdown("update_restart")),
           onShutdownRequested: () => setImmediate(() => gracefulShutdown("ui-shutdown").catch(() => process.exit(1))),
+          // Live snapshot for GET /api/status so `mailpouch status` reads the
+          // running instance's authoritative connection + agent state.
+          onStatus: () => ({
+            connected: sharedState.smtpStatus.connected,
+            account: config.smtp.username || "",
+            pendingCount: agentGrants.list({ status: "pending" }).length,
+            activeCount: agentGrants.list({ status: "active" }).length,
+          }),
         });
         _settingsStop    = stop;
         _settingsUrl     = `${scheme}://localhost:${port}`;
@@ -2204,35 +2213,57 @@ async function _initTray(): Promise<void> {
 }
 
 async function main() {
-  // `--version` short-circuits before any side effects. Used by tarball-smoke
-  // and routinely by users to identify the installed binary.
-  if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  // Resolve the invocation up front. Known subcommands and --help/--version are
+  // handled and EXIT; an unknown positional command is an error and exits — it
+  // never falls through to boot a server. Only a bare or flag-only invocation
+  // (the MCP stdio child an MCP client spawns) reaches the server path below.
+  // This is the fix for `mailpouch status` / `--help` silently booting a second
+  // full server in the foreground beside the real daemon.
+  const invocation = resolveInvocation(process.argv);
+
+  if (invocation.kind === "help") {
+    process.stdout.write(`${USAGE}\n\nPaths:\n  config: ${getConfigPath()}\n  log:    ${getLogFilePath()}\n`);
+    process.exit(0);
+  }
+  if (invocation.kind === "version") {
+    // --version is used by tarball-smoke and routinely to identify the binary.
     process.stdout.write(`mailpouch v${_pkgVersion}\n`);
     process.exit(0);
   }
-
-  // `mailpouch agent <issue|list|revoke>` — provision/manage service accounts,
-  // then exit. Runs before any server side effects (no Bridge connect, no
-  // transport) so it's a quick offline admin command. Uses the module-scope
-  // grant + service-account stores already constructed above.
-  if (process.argv[2] === "agent") {
-    const { runAgentCli } = await import("./cli/agent-cli.js");
-    const code = await runAgentCli(process.argv.slice(3), { serviceAccounts, agentGrants });
-    process.exit(code);
+  if (invocation.kind === "unknown") {
+    process.stderr.write(`mailpouch: unknown command '${invocation.arg}'\n\n${USAGE}\n`);
+    process.exit(2);
   }
 
-  // `mailpouch setup …` writes Bridge credentials to ~/.mailpouch.json + keychain
-  // non-interactively (the agent/CI path; the wizard remains the default for
-  // humans). `mailpouch doctor` prints the install/connect diagnosis and exits.
-  // Both run offline — no Bridge connect, no transport — before any server side
-  // effects, mirroring the `agent` subcommand above.
-  if (process.argv[2] === "setup") {
-    const { runSetupCli } = await import("./cli/setup-cli.js");
-    process.exit(await runSetupCli(process.argv.slice(3)));
-  }
-  if (process.argv[2] === "doctor") {
-    const { runDoctorCli } = await import("./cli/doctor-cli.js");
-    process.exit(await runDoctorCli(process.argv.slice(3)));
+  // Offline admin subcommands run before any server side effects (no Bridge
+  // connect, no transport) and exit. `daemon` is the exception — it continues
+  // into the server path below in HTTP mode. Args are taken after the
+  // subcommand token so `mailpouch <cmd> [flags]` parses correctly.
+  if (invocation.kind === "subcommand" && invocation.name !== "daemon") {
+    const subIdx = process.argv.indexOf(invocation.name, 2);
+    const subArgs = subIdx >= 0 ? process.argv.slice(subIdx + 1) : [];
+    switch (invocation.name) {
+      case "agent": {
+        const { runAgentCli } = await import("./cli/agent-cli.js");
+        process.exit(await runAgentCli(subArgs, { serviceAccounts, agentGrants }));
+        break;
+      }
+      case "setup": {
+        const { runSetupCli } = await import("./cli/setup-cli.js");
+        process.exit(await runSetupCli(subArgs));
+        break;
+      }
+      case "doctor": {
+        const { runDoctorCli } = await import("./cli/doctor-cli.js");
+        process.exit(await runDoctorCli(subArgs));
+        break;
+      }
+      case "status": {
+        const { runStatusCli } = await import("./cli/status-cli.js");
+        process.exit(await runStatusCli(subArgs));
+        break;
+      }
+    }
   }
 
   // `mailpouch daemon [--host H] [--port P]` runs the shared HTTP daemon
@@ -2244,7 +2275,7 @@ async function main() {
     const i = process.argv.indexOf(flag);
     return i >= 0 ? process.argv[i + 1] : undefined;
   };
-  const daemonMode = process.argv[2] === "daemon";
+  const daemonMode = invocation.kind === "subcommand" && invocation.name === "daemon";
   const daemonHostOverride = daemonMode ? argVal("--host") : undefined;
   const daemonPortOverride = daemonMode ? argVal("--port") : undefined;
 

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -236,6 +236,13 @@ export interface ServerSecurityOptions {
    * `process.exit(0)`, which bypasses tray cleanup.
    */
   onShutdownRequested?: () => void;
+  /**
+   * Live status snapshot for GET /api/status. Lets `mailpouch status` (and any
+   * tooling) read the running instance's authoritative connection + agent state
+   * — something an offline probe can't determine. When omitted, /api/status
+   * returns just `{ hasConfig }` (the back-compat singleton-probe shape).
+   */
+  onStatus?: () => { connected: boolean; account: string; pendingCount: number; activeCount: number };
 }
 
 // ── /agent-setup — integration reference for AI clients ─────────────────
@@ -776,8 +783,17 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
       }
 
       // ── GET /api/status ───────────────────────────────────────────────────
+      // `hasConfig` is the load-bearing field the singleton probe checks
+      // (src/index.ts) — keep it. The rest is the live snapshot `mailpouch
+      // status` surfaces; present only when the running instance supplied a
+      // status provider.
       if (method === "GET" && path === "/api/status") {
-        json(res, 200, { hasConfig: configExists() });
+        const live = secOpts.onStatus?.();
+        json(res, 200, {
+          hasConfig: configExists(),
+          version: _agentSetupPkgVersion,
+          ...(live ?? {}),
+        });
         return;
       }
 
@@ -2214,7 +2230,11 @@ export async function startSettingsServer(
   port  = 8766,
   lan   = false,
   quiet = false,
-  opts: { onRestartRequested?: () => void; onShutdownRequested?: () => void } = {},
+  opts: {
+    onRestartRequested?: () => void;
+    onShutdownRequested?: () => void;
+    onStatus?: () => { connected: boolean; account: string; pendingCount: number; activeCount: number };
+  } = {},
 ): Promise<{ scheme: "http" | "https"; stop: () => Promise<void> }> {
   const bindHost    = lan ? "0.0.0.0" : "127.0.0.1";
   const lanIP       = lan ? getPrimaryLanIP() : "";

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -240,7 +240,9 @@ export interface ServerSecurityOptions {
    * Live status snapshot for GET /api/status. Lets `mailpouch status` (and any
    * tooling) read the running instance's authoritative connection + agent state
    * — something an offline probe can't determine. When omitted, /api/status
-   * returns just `{ hasConfig }` (the back-compat singleton-probe shape).
+   * returns `{ hasConfig, version }`; the live connection/account/agent fields
+   * are added only when this provider is supplied. (`hasConfig` is the only
+   * field the singleton probe relies on, so the shape stays back-compatible.)
    */
   onStatus?: () => { connected: boolean; account: string; pendingCount: number; activeCount: number };
 }


### PR DESCRIPTION
## Summary

Fixes the install/inspection footgun where human-facing CLI commands booted a full server.

- **`mailpouch status`, `--help`, and typos no longer start a server.** They used to fall through and boot a full MCP server in the foreground (hung until SIGTERM, exit 143) and spawn a transient instance beside the real daemon. Invocation is resolved up front (pure `src/cli/invocation.ts`): known subcommands + `--help`/`--version` print and exit; an unknown command errors with usage and exits 2; only bare/flag-only (the MCP stdio child) starts the server.
- **New `mailpouch status [--json]`** — read-only operational view: is an instance running (PID from the singleton lock + `/api/status` probe), connection state, approved-agent counts, Bridge reachability, config/log paths. Never starts a server.
- **`--help`/`-h`** — usage listing all commands/flags, the PATH-proof `npx -y mailpouch <command>` form, and the resolved config/log paths (addresses the "where do files live / not on PATH" frictions).
- **`GET /api/status` enriched** with `version`/`connected`/`account`/`pendingCount`/`activeCount` (backward-compatible — `hasConfig` unchanged) so `status` reads a running instance's authoritative live state.

## Test plan
- [x] `npm run preship:release` PASS (Bridge E2E skipped via PRESHIP_NO_BRIDGE=1; Greenmail E2E green; changelog-has-entry / git-tag-free / npm-version-free ✓)
- [x] 2,205 unit tests (14 new: `invocation.test.ts` incl. the "unknown positional is never `server`" regression guard; `status-cli.test.ts`)
- [x] Manual smoke: `--help`/`status`/`bogus` print-and-exit (0/0/2), **no rogue server spawned**; verified `status` against the live daemon (pid 3839551)

## Security checklist
- [x] No secrets committed
- [x] `status` and the guard are read-only; `/api/status` enrichment exposes no secrets (booleans/counts/account already shown in the tray) and is localhost-only
- [x] No new attack surface — the change *removes* an unintended server-spawn path
- [x] Bare `mailpouch` (MCP stdio) and `daemon`/`--settings-only` paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)