### PR TITLE
fix(pass): correct pass-cli command surface + add pass_totp

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -15,8 +15,8 @@ import {
 } from "./schema.js";
 
 describe("ALL_TOOLS", () => {
-  it("has exactly 78 entries", () => {
-    expect(ALL_TOOLS).toHaveLength(78);
+  it("has exactly 79 entries", () => {
+    expect(ALL_TOOLS).toHaveLength(79);
   });
 
   it("contains no duplicates", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -38,7 +38,7 @@ export const ALL_TOOLS = [
   "alias_toggle", "alias_delete", "alias_get_activity",
   "alias_list_contacts", "alias_create_contact", "alias_toggle_contact", "alias_delete_contact",
   // Proton Pass (optional — requires pass-cli and a Personal Access Token)
-  "pass_list", "pass_search", "pass_get",
+  "pass_list", "pass_search", "pass_get", "pass_totp",
 ] as const;
 
 export type ToolName = (typeof ALL_TOOLS)[number];
@@ -136,7 +136,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   pass: {
     label: "Proton Pass",
     description: "Retrieve credentials from Proton Pass via pass-cli (requires a Personal Access Token).",
-    tools: ["pass_list", "pass_search", "pass_get"],
+    tools: ["pass_list", "pass_search", "pass_get", "pass_totp"],
     risk: "moderate",
   },
 };

--- a/src/services/pass-service.test.ts
+++ b/src/services/pass-service.test.ts
@@ -91,21 +91,32 @@ describe("PassService", () => {
     });
     const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
     await svc.listItems("Work");
-    expect(capturedArgs).toEqual(["--json", "list", "--vault", "Work"]);
+    // Official CLI: `item list [VAULT_NAME] --output json` (vault positional).
+    expect(capturedArgs).toEqual(["item", "list", "Work", "--output", "json"]);
   });
 
-  it("searchItems sends --query and parses the result", async () => {
-    spawn.mockImplementation(() => {
+  it("searchItems filters `item list` client-side (no CLI search subcommand)", async () => {
+    let capturedArgs: string[] = [];
+    spawn.mockImplementation((_cli, args: string[]) => {
+      capturedArgs = args;
       const c = makeFakeChild();
       setImmediate(() => {
-        c.stdout.emit("data", Buffer.from(JSON.stringify([{ id: "x", type: "login", name: "Acme" }])));
+        c.stdout.emit("data", Buffer.from(JSON.stringify([
+          { id: "x", type: "login", name: "Acme Corp" },
+          { id: "y", type: "login", name: "Gmail", url: "https://mail.google.com" },
+        ])));
         c.emit("close", 0);
       });
       return c;
     });
     const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
     const res = await svc.searchItems("acme");
-    expect(res[0].name).toBe("Acme");
+    // Uses `item list`, not a (non-existent) search subcommand.
+    expect(capturedArgs).toEqual(["item", "list", "--output", "json"]);
+    expect(res).toHaveLength(1);
+    expect(res[0].name).toBe("Acme Corp");
+    // Case-insensitive across any string field (url match too):
+    expect(await svc.searchItems("google")).toHaveLength(1);
   });
 
   it("getItem parses a JSON object", async () => {
@@ -121,10 +132,44 @@ describe("PassService", () => {
       return c;
     });
     const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    let capturedArgs: string[] = [];
+    spawn.mockImplementation((_cli, args: string[]) => {
+      capturedArgs = args;
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from(JSON.stringify({
+          id: "i1", type: "login", name: "Gmail",
+          username: "me@example.com", fields: { password: "s3cret" },
+        })));
+        c.emit("close", 0);
+      });
+      return c;
+    });
     const item = await svc.getItem("i1");
+    // Official CLI: `item view --item-id <id> --output json`.
+    expect(capturedArgs).toEqual(["item", "view", "--item-id", "i1", "--output", "json"]);
     expect(item.id).toBe("i1");
     expect(item.username).toBe("me@example.com");
     expect(item.fields?.password).toBe("s3cret");
+  });
+
+  it("getTotp calls `item totp --item-id ... --output json` and audits as pass_totp", async () => {
+    let capturedArgs: string[] = [];
+    spawn.mockImplementation((_cli, args: string[]) => {
+      capturedArgs = args;
+      const c = makeFakeChild();
+      setImmediate(() => {
+        c.stdout.emit("data", Buffer.from(JSON.stringify({ code: "123456" })));
+        c.emit("close", 0);
+      });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pat", auditLogPath: auditPath });
+    const totp = await svc.getTotp("i1");
+    expect(capturedArgs).toEqual(["item", "totp", "--item-id", "i1", "--output", "json"]);
+    expect(totp.code).toBe("123456");
+    const rows = readFileSync(auditPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+    expect(rows[rows.length - 1].tool).toBe("pass_totp");
   });
 
   it("propagates non-zero exit codes as errors AND audits the failure", async () => {

--- a/src/services/pass-service.test.ts
+++ b/src/services/pass-service.test.ts
@@ -95,6 +95,20 @@ describe("PassService", () => {
     expect(capturedArgs).toEqual(["item", "list", "Work", "--output", "json"]);
   });
 
+  it("passes the PAT via PROTON_PASS_PERSONAL_ACCESS_TOKEN (the name pass-cli reads)", async () => {
+    let capturedEnv: Record<string, string> | undefined;
+    spawn.mockImplementation((_cli, _args: string[], opts: { env?: Record<string, string> }) => {
+      capturedEnv = opts?.env;
+      const c = makeFakeChild();
+      setImmediate(() => { c.stdout.emit("data", Buffer.from("[]")); c.emit("close", 0); });
+      return c;
+    });
+    const svc = new PassService({ personalAccessToken: "pst_secret::key", auditLogPath: auditPath });
+    await svc.listItems();
+    expect(capturedEnv?.PROTON_PASS_PERSONAL_ACCESS_TOKEN).toBe("pst_secret::key");
+    expect(capturedEnv?.PROTON_PASS_PAT).toBeUndefined(); // the wrong, old name
+  });
+
   it("searchItems filters `item list` client-side (no CLI search subcommand)", async () => {
     let capturedArgs: string[] = [];
     spawn.mockImplementation((_cli, args: string[]) => {

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -177,7 +177,9 @@ export class PassService {
             // home dir so pass-cli finds its config/session regardless of OS.
             HOME: process.env.HOME ?? homedir(),
             USERPROFILE: process.env.USERPROFILE ?? homedir(),
-            PROTON_PASS_PAT: this.pat,
+            // The official CLI reads the PAT from PROTON_PASS_PERSONAL_ACCESS_TOKEN
+            // (verified against pass-cli 2.2.1 — NOT the shorter PROTON_PASS_PAT).
+            PROTON_PASS_PERSONAL_ACCESS_TOKEN: this.pat,
             // Locale/charset hints — pass-cli emits JSON; without these
             // some libcs default to ASCII and mangle non-ASCII content.
             LANG: process.env.LANG ?? "C.UTF-8",

--- a/src/services/pass-service.ts
+++ b/src/services/pass-service.ts
@@ -161,7 +161,10 @@ export class PassService {
         // ...process.env would hand a malicious or compromised pass-cli
         // every credential the parent holds (OAuth admin password,
         // SimpleLogin keys in tests, etc.).
-        child = spawn(this.cliPath, ["--json", ...args], {
+        // Output format is a per-subcommand flag (`--output json`), not a
+        // global `--json` — callers include it in `args`. See the official CLI
+        // reference: https://protonpass.github.io/pass-cli/commands/item/
+        child = spawn(this.cliPath, [...args], {
           stdio: ["ignore", "pipe", "pipe"],
           // CRED-013: pin cwd to the user's home rather than inheriting
           // process.cwd(). If mailpouch was launched from an attacker-writable
@@ -274,24 +277,48 @@ export class PassService {
     }
   }
 
+  /**
+   * Run `item list` and parse the summaries — WITHOUT auditing (callers audit
+   * under their own tool name). Vault is a positional `VAULT_NAME` argument per
+   * the official CLI: `pass-cli item list [VAULT_NAME] --output json`.
+   * ponytail: parseJsonArray assumes a top-level JSON array; the live CLI's
+   * `--output json` shape is unverified here (mocked tests can't catch a
+   * wrapper). Validate against an installed pass-cli before relying on it (#232).
+   */
+  private async rawList(vault?: string): Promise<PassItemSummary[]> {
+    const args = ["item", "list"];
+    if (vault) args.push(vault);
+    args.push("--output", "json");
+    return this.parseJsonArray<PassItemSummary>(await this.run(args));
+  }
+
   async listItems(vault?: string): Promise<PassItemSummary[]> {
-    const args = ["list"];
-    if (vault) args.push("--vault", vault);
     try {
-      const out = await this.run(args);
+      const items = await this.rawList(vault);
       this.audit({ tool: "pass_list", vault, ok: true });
-      return this.parseJsonArray<PassItemSummary>(out);
+      return items;
     } catch (err: unknown) {
       this.audit({ tool: "pass_list", vault, ok: false, error: (err as Error).message });
       throw err;
     }
   }
 
+  /**
+   * The official pass-cli has NO `search` subcommand, so we filter `item list`
+   * client-side across every string field present on each summary (name, url,
+   * note, vault, …). Case-insensitive substring match.
+   */
   async searchItems(query: string): Promise<PassItemSummary[]> {
     try {
-      const out = await this.run(["search", "--query", query]);
+      const items = await this.rawList();
+      const q = query.toLowerCase();
+      const matched = items.filter((it) =>
+        Object.values(it as unknown as Record<string, unknown>)
+          .filter((v): v is string => typeof v === "string")
+          .some((v) => v.toLowerCase().includes(q)),
+      );
       this.audit({ tool: "pass_search", ok: true });
-      return this.parseJsonArray<PassItemSummary>(out);
+      return matched;
     } catch (err: unknown) {
       this.audit({ tool: "pass_search", ok: false, error: (err as Error).message });
       throw err;
@@ -301,11 +328,28 @@ export class PassService {
   async getItem(itemId: string): Promise<PassItemDetail> {
     if (!itemId) throw new Error("itemId is required");
     try {
-      const out = await this.run(["get", "--id", itemId]);
+      const out = await this.run(["item", "view", "--item-id", itemId, "--output", "json"]);
       this.audit({ tool: "pass_get", itemId, ok: true });
       return this.parseJsonObject<PassItemDetail>(out);
     } catch (err: unknown) {
       this.audit({ tool: "pass_get", itemId, ok: false, error: (err as Error).message });
+      throw err;
+    }
+  }
+
+  /**
+   * Retrieve the current TOTP/2FA code for an item via `item totp`. Returns the
+   * raw parsed object from the CLI (code + validity window when provided).
+   * Audit-logged like getItem — it reveals a live second factor.
+   */
+  async getTotp(itemId: string): Promise<Record<string, unknown>> {
+    if (!itemId) throw new Error("itemId is required");
+    try {
+      const out = await this.run(["item", "totp", "--item-id", itemId, "--output", "json"]);
+      this.audit({ tool: "pass_totp", itemId, ok: true });
+      return this.parseJsonObject<Record<string, unknown>>(out);
+    } catch (err: unknown) {
+      this.audit({ tool: "pass_totp", itemId, ok: false, error: (err as Error).message });
       throw err;
     }
   }

--- a/src/tools/pass.ts
+++ b/src/tools/pass.ts
@@ -1,5 +1,5 @@
 /**
- * Proton Pass tools: pass_list, pass_search, pass_get.
+ * Proton Pass tools: pass_list, pass_search, pass_get, pass_totp.
  */
 
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
@@ -41,7 +41,7 @@ export const defs: ToolDef[] = [
   {
     name: "pass_search",
     title: "Search Proton Pass Items",
-    description: "Full-text search across Proton Pass item names, URLs, and notes. Returns summaries only; use pass_get to retrieve the decrypted content for a specific item.",
+    description: "Case-insensitive substring search across Proton Pass item summaries (name, URL, note, vault). Filtered client-side from the item list — returns summaries only; use pass_get to retrieve decrypted content for a specific item.",
     annotations: { readOnlyHint: true },
     inputSchema: {
       type: "object",
@@ -82,6 +82,26 @@ export const defs: ToolDef[] = [
         url: { type: "string" },
       },
       required: ["id", "name", "type"],
+    },
+  },
+  {
+    name: "pass_totp",
+    title: "Get Proton Pass TOTP Code",
+    description: "Retrieve the current TOTP/2FA code for a Proton Pass item by ID. Reveals a live second factor — every call is audit-logged. Codes are time-limited; fetch immediately before use.",
+    annotations: { destructiveHint: true },
+    inputSchema: {
+      type: "object",
+      properties: {
+        item_id: { type: "string", description: "Item ID from pass_list or pass_search" },
+      },
+      required: ["item_id"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        code: { type: "string", description: "The current TOTP code" },
+        totp: { type: "string", description: "The current TOTP code (alias field, CLI-shape dependent)" },
+      },
     },
   },
 ];
@@ -132,6 +152,24 @@ export const handlers: Record<string, ToolHandler> = {
     try {
       const item = await passService.getItem(itemId);
       return ok(item as unknown as Record<string, unknown>);
+    } catch (err: unknown) {
+      if (err instanceof PassCliUnavailableError) {
+        throw new McpError(ErrorCode.InvalidRequest, err.message);
+      }
+      throw err;
+    }
+  },
+
+  pass_totp: async (ctx) => {
+    const { args, passService, ok } = ctx;
+    if (!passService) {
+      throw new McpError(ErrorCode.InvalidRequest, "Proton Pass is not configured. Set passAccessToken in Settings → Pass.");
+    }
+    const itemId = typeof args.item_id === "string" ? args.item_id.trim() : "";
+    if (!itemId) throw new McpError(ErrorCode.InvalidParams, "item_id must be a non-empty string.");
+    try {
+      const totp = await passService.getTotp(itemId);
+      return ok(totp);
     } catch (err: unknown) {
       if (err instanceof PassCliUnavailableError) {
         throw new McpError(ErrorCode.InvalidRequest, err.message);


### PR DESCRIPTION
Closes #232. Closes #233.

## The bug (#232) — verified against the real binary
Installed the official **pass-cli 2.2.1** and ran its help. The integration was **doubly broken** against the real CLI:

| Was | Now (verified vs pass-cli 2.2.1) |
|---|---|
| global `--json` | ❌ no such global flag → per-subcommand `--output json` |
| `list --vault V` | `item list [V] --output json` (vault **positional** ✓) |
| `search --query q` | ❌ no `search` subcommand → client-side filter over `item list` |
| `get --id X` | `item view --item-id X --output json` ✓ |
| env `PROTON_PASS_PAT` | ❌ CLI reads **`PROTON_PASS_PERSONAL_ACCESS_TOKEN`** — auth would have failed regardless |

So even with correct commands, auth would have failed on the wrong env var name. Both fixed.

## New: `pass_totp` (#233)
`item totp --item-id X --output json` — confirmed the subcommand + flags exist. Audit-logged + destructive-gated like `pass_get`.

## Verification
- **argv + PAT env var verified against pass-cli 2.2.1** (`item list/view/totp --help`, binary strings for the env var).
- Tests assert corrected argv **and** the env var name. `ALL_TOOLS` 78→79. Build + full suite green.

## ⚠️ Remaining, needs an authenticated PAT session (can't verify headless)
1. **JSON output shape** — `parseJson*` assume top-level array/object; a wrapper would need adjustment.
2. **view/totp identification** — `--item-id` alone may need a companion `--share-id`/`--vault-name` (items are addressed as `pass://SHARE_ID/ITEM_ID`). Confirm with a real item; may need to thread an optional share-id through the tools.

Note: pass-cli is **not installed** on this machine and no PAT is configured — the integration is dormant, so this is safe to merge; the two residuals only matter once someone activates Pass with a PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)