### PR TITLE
fix(e2e): retry definite Bridge refusals instead of poisoning cleanup

### DIFF
--- a/test/e2e-uid-batches.test.ts
+++ b/test/e2e-uid-batches.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./e2e/support/uid-batches.mjs";
 import {
   isFatalCleanupError,
+  MutationRefusedError,
   requireMutationResult,
 } from "./e2e/support/mutation-result.mjs";
 
@@ -36,5 +37,25 @@ describe("Bridge E2E UID batching", () => {
       expect(isFatalCleanupError(thrown)).toBe(true);
     }
     expect(requireMutationResult({ ok: true }, "exact-owned UID MOVE")).toEqual({ ok: true });
+  });
+
+  it("treats a tagged NO on a usable connection as a retryable definite refusal", () => {
+    let thrown: unknown;
+    try { requireMutationResult(false, "exact-owned UID MOVE", { connectionUsable: true }); }
+    catch (error) { thrown = error; }
+    expect(thrown).toBeInstanceOf(MutationRefusedError);
+    expect(isFatalCleanupError(thrown)).toBe(false);
+    // A dead socket stays ambiguous even when the result is false.
+    let ambiguous: unknown;
+    try { requireMutationResult(false, "exact-owned UID MOVE", { connectionUsable: false }); }
+    catch (error) { ambiguous = error; }
+    expect(isFatalCleanupError(ambiguous)).toBe(true);
+    // undefined/null are precondition failures, never a definite refusal.
+    for (const result of [undefined, null]) {
+      let precondition: unknown;
+      try { requireMutationResult(result, "exact-owned UID MOVE", { connectionUsable: true }); }
+      catch (error) { precondition = error; }
+      expect(isFatalCleanupError(precondition)).toBe(true);
+    }
   });
 });

--- a/test/e2e/fixtures/imap-fixtures.ts
+++ b/test/e2e/fixtures/imap-fixtures.ts
@@ -28,6 +28,7 @@ import { BRIDGE_MUTATION_COMMAND_MS } from "../support/time-budgets.mjs";
 import {
   isFatalCleanupError,
   MutationOutcomeUnknownError,
+  MutationRefusedError,
   requireMutationResult,
 } from "../support/mutation-result.mjs";
 import {
@@ -308,8 +309,15 @@ export class ImapFixtures {
         label,
         onDeadline: () => this.abortCleanupSession(new DeadlineExceededError(label)),
       });
-      return requireMutationResult(result, label);
+      return requireMutationResult(result, label, {
+        connectionUsable: this.client.usable === true,
+      });
     } catch (error) {
+      // A tagged NO with a usable connection is a definite single-UID no-op:
+      // nothing was applied, so the session stays healthy and the bounded
+      // convergence rounds retry after the server settles (Proton refuses
+      // moves of freshly-sent Sent messages until its backend catches up).
+      if (error instanceof MutationRefusedError) throw error;
       if (isFatalCleanupError(error)) {
         this.abortCleanupSession(error instanceof Error ? error : new Error(String(error)));
         throw error;

--- a/test/e2e/support/cleanup-bridge.mjs
+++ b/test/e2e/support/cleanup-bridge.mjs
@@ -39,6 +39,7 @@ import { buildOwnershipDiscoveryQuery } from "./ownership-search.mjs";
 import {
   isFatalCleanupError,
   MutationOutcomeUnknownError,
+  MutationRefusedError,
   requireMutationResult,
 } from "./mutation-result.mjs";
 import {
@@ -1002,8 +1003,15 @@ async function runMutationCommand(label, operation) {
       },
       onTransition: debugPhaseTransition,
     });
-    return requireMutationResult(result, label);
+    return requireMutationResult(result, label, {
+      connectionUsable: client?.usable === true,
+    });
   } catch (error) {
+    // A tagged NO with a usable connection is a definite single-UID no-op:
+    // nothing was applied, so the session stays healthy and the convergence
+    // loop retries after the server settles (Proton refuses moves of
+    // freshly-sent Sent messages until its backend catches up).
+    if (error instanceof MutationRefusedError) throw error;
     // Once the command callback has been entered, a rejection does not prove
     // whether Bridge applied the mutation before reporting failure. Poison the
     // session and retain the recovery manifest for exact re-discovery.

--- a/test/e2e/support/mutation-result.d.mts
+++ b/test/e2e/support/mutation-result.d.mts
@@ -1,5 +1,12 @@
 export class MutationOutcomeUnknownError extends Error {
   code: "MAILPOUCH_E2E_MUTATION_OUTCOME_UNKNOWN";
 }
-export function requireMutationResult<T>(result: T | false | null | undefined, label: string): T;
+export class MutationRefusedError extends Error {
+  code: "MAILPOUCH_E2E_MUTATION_REFUSED";
+}
+export function requireMutationResult<T>(
+  result: T | false | null | undefined,
+  label: string,
+  options?: { connectionUsable?: boolean },
+): T;
 export function isFatalCleanupError(error: unknown): boolean;

--- a/test/e2e/support/mutation-result.mjs
+++ b/test/e2e/support/mutation-result.mjs
@@ -6,9 +6,29 @@ export class MutationOutcomeUnknownError extends Error {
   }
 }
 
