### PR TITLE
feat(simplelogin): alias_update tool + fix PATCH method

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -138,6 +138,7 @@ export function buildPermissions(preset: PermissionPreset): ServerConfig["permis
     tools["alias_create_random"].rateLimit = 50;
     tools["alias_create_custom"].rateLimit = 50;
     tools["alias_toggle"].rateLimit = 100;
+    tools["alias_update"].rateLimit = 100;
     tools["alias_delete"].rateLimit = 20;
     tools["alias_create_contact"].rateLimit = 50;
     tools["alias_toggle_contact"].rateLimit = 100;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -15,8 +15,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 77 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(77);
+  it("has exactly 78 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(78);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -34,7 +34,7 @@ export const ALL_TOOLS = [
   // Bridge & server control
   "start_bridge", "shutdown_server", "restart_server",
   // SimpleLogin aliases (Proton-owned; optional — requires API key)
-  "alias_list", "alias_create_random", "alias_create_custom",
+  "alias_list", "alias_create_random", "alias_create_custom", "alias_update",
   "alias_toggle", "alias_delete", "alias_get_activity",
   "alias_list_contacts", "alias_create_contact", "alias_toggle_contact", "alias_delete_contact",
   // Proton Pass (optional — requires pass-cli and a Personal Access Token)
@@ -127,7 +127,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     label: "SimpleLogin Aliases",
     description: "Create and manage SimpleLogin aliases (Proton-owned alias service; requires API key)",
     tools: [
-      "alias_list", "alias_create_random", "alias_create_custom",
+      "alias_list", "alias_create_random", "alias_create_custom", "alias_update",
       "alias_toggle", "alias_delete", "alias_get_activity",
       "alias_list_contacts", "alias_create_contact", "alias_toggle_contact", "alias_delete_contact",
     ],

--- a/src/services/simplelogin-service.test.ts
+++ b/src/services/simplelogin-service.test.ts
@@ -249,6 +249,22 @@ describe("SimpleLoginService", () => {
     });
   });
 
