### PR TITLE
feat: expose account_id on every tool inputSchema

### DIFF
--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Registry-level invariants. The wrapper applied in `allToolDefs()` widens
+ * every served tool's inputSchema with an optional `account_id` field so
+ * strict-schema MCP clients can reach the per-call multi-account routing
+ * added in B1 (PR #60, shipped via PR #63).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { allToolDefs } from "./registry.js";
+
+interface SchemaShape {
+  type?: string;
+  properties?: Record<string, { type?: string; description?: string }>;
+  required?: string[];
+}
+
+describe("allToolDefs — account_id surface", () => {
+  const defs = allToolDefs();
+
+  it("returns a non-empty registry", () => {
+    expect(defs.length).toBeGreaterThan(0);
+  });
+
+  it("every tool advertises an optional account_id of type string", () => {
+    const offenders: string[] = [];
+    for (const def of defs) {
+      const schema = (def.inputSchema ?? {}) as SchemaShape;
+      const field = schema.properties?.account_id;
+      if (!field || field.type !== "string") {
+        offenders.push(def.name);
+      }
+    }
+    expect(offenders, `tools missing account_id: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("does not add account_id to the required list (it must stay optional)", () => {
+    const offenders: string[] = [];
+    for (const def of defs) {
+      const schema = (def.inputSchema ?? {}) as SchemaShape;
+      if (schema.required?.includes("account_id")) {
+        offenders.push(def.name);
+      }
+    }
+    expect(offenders, `tools wrongly require account_id: ${offenders.join(", ")}`).toEqual([]);
+  });
+
+  it("preserves pre-existing per-tool inputSchema properties (e.g. folder, limit)", () => {
+    // get_emails carries several fields — confirm the wrapper widened rather than replaced.
+    const getEmails = defs.find((d) => d.name === "get_emails");
+    expect(getEmails, "get_emails missing from registry").toBeDefined();
+    const schema = (getEmails!.inputSchema ?? {}) as SchemaShape;
+    expect(schema.properties?.folder).toBeDefined();
+    expect(schema.properties?.limit).toBeDefined();
+    expect(schema.properties?.account_id).toBeDefined();
+  });
+
+  it("widens previously-empty schemas (get_folders has no other properties)", () => {
+    const getFolders = defs.find((d) => d.name === "get_folders");
+    expect(getFolders, "get_folders missing from registry").toBeDefined();
+    const schema = (getFolders!.inputSchema ?? {}) as SchemaShape;
+    expect(Object.keys(schema.properties ?? {})).toEqual(["account_id"]);
+  });
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -30,6 +30,56 @@ import * as escalation from "./escalation.js";
 import type { ToolDef, ToolHandler } from "./types.js";
 import type { EscalationHandler } from "./escalation.js";
 
+/**
+ * Optional `account_id` parameter advertised on every tool's inputSchema.
+ *
+ * The dispatcher in `src/index.ts` already reads `args.account_id` and
+ * routes the call to the matching account's IMAP/SMTP services (added in
+ * B1 / PR #60, shipped via PR #63). Strict-schema MCP clients — Claude
+ * Code's typed function-call interface is the immediate example — strip
+ * arguments not declared in `inputSchema.properties` before forwarding
+ * the JSON-RPC call, so without this declaration the runtime routing is
+ * unreachable from those clients and every call silently runs against
+ * `activeAccountId`.
+ *
+ * Advertising the parameter shape does NOT leak the configured account
+ * list, which remains operator-controlled via the settings UI by
+ * deliberate choice (see `src/settings/server.js` discovery copy).
+ */
+const ACCOUNT_ID_SCHEMA_FIELD = {
+  type: "string",
+  description:
+    "Optional account ID to route this call to (multi-account configs). " +
+    "Omit to use the active account. Configured account IDs are listed in " +
+    "the settings UI (Accounts tab).",
+} as const;
+
+/**
+ * Inject the optional `account_id` field into a tool's inputSchema.
+ *
+ * Spread order preserves any existing `account_id` declaration on the
+ * tool (none today) and any sibling fields — only the property map is
+ * widened. Tools that omit `inputSchema` altogether get the minimal
+ * `{ type: "object", properties: { account_id } }` shape.
+ */
+function withAccountIdField(def: ToolDef): ToolDef {
+  const schema = (def.inputSchema ?? { type: "object", properties: {} }) as {
+    type?: string;
+    properties?: Record<string, unknown>;
+    [k: string]: unknown;
+  };
+  return {
+    ...def,
+    inputSchema: {
+      ...schema,
+      properties: {
+        account_id: ACCOUNT_ID_SCHEMA_FIELD,
+        ...(schema.properties ?? {}),
+      },
+    },
+  };
+}
+
 /** Ordered ListTools definitions. */
 export function allToolDefs(): ToolDef[] {
   return [
@@ -47,7 +97,7 @@ export function allToolDefs(): ToolDef[] {
     ...reading.defsLate,
     ...diagnostics.defs,
     ...escalation.defs,
-  ];
+  ].map(withAccountIdField);
 }
 
 /** Tool-name-keyed dispatch table for the (post-gate) CallTool handlers. */


### PR DESCRIPTION

Closes the deferred follow-up from #60:

> Adding `account_id` to every tool's JSON schema (MCP schemas are permissive; routing already works).

Strict-schema MCP clients (Claude Code's typed function-call interface is the immediate one I hit) drop arguments outside `inputSchema.properties` before forwarding the JSON-RPC request. With `account_id` undeclared, the per-tool routing wired up in B1 was unreachable from those clients — every call silently ran against `activeAccountId` regardless of what the agent passed. Filed as #210.

Centralises the injection in `src/tools/registry.ts/allToolDefs()` so every served tool — and any tool added later — automatically advertises an optional `account_id: { type: "string" }`. The dispatcher's existing `args.account_id` read is untouched.

I considered the per-tool inline declaration instead (76 file changes), but went with the registry-level wrapper because the dispatcher already reads `account_id` from one central place and the schema declaration ought to match that locus. Easy to switch if you'd rather see it inline on each def.

The privacy stance from `src/settings/server.ts` is preserved: this PR publishes the parameter *shape*, not the account *list*. Operators still control which IDs exist via the settings UI.

## Tests

- `src/tools/registry.test.ts` (new) — every served def carries `account_id`, none mark it required, pre-existing properties are preserved, previously-empty schemas widen to expose the field.

## Checklist

- [x] `npm run build` clean
- [x] `npm test` — 2210 passing across 83 files (was 2205 / 82 on `main` at HEAD)
- [x] `npm run lint` clean (`tsc --noEmit`)
- [x] Manual: `get_folders(account_id: "<other>")` returns the other account's folders from a Claude Code stdio session.
- [x] Conventional Commit format
- [x] No secrets in diff

## Notes for the reviewer

Two small judgment calls happy to revisit:

1. Wrapper location — currently in `registry.ts`. Could equally live in `src/tools/types.ts` next to `ToolDef`. Picked registry because the wrapping is part of "what gets served", not part of the type contract.
2. Description text on the field — current copy points operators at the settings UI for the account list. If you'd rather not surface a UI reference there, I can drop it to a one-line "Optional account ID; omit for the active account."
