### PR TITLE
fix(e2e): raise Bridge cleanup settle budget to cover real All Mail lag

### DIFF
--- a/scripts/lib/preship-runner.mjs
+++ b/scripts/lib/preship-runner.mjs
@@ -60,7 +60,18 @@ export async function runSteps(steps, { header = "PRESHIP", verbose = false } = 
     const summary = res.summary ? "  " + styleText("gray", res.summary) : "";
     console.log(`${mark} ${nameCol} ${durCol}${summary}`);
     if (status === "fail") {
-      if (res.output) console.log(styleText("gray", res.output));
+      if (res.output) {
+        // CI step logs can truncate one large flush from the end, losing the
+        // test-runner summary. Print the tail first so the failure detail
+        // survives truncation, then the full output for local readers.
+        const lines = res.output.split("\n");
+        if (lines.length > 200) {
+          console.log(styleText("gray", `--- last 200 lines of ${step.name} output ---`));
+          console.log(styleText("gray", lines.slice(-200).join("\n")));
+          console.log(styleText("gray", `--- full ${step.name} output follows ---`));
+        }
+        console.log(styleText("gray", res.output));
+      }
       halted = true;
     } else if (status === "advisory" && (res.output || verbose)) {
       if (res.output) console.log(styleText("gray", res.output));

--- a/test/cleanup-bridge-standalone.test.ts
+++ b/test/cleanup-bridge-standalone.test.ts
@@ -14,6 +14,11 @@ import { createHash } from "node:crypto";
 import { tmpdir as osTmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { BRIDGE_CLEANUP_SETTLE_MS } from "./e2e/support/time-budgets.mjs";
+
+// Simulated-clock advance that guarantees the cleanup convergence deadline
+// (BRIDGE_CLEANUP_SETTLE_MS plus scheduling slack) has expired.
+const SETTLE_DEADLINE_ADVANCE_MS = BRIDGE_CLEANUP_SETTLE_MS + 2_001;
 
 // The standalone cleaner requires the recovery clone path to resolve to
 // itself. macOS tmpdir is a /var → /private/var symlink and Windows runners
@@ -1800,7 +1805,7 @@ describe("standalone Bridge cleanup safety", () => {
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
     await vi.waitFor(() => expect(imap.connectCalls).toBeGreaterThan(0));
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     const retained = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -1843,7 +1848,7 @@ describe("standalone Bridge cleanup safety", () => {
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
     await vi.waitFor(() => expect(imap.connectCalls).toBeGreaterThan(0));
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     const retained = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -2251,7 +2256,7 @@ describe("standalone Bridge cleanup safety", () => {
 
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     expect(imap.mailboxCreates).toEqual([]);
@@ -2281,7 +2286,7 @@ describe("standalone Bridge cleanup safety", () => {
 
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     expect(imap.mailboxCreates).toEqual([]);
@@ -2484,7 +2489,7 @@ describe("standalone Bridge cleanup safety", () => {
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     const completed = import("./e2e/support/cleanup-bridge.mjs");
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await completed;
 
     expect(exit).not.toHaveBeenCalled();
@@ -2539,7 +2544,7 @@ describe("standalone Bridge cleanup safety", () => {
 
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
-    await vi.advanceTimersByTimeAsync(182_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     const retained = JSON.parse(readFileSync(manifestPath, "utf8"));
@@ -2633,7 +2638,7 @@ describe("standalone Bridge cleanup safety", () => {
 
     const assertion = expect(import("./e2e/support/cleanup-bridge.mjs"))
       .rejects.toThrow(/process\.exit\(1\)/);
-    await vi.advanceTimersByTimeAsync(180_001);
+    await vi.advanceTimersByTimeAsync(SETTLE_DEADLINE_ADVANCE_MS);
     await assertion;
 
     expect(imap.folderDeletes).toEqual([]);

--- a/test/e2e/support/time-budgets.mjs
+++ b/test/e2e/support/time-budgets.mjs
@@ -1,7 +1,11 @@
 /** Shared live-Bridge E2E phase budgets. */
 /** Credential hydration, full IMAP connect/auth, baseline capture, and MCP handshake. */
 export const BRIDGE_SETUP_MS = 180_000;
-export const BRIDGE_CLEANUP_SETTLE_MS = 180_000;
+/** Proton's All Mail union can take several minutes to reflect concrete-folder
+ * deletions under real load (observed >6 min during release attestation).
+ * Convergence exits early on two consecutive clean ownership scans, so a
+ * generous ceiling costs nothing when the projection keeps up. */
+export const BRIDGE_CLEANUP_SETTLE_MS = 600_000;
 /** Require one unchanged exact Message-ID set across fresh Bridge sessions for
  * this long before the first All Mail rescue COPY. This lets delayed virtual
  * projections from concrete-folder cleanup disappear without creating an

--- a/test/improvement-loop.test.ts
+++ b/test/improvement-loop.test.ts
@@ -282,7 +282,9 @@ describe("improvement-loop runner", () => {
       ok: false,
       checks: [{ timedOut: true }],
     });
-  });
+    // Spawns a real process tree; Windows CI runners need well over the 5s
+    // default to create and reap it under load.
+  }, 30_000);
 
   it("fails closed if a recorded audit artifact changes after import", () => {
     const root = createRoot();


### PR DESCRIPTION
## Summary
Release attestation cleaned every concrete-folder copy, but Proton's All Mail union kept projecting the deleted messages past the 180s convergence budget (observed >6 min under load), retaining the manifest and failing the run. Raise BRIDGE_CLEANUP_SETTLE_MS to 10 minutes — convergence still exits early on two consecutive clean scans, so the ceiling only costs wall-clock when the projection actually lags. Standalone-cleanup fake-timer tests now derive their deadline advances from the constant instead of hardcoding 18x_001.

## Test plan
- [x] cleanup-bridge-standalone 65/65, time-budgets, deadline-controls, vitest-config green locally
- [x] preship:fast via pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)