### PR TITLE
feat(simplelogin): reverse-alias contacts for PGP-encrypted replies

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -104,9 +104,10 @@ export function buildPermissions(preset: PermissionPreset): ServerConfig["permis
       ...TOOL_CATEGORIES.system.tools,
       "get_folders",
       "start_bridge",  // needed to bring Bridge up before reading
-      // SimpleLogin read-only surface: list + activity logs only.
+      // SimpleLogin read-only surface: list + activity logs + contact list only.
       "alias_list",
       "alias_get_activity",
+      "alias_list_contacts",
     ]);
     for (const tool of ALL_TOOLS) {
       tools[tool].enabled = allowed.has(tool);
@@ -138,6 +139,9 @@ export function buildPermissions(preset: PermissionPreset): ServerConfig["permis
     tools["alias_create_custom"].rateLimit = 50;
     tools["alias_toggle"].rateLimit = 100;
     tools["alias_delete"].rateLimit = 20;
+    tools["alias_create_contact"].rateLimit = 50;
+    tools["alias_toggle_contact"].rateLimit = 100;
+    tools["alias_delete_contact"].rateLimit = 20;
     // Server lifecycle: allow a few per session.
     tools["shutdown_server"].rateLimit = 5;
     tools["restart_server"].rateLimit = 5;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -15,8 +15,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 73 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(73);
+  it("has exactly 77 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(77);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -36,6 +36,7 @@ export const ALL_TOOLS = [
   // SimpleLogin aliases (Proton-owned; optional — requires API key)
   "alias_list", "alias_create_random", "alias_create_custom",
   "alias_toggle", "alias_delete", "alias_get_activity",
+  "alias_list_contacts", "alias_create_contact", "alias_toggle_contact", "alias_delete_contact",
   // Proton Pass (optional — requires pass-cli and a Personal Access Token)
   "pass_list", "pass_search", "pass_get",
 ] as const;
@@ -128,6 +129,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     tools: [
       "alias_list", "alias_create_random", "alias_create_custom",
       "alias_toggle", "alias_delete", "alias_get_activity",
+      "alias_list_contacts", "alias_create_contact", "alias_toggle_contact", "alias_delete_contact",
     ],
     risk: "moderate",
   },

--- a/src/services/simplelogin-service.test.ts
+++ b/src/services/simplelogin-service.test.ts
@@ -249,6 +249,74 @@ describe("SimpleLoginService", () => {
     });
   });
 