+/** The server answered a single-UID mutation with a tagged NO while the
+ * connection stayed usable: a definite, complete refusal — nothing was
+ * applied. Proton refuses MOVE/DELETE on freshly-sent Sent messages until its
+ * backend settles them, so callers retry inside their bounded convergence
+ * rounds instead of poisoning the session. Only valid for single-UID operands
+ * (BRIDGE_MUTATION_UID_BATCH_SIZE); a multi-UID NO could be a partial apply. */
+export class MutationRefusedError extends Error {
+  constructor(label) {
+    super(`${label} was refused by the server (tagged NO; nothing was applied)`);
+    this.name = "MutationRefusedError";
+    this.code = "MAILPOUCH_E2E_MUTATION_REFUSED";
+  }
+}
+
 /** ImapFlow returns false/undefined for several command failures instead of
- * throwing. Treat that outcome as ambiguous and stop before another mutation. */
-export function requireMutationResult(result, label) {
+ * throwing. `false` with the connection still usable is a tagged NO — a
+ * definite single-UID no-op, surfaced as retryable. Every other non-result
+ * (undefined preconditions, false after a dead socket) stays ambiguous and
+ * stops the session before another mutation. */
+export function requireMutationResult(result, label, options = {}) {
+  if (result === false && options.connectionUsable === true) {
+    throw new MutationRefusedError(label);
+  }
   if (result === false || result === undefined || result === null) {
     throw new MutationOutcomeUnknownError(label);
   }

--- a/test/scratch-guard.test.ts
+++ b/test/scratch-guard.test.ts
@@ -228,16 +228,17 @@ describe("scratch guard — non-destructive ownership contract", () => {
     const fake = fakeImap({ [collision]: [] }, { unclaimedScratch: true });
 
     const report = await new ScratchSession(fake.imap, TOKEN_A).cleanup({
-      // Leave enough wall-clock budget for instrumented coverage runs to
-      // observe the semantic retention error instead of only the deadline.
-      settleAfterPurgeMs: 250,
+      // Leave enough wall-clock budget for loaded CI runners to complete a
+      // full reconciliation round and record the semantic retention error
+      // instead of only the deadline (flaked at 250ms on macOS/Windows CI).
+      settleAfterPurgeMs: 5_000,
     });
 
     expect(report.ok).toBe(false);
     expect(report.errors.join(" ")).toMatch(/no positive mailbox-creation proof/i);
     expect(fake.deleted).toEqual([]);
     expect(fake.folders.has(collision)).toBe(true);
-  });
+  }, 20_000);
 
   it("cleans this run across system and scratch folders without touching other mail", async () => {
     const scratch = `Folders/${TOKEN_A}-1`;
@@ -533,14 +534,16 @@ describe("scratch guard — non-destructive ownership contract", () => {
     };
 
     const report = await new ScratchSession(fake.imap, TOKEN_A).cleanup({
-      settleAfterPurgeMs: 250,
+      // 5s so loaded CI runners complete a round before the deadline
+      // (flaked at 250ms on Windows CI).
+      settleAfterPurgeMs: 5_000,
     });
 
     expect(report.ok).toBe(false);
     expect(fake.deleted).toEqual([]);
     expect(fake.folders.has(scratch)).toBe(true);
     expect(report.errors.join(" ")).toMatch(/no positive mailbox-creation proof/i);
-  });
+  }, 20_000);
 
   it("does not delete when a second fresh session reveals foreign folder content", async () => {
     const scratch = `Folders/${TOKEN_A}-transient-empty`;


### PR DESCRIPTION
## Summary
Release-attestation blocker: Proton Bridge answers UID MOVE on a freshly-sent Sent message with a tagged NO until its backend settles; imapflow returns `false`, which the cleanup runners treated as outcome-unknown — poisoning the session, retaining recovery state, and deterministically failing the sending.e2e teardown plus all 8 standalone recovery attempts.

A tagged NO with a usable connection is a definite, complete no-op for a single-UID operand, so it now surfaces as a retryable `MutationRefusedError` handled by the existing bounded convergence rounds. Timeouts, dead sockets, and precondition failures remain ambiguous and still fail closed.

## Test plan
- [x] typecheck + affected suites green (uid-batches, cleanup-bridge-standalone ×65, scratch-guard, deadline-controls, standalone-recovery — 119 tests)
- [x] New unit test: refused vs ambiguous vs precondition classification

## Security checklist
- [x] No secrets committed
- [x] Fail-closed semantics preserved for every ambiguous outcome
- [x] No dependency changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)