### PR TITLE
Release v3.1.0 — SimpleLogin alias suite, Pass CLI fix, security bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.78] — 2026-07-01
+## [3.1.0] — 2026-07-01
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.78] — 2026-07-01
+
+### Added
+
+- **SimpleLogin alias management is now first-class.** Beyond the existing create/toggle/delete/activity tools, mailpouch can now: send *from* an alias via **reverse-alias contacts** (`alias_list_contacts` / `alias_create_contact` / `alias_toggle_contact` / `alias_delete_contact`) — the path that reaches a recipient's PGP key; **update an alias in place** (`alias_update` — display name, note, delivery mailboxes, PGP, pinned); and manage the supporting surfaces (`alias_list_mailboxes`, `alias_create_mailbox`, `alias_delete_mailbox`, `alias_list_domains`, `alias_options`). Eleven new tools; all request/response shapes verified against SimpleLogin's public API docs.
+- **`pass_totp`** — dedicated Proton Pass TOTP/2FA-code retrieval (`item totp`), audit-logged and confirm-gated like `pass_get`.
+- **Per-call `account_id` on every tool's inputSchema.** Strict-schema MCP clients (e.g. Claude Code) strip undeclared arguments, so the multi-account routing added in B1 was unreachable from them; every served tool now advertises the optional `account_id` it already honored.
+
+### Fixed
+
+- **The Proton Pass integration was calling a CLI surface that doesn't exist** and would have failed against a real install (latent — `pass-cli` isn't required to be present, and the tests mock it). Corrected and **verified against the official `pass-cli` 2.2.1**: global `--json` → per-subcommand `--output json`; `list` → `item list`; `get --id` → `item view --item-id`; the non-existent `search` → a client-side filter over `item list`; and the PAT env var `PROTON_PASS_PAT` → **`PROTON_PASS_PERSONAL_ACCESS_TOKEN`** (the name the CLI actually reads). Note: the JSON *output shape* and `--share-id` handling still need one validation pass against an authenticated `pass-cli` session before the Pass tools are relied upon.
+- **SimpleLogin alias update used `PUT`; the API defines it as `PATCH`.** Would have failed against the live API.
+- Flaky live-Bridge `safe-bridge` e2e — it searched All Mail by the shared run token and could move the wrong message; now searches by the unique seeded subject.
+
+### Security
+
+- **nodemailer 8 → 9** — resolves the high-severity `raw`-option arbitrary-file-read / SSRF advisory (GHSA). mailpouch never uses the message-level `raw` option, so no behavior change.
+- **hono → 4.12.27** (transitive, via `@modelcontextprotocol/sdk`) — clears five hono advisories (CORS, body-limit, `serve-static` path traversal, Lambda adapters).
+
+### Dependencies
+
+- imapflow 1.3.6 → 1.4.3, mailparser 3.9.9 → 3.9.12, better-sqlite3 → 12.11.1; @types/node 26, vitest / @vitest/coverage-v8 4.1.9; `actions/checkout` v6 → v7 across all workflows. `npm audit`: 0 vulnerabilities.
+
 ## [3.0.77] — 2026-06-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.77-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.0.78-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.0.78-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v3.1.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.78",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.78",
+      "version": "3.1.0",
       "cpu": [
         "x64",
         "arm64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.0.77",
+  "version": "3.0.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.0.77",
+      "version": "3.0.78",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.77",
+  "version": "3.0.78",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.0.78",
+  "version": "3.1.0",
   "description": "mailpouch — MCP server that exposes Proton Mail via Proton Bridge. 70 tools, Resources, and Prompts for agentic email management with user-initiated permission controls.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Release PR bundling everything on `main` since v3.0.77.

## Highlights
- **SimpleLogin alias management** — reverse-alias contacts (PGP replies), `alias_update`, mailboxes/domains/options. **11 new tools** (#234, #235, #236).
- **Proton Pass** — corrected the entire `pass-cli` command surface + PAT env var (**verified against `pass-cli` 2.2.1**) and added `pass_totp` (#232, #233).
- **Per-call `account_id`** on every tool inputSchema (#213).
- **Security** — nodemailer 9 + hono 4.12.27 clear all 7 Dependabot alerts, plus supporting dep bumps (#230).

## Verification
- Version-sync OK (package.json / README badge / CHANGELOG all → 3.1.0). Build + full unit/integration suite **2221** green. GreenMail e2e green. CI preship (GreenMail) gates this PR.

## ⚠️ Known limitation shipping in this release
The Proton Pass fix corrects verified-broken behavior, but two paths still need one validation against an **authenticated** `pass-cli` session before the Pass tools can be relied on: the JSON **output shape** and whether `view`/`totp` need `--share-id` alongside `--item-id`. The integration is **dormant** unless a user installs `pass-cli` and issues a PAT, so this is safe to ship; it's documented in the CHANGELOG.

Merging this, then publishing the GitHub Release `v3.1.0`, triggers the npm publish (`publish.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