+  describe("reverse-alias contacts", () => {
+    it("lists contacts, paginating until an empty page", async () => {
+      const pages: Record<string, unknown> = {
+        "page_id=0": { contacts: [
+          { id: 1, contact: "a@ex.com", reverse_alias: "A <ra1@sl>", reverse_alias_address: "ra1@sl" },
+          { id: 2, contact: "b@ex.com", reverse_alias: "B <ra2@sl>", reverse_alias_address: "ra2@sl" },
+        ] },
+        "page_id=1": { contacts: [] },
+      };
+      const urls: string[] = [];
+      globalThis.fetch = mockFetch((url) => {
+        urls.push(url);
+        const key = url.includes("page_id=1") ? "page_id=1" : "page_id=0";
+        return { status: 200, body: pages[key] };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const contacts = await svc.listContacts(42);
+      expect(contacts).toHaveLength(2);
+      expect(contacts[0].reverse_alias_address).toBe("ra1@sl");
+      expect(urls[0]).toContain("/api/aliases/42/contacts?page_id=0");
+    });
+
+    it("creates a contact and returns the reverse-alias address to send from", async () => {
+      let capturedUrl = "", capturedMethod = "", capturedBody = "";
+      globalThis.fetch = mockFetch((url, init) => {
+        capturedUrl = url; capturedMethod = init.method ?? "GET"; capturedBody = String(init.body ?? "");
+        return { status: 201, body: {
+          id: 7, contact: "ext@ex.com", reverse_alias: "Ext <ra7@sl>", reverse_alias_address: "ra7@sl", existed: false,
+        } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const c = await svc.createContact(42, "Name <ext@ex.com>");
+      expect(capturedMethod).toBe("POST");
+      expect(capturedUrl).toContain("/api/aliases/42/contacts");
+      expect(JSON.parse(capturedBody)).toEqual({ contact: "Name <ext@ex.com>" });
+      expect(c.reverse_alias_address).toBe("ra7@sl");
+    });
+
+    it("toggles a contact's block state via /api/contacts/:id/toggle", async () => {
+      let capturedUrl = "", capturedMethod = "";
+      globalThis.fetch = mockFetch((url, init) => {
+        capturedUrl = url; capturedMethod = init.method ?? "GET";
+        return { status: 200, body: { block_forward: true } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      const r = await svc.toggleContact(7);
+      expect(capturedMethod).toBe("POST");
+      expect(capturedUrl).toContain("/api/contacts/7/toggle");
+      expect(r.block_forward).toBe(true);
+    });
+
+    it("deletes a contact via DELETE /api/contacts/:id", async () => {
+      let capturedUrl = "", capturedMethod = "";
+      globalThis.fetch = mockFetch((url, init) => {
+        capturedUrl = url; capturedMethod = init.method ?? "GET";
+        return { status: 200, body: { deleted: true } };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      await svc.deleteContact(7);
+      expect(capturedMethod).toBe("DELETE");
+      expect(capturedUrl).toContain("/api/contacts/7");
+    });
+  });
+
   describe("baseUrl normalization", () => {
     it("strips trailing slashes from the base URL", async () => {
       let capturedUrl = "";

--- a/src/services/simplelogin-service.ts
+++ b/src/services/simplelogin-service.ts
@@ -39,6 +39,23 @@ export interface SimpleLoginActivity {
   reverse_alias?: string;
 }
 
+export interface SimpleLoginContact {
+  id: number;
+  /** The external email address this reverse-alias forwards to. */
+  contact: string;
+  /** Display form, e.g. "Name <ra+xxx@simplelogin.co>". */
+  reverse_alias: string;
+  /** The raw reverse-alias address to put in To: when sending as the alias. */
+  reverse_alias_address: string;
+  /** POST only: true when the contact already existed (idempotent create). */
+  existed?: boolean;
+  block_forward?: boolean;
+  creation_date?: string;
+  creation_timestamp?: number;
+  last_email_sent_date?: string | null;
+  last_email_sent_timestamp?: number | null;
+}
+
 export interface AliasCreateRandomOptions {
   /** "uuid" = long random hex; "word" = readable word-pairs. */
   mode?: "uuid" | "word";
@@ -235,5 +252,51 @@ export class SimpleLoginService {
       method: "PUT",
       body: JSON.stringify(patch),
     });
+  }
+
+  /**
+   * List the reverse-alias contacts for an alias. Each contact is an external
+   * address you can send *as* this alias to; `reverse_alias_address` is the
+   * To: address that routes the reply out through SimpleLogin (and encrypts to
+   * the recipient's PGP key when one is configured).
+   */
+  async listContacts(aliasId: number, pageSize = 100): Promise<SimpleLoginContact[]> {
+    const collected: SimpleLoginContact[] = [];
+    let page = 0;
+    // SimpleLogin returns { contacts: SimpleLoginContact[] }; empty array = end.
+    while (collected.length < pageSize) {
+      const body = await this.request<{ contacts?: SimpleLoginContact[] }>(
+        `/api/aliases/${aliasId}/contacts?page_id=${page}`,
+      );
+      const batch = body.contacts ?? [];
+      if (batch.length === 0) break;
+      collected.push(...batch);
+      if (collected.length >= pageSize) break;
+      page += 1;
+      if (page >= 50) break;
+    }
+    return collected.slice(0, pageSize);
+  }
+
+  /**
+   * Create (or fetch, if it already exists) a reverse-alias contact. `contact`
+   * is the external recipient as "email@example.com" or "Name <email@…>".
+   * Returns `reverse_alias_address` — the To: address to send to so the message
+   * goes out from the alias. `existed: true` means the contact was already present.
+   */
+  async createContact(aliasId: number, contact: string): Promise<SimpleLoginContact> {
+    return this.request<SimpleLoginContact>(`/api/aliases/${aliasId}/contacts`, {
+      method: "POST",
+      body: JSON.stringify({ contact }),
+    });
+  }
+
+  async deleteContact(contactId: number): Promise<void> {
+    await this.request(`/api/contacts/${contactId}`, { method: "DELETE" });
+  }
+
+  /** Block or unblock a contact from forwarding. Returns the new block state. */
+  async toggleContact(contactId: number): Promise<{ block_forward: boolean }> {
+    return this.request(`/api/contacts/${contactId}/toggle`, { method: "POST" });
   }
 }

--- a/src/tools/aliases.ts
+++ b/src/tools/aliases.ts
@@ -1,6 +1,8 @@
 /**
  * SimpleLogin alias tools: alias_list, alias_create_random,
- * alias_create_custom, alias_toggle, alias_delete, alias_get_activity.
+ * alias_create_custom, alias_toggle, alias_delete, alias_get_activity,
+ * and reverse-alias contacts: alias_list_contacts, alias_create_contact,
+ * alias_toggle_contact, alias_delete_contact.
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
@@ -163,6 +165,94 @@ export const defs: ToolDef[] = [
       },
     },
   },
+  {
+    name: "alias_list_contacts",
+    title: "List SimpleLogin Alias Contacts",
+    description: "List the reverse-alias contacts for a SimpleLogin alias. Each contact is an external address you can send *as* the alias to; the returned reverse_alias_address is what you put in To: to route a reply out through the alias (encrypted to the recipient's PGP key when set).",
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        aliasId: { type: "number" },
+        pageSize: { type: "number", description: "Max contacts to return (default 100, cap 1000)" },
+      },
+      required: ["aliasId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        contacts: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "number" },
+              contact: { type: "string" },
+              reverse_alias: { type: "string" },
+              reverse_alias_address: { type: "string" },
+              block_forward: { type: "boolean" },
+            },
+          },
+        },
+      },
+    },
+  },
+  {
+    name: "alias_create_contact",
+    title: "Create SimpleLogin Alias Contact",
+    description: "Create (or fetch, if it already exists) a reverse-alias contact so you can send FROM a SimpleLogin alias TO an external address. Send your reply to the returned reverse_alias_address. `contact` is the recipient as \"email@example.com\" or \"Name <email@example.com>\".",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        aliasId: { type: "number" },
+        contact: { type: "string", description: "External recipient: \"email@example.com\" or \"Name <email@example.com>\"" },
+      },
+      required: ["aliasId", "contact"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "number" },
+        contact: { type: "string" },
+        reverse_alias: { type: "string" },
+        reverse_alias_address: { type: "string" },
+        existed: { type: "boolean" },
+      },
+    },
+  },
+  {
+    name: "alias_toggle_contact",
+    title: "Block/Unblock SimpleLogin Alias Contact",
+    description: "Block or unblock a reverse-alias contact from forwarding. Blocking stops mail to/from that contact without deleting the reverse-alias. Returns the new block_forward state.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        contactId: { type: "number" },
+      },
+      required: ["contactId"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: { block_forward: { type: "boolean" } },
+    },
+  },
+  {
+    name: "alias_delete_contact",
+    title: "Delete SimpleLogin Alias Contact",
+    description: "Permanently delete a reverse-alias contact. Irreversible — prefer alias_toggle_contact to just block. Destructive: requires { confirmed: true }.",
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
+    inputSchema: {
+      type: "object",
+      properties: {
+        contactId: { type: "number" },
+        confirmed: { type: "boolean", description: "Must be true to execute." },
+      },
+      required: ["contactId"],
+    },
+    outputSchema: ACTION_RESULT_SCHEMA,
+  },
 ];
 
 export const handlers: Record<string, ToolHandler> = {
@@ -246,6 +336,62 @@ export const handlers: Record<string, ToolHandler> = {
     const pageSize = clampOptionalInt(args.pageSize, 50, 1, 1000);
     const activities = await simpleloginService.getAliasActivities(args.aliasId, pageSize);
     return ok({ activities });
+  },
+
+  alias_list_contacts: async (ctx) => {
+    const { args, simpleloginService, ok } = ctx;
+    if (!simpleloginService.isConfigured()) {
+      throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+    }
+    if (typeof args.aliasId !== "number") {
+      throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+    }
+    const pageSize = clampOptionalInt(args.pageSize, 100, 1, 1000);
+    const contacts = await simpleloginService.listContacts(args.aliasId, pageSize);
+    return ok({ contacts });
+  },
+
+  alias_create_contact: async (ctx) => {
+    const { args, simpleloginService, ok } = ctx;
+    if (!simpleloginService.isConfigured()) {
+      throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+    }
+    if (typeof args.aliasId !== "number") {
+      throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+    }
+    const contact = requireNonEmptyString(args.contact, "contact");
+    const created = await simpleloginService.createContact(args.aliasId, contact);
+    return ok({
+      id: created.id,
+      contact: created.contact,
+      reverse_alias: created.reverse_alias,
+      reverse_alias_address: created.reverse_alias_address,
+      existed: created.existed ?? false,
+    });
+  },
+
+  alias_toggle_contact: async (ctx) => {
+    const { args, simpleloginService, ok } = ctx;
+    if (!simpleloginService.isConfigured()) {
+      throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+    }
+    if (typeof args.contactId !== "number") {
+      throw new McpError(ErrorCode.InvalidParams, "contactId must be a number.");
+    }
+    const result = await simpleloginService.toggleContact(args.contactId);
+    return ok({ block_forward: result.block_forward });
+  },
+
+  alias_delete_contact: async (ctx) => {
+    const { args, simpleloginService, ok } = ctx;
+    if (!simpleloginService.isConfigured()) {
+      throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+    }
+    if (typeof args.contactId !== "number") {
+      throw new McpError(ErrorCode.InvalidParams, "contactId must be a number.");
+    }
+    await simpleloginService.deleteContact(args.contactId);
+    return ok({ success: true });
   },
 };
 


### PR DESCRIPTION
Closes #234. First of the Tier-A gaps from the Proton/Bridge capability review.

## What
Adds the SimpleLogin **contacts / reverse-alias** surface — the path that lets an agent send **from** an alias **to** an external address (and reach that recipient's PGP key when configured). Previously the 6 alias tools covered lifecycle only; sending-as-alias was unreachable.

## New tools
| Tool | Kind | Notes |
|---|---|---|
| `alias_list_contacts` | read | paginated; enabled in `read_only` preset |
| `alias_create_contact` | write (idempotent) | returns `reverse_alias_address` — the To: address to send from the alias; `existed` flags dedupe |
| `alias_toggle_contact` | write | block/unblock forwarding |
| `alias_delete_contact` | destructive | confirm-gated like `alias_delete` |

## Wiring
- Service: `listContacts` / `createContact` / `deleteContact` / `toggleContact` + `SimpleLoginContact` type, reusing the existing auth + CRED-012 secret-redaction path.
- `ALL_TOOLS` + `TOOL_CATEGORIES.aliases`; `read_only` allows the list tool; `supervised` rate-limits writes (50/100/20-hr) matching existing alias ops.

## Verification
- `tsc` clean; full suite **2214/2214** (adds 4 service tests; `ALL_TOOLS` 73→77).

Follow-ups tracked: #235 (alias update — service method already exists, needs tool wiring), #236 (mailboxes/domains), #232/#233 (Proton Pass CLI fix + TOTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)