### PR TITLE
fix(test): make safe-bridge All-Mail-union e2e deterministic

### DIFF
--- a/test/e2e/scenarios/safe-bridge.e2e.test.ts
+++ b/test/e2e/scenarios/safe-bridge.e2e.test.ts
@@ -177,7 +177,7 @@ describe("safe-bridge.e2e — non-destructive Bridge audit (scratch-scoped)", ()
     // All Mail indexing can lag a moment after APPEND — poll for OUR message.
     let amUids: number[] = [];
     for (let i = 0; i < 12 && amUids.length === 0; i++) {
-      amUids = await h.imap.searchSubject("All Mail", token);
+      amUids = await h.imap.searchSubject("All Mail", seed.subject);
       if (amUids.length === 0) await new Promise((r) => setTimeout(r, 500));
     }
     if (amUids.length === 0) {


### PR DESCRIPTION
The live-Bridge `safe-bridge` e2e test "relocates a self-seeded message OUT of the real All Mail union" was flaky (~1-in-3 failures).

**Root cause:** it searched All Mail by the shared run `token`, but every scratch message carries that token (`tokenSeed` → `${token} ${tag}`). With sibling scratch folders present, `searchSubject` returned multiple UIDs and the test moved `amUids[0]` — frequently a *different* test's message — leaving `dst` with the wrong subject. `bulk_move` itself was correct; the test just picked the wrong UID.

**Fix:** search by the unique `seed.subject`, aligning with the test's own doc-comment ("acts solely on ONE self-seeded, token-subjected message … never other mail").

**Verification:** 3/3 consecutive clean live-Proton-Bridge runs pass (8/8 each); previously failed roughly 1 run in 3 at this assertion. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)