+  describe("updateAlias", () => {
+    it("sends PATCH (not PUT) to /api/aliases/:id with only the given fields", async () => {
+      let capturedUrl = "", capturedMethod = "", capturedBody = "";
+      globalThis.fetch = mockFetch((url, init) => {
+        capturedUrl = url; capturedMethod = init.method ?? "GET"; capturedBody = String(init.body ?? "");
+        return { status: 200, body: "" };
+      }) as unknown as typeof globalThis.fetch;
+
+      const svc = new SimpleLoginService("sl-key");
+      await svc.updateAlias(99, { note: "renamed", mailbox_ids: [3, 4] });
+      expect(capturedMethod).toBe("PATCH");
+      expect(capturedUrl).toContain("/api/aliases/99");
+      expect(JSON.parse(capturedBody)).toEqual({ note: "renamed", mailbox_ids: [3, 4] });
+    });
+  });
+
   describe("reverse-alias contacts", () => {
     it("lists contacts, paginating until an empty page", async () => {
       const pages: Record<string, unknown> = {

--- a/src/services/simplelogin-service.ts
+++ b/src/services/simplelogin-service.ts
@@ -244,12 +244,17 @@ export class SimpleLoginService {
     return collected.slice(0, pageSize);
   }
 
+  /**
+   * Update an existing alias. SimpleLogin defines this as PATCH
+   * /api/aliases/:id (not PUT) — see docs/api.md "Update alias info". Any
+   * subset of the fields may be sent; omitted fields are left unchanged.
+   */
   async updateAlias(
     aliasId: number,
-    patch: { name?: string; note?: string; mailbox_ids?: number[]; disable_pgp?: boolean },
+    patch: { name?: string; note?: string; mailbox_ids?: number[]; disable_pgp?: boolean; pinned?: boolean },
   ): Promise<void> {
     await this.request(`/api/aliases/${aliasId}`, {
-      method: "PUT",
+      method: "PATCH",
       body: JSON.stringify(patch),
     });
   }

--- a/src/tools/aliases.ts
+++ b/src/tools/aliases.ts
@@ -1,8 +1,8 @@
 /**
  * SimpleLogin alias tools: alias_list, alias_create_random,
- * alias_create_custom, alias_toggle, alias_delete, alias_get_activity,
- * and reverse-alias contacts: alias_list_contacts, alias_create_contact,
- * alias_toggle_contact, alias_delete_contact.
+ * alias_create_custom, alias_update, alias_toggle, alias_delete,
+ * alias_get_activity, and reverse-alias contacts: alias_list_contacts,
+ * alias_create_contact, alias_toggle_contact, alias_delete_contact.
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
@@ -164,6 +164,25 @@ export const defs: ToolDef[] = [
         },
       },
     },
+  },
+  {
+    name: "alias_update",
+    title: "Update SimpleLogin Alias",
+    description: "Update an existing SimpleLogin alias in place: display name (shown in replies), note, which mailbox(es) receive its mail, PGP on/off, and pinned state. Provide only the fields you want to change; at least one is required. Use alias_list to find the aliasId and alias_list_mailboxes-equivalent workflow (mailbox_ids come from SimpleLogin's dashboard) to retarget delivery.",
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        aliasId: { type: "number" },
+        name: { type: "string", description: "Display name shown in replies (empty string clears it)" },
+        note: { type: "string", description: "Free-text note describing what this alias is for" },
+        mailboxIds: { type: "array", items: { type: "number" }, description: "Mailbox IDs that should receive this alias's mail (replaces the current set)" },
+        disablePgp: { type: "boolean", description: "true disables PGP encryption for forwards to the mailbox" },
+        pinned: { type: "boolean", description: "Pin the alias to the top of the SimpleLogin dashboard" },
+      },
+      required: ["aliasId"],
+    },
+    outputSchema: ACTION_RESULT_SCHEMA,
   },
   {
     name: "alias_list_contacts",
@@ -336,6 +355,27 @@ export const handlers: Record<string, ToolHandler> = {
     const pageSize = clampOptionalInt(args.pageSize, 50, 1, 1000);
     const activities = await simpleloginService.getAliasActivities(args.aliasId, pageSize);
     return ok({ activities });
+  },
+
+  alias_update: async (ctx) => {
+    const { args, simpleloginService, ok } = ctx;
+    if (!simpleloginService.isConfigured()) {
+      throw new McpError(ErrorCode.InvalidRequest, "SimpleLogin API key is not configured. Set simpleloginApiKey in Settings → Aliases.");
+    }
+    if (typeof args.aliasId !== "number") {
+      throw new McpError(ErrorCode.InvalidParams, "aliasId must be a number.");
+    }
+    const patch: { name?: string; note?: string; mailbox_ids?: number[]; disable_pgp?: boolean; pinned?: boolean } = {};
+    if (typeof args.name === "string") patch.name = args.name;
+    if (typeof args.note === "string") patch.note = args.note;
+    if (Array.isArray(args.mailboxIds)) patch.mailbox_ids = args.mailboxIds as number[];
+    if (typeof args.disablePgp === "boolean") patch.disable_pgp = args.disablePgp;
+    if (typeof args.pinned === "boolean") patch.pinned = args.pinned;
+    if (Object.keys(patch).length === 0) {
+      throw new McpError(ErrorCode.InvalidParams, "Provide at least one field to update (name, note, mailboxIds, disablePgp, or pinned).");
+    }
+    await simpleloginService.updateAlias(args.aliasId, patch);
+    return ok({ success: true });
   },
 
   alias_list_contacts: async (ctx) => {


### PR DESCRIPTION
Closes #235.

## What
Exposes the existing `SimpleLoginService.updateAlias` (previously unreachable — no tool wired it) as **`alias_update`**: change an alias's display name, note, delivery `mailbox_ids`, PGP on/off, and pinned state in place. Requires ≥1 field; omitted fields unchanged.

## Bug fix included
`updateAlias` used **`PUT`**, but SimpleLogin defines the endpoint as **`PATCH /api/aliases/:id`** (verified against docs/api.md "Update alias info"). `PUT` would fail against the real API. Also added the `pinned` field.

## Wiring & verification
- `ALL_TOOLS` + `TOOL_CATEGORIES.aliases`; `supervised` rate-limit 100/hr (write, idempotent; not in `read_only`).
- Test asserts PATCH + partial body (omitted fields excluded). Full suite **2215/2215**, build clean. `ALL_TOOLS` 77→78.

Next in the Tier-A queue: #232 (pass-cli subcommand fix), #233 (Pass TOTP), #236 (mailboxes/domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)