### PR TITLE
fix(transport): bind MCP sessions to their owning OAuth client (XPORT-016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- MCP sessions on the HTTP transport are now bound to the OAuth client that opened them. A session id is a routing handle, not a credential: previously any *other* authenticated agent could present a peer's `Mcp-Session-Id` and attach to that session — reading the peer's server→client SSE stream on `GET`, or tearing the session down on `DELETE`. A session id presented by a non-owner is now treated as if it did not exist.
+- Cleared all outstanding dependency advisories by moving to `@modelcontextprotocol/sdk` 1.30.0, which resolves patched `fast-uri`, `@hono/node-server`, and `body-parser` transitives. `npm audit` reports no findings.
+
 ## [3.2.0] — 2026-07-12
 
 ### Added

--- a/src/transports/http.test.ts
+++ b/src/transports/http.test.ts
@@ -643,6 +643,78 @@ describe("HTTP transport", () => {
       }, 15_000);
     });
 
+    describe("session ownership (XPORT-016)", () => {
+      // The Mcp-Session-Id is a routing handle, not a credential. A second agent
+      // holding its OWN valid token must not be able to attach to a peer's
+      // session by presenting the peer's id — on GET that would hand it the
+      // peer's server->client SSE stream, and on DELETE it would let it tear the
+      // peer's session down.
+      async function twoAuthedClients() {
+        const port = await freePort();
+        const sa = newServiceAccountStore();
+        const a = sa.issue({ name: "session-owner-a", preset: "read_only" });
+        const b = sa.issue({ name: "session-thief-b", preset: "read_only" });
+        handle = await startHttpTransport({ server: buildServer(), port, host: "127.0.0.1", oauthEnabled: true, serviceAccounts: sa });
+        const url = `http://127.0.0.1:${port}`;
+        const tokenA = (await clientCredentialsToken(url, a.account.clientId, a.clientSecret)).token;
+        const tokenB = (await clientCredentialsToken(url, b.account.clientId, b.clientSecret)).token;
+        const init = await mcpInitialize(url, tokenA);
+        expect(init.status).toBe(200);
+        const sid = init.headers.get("mcp-session-id") ?? "";
+        expect(sid).toBeTruthy();
+        return { url, tokenA, tokenB, sid };
+      }
+
+      const listTools = (url: string, token: string, sid: string) =>
+        fetch(`${url}/mcp`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            Authorization: `Bearer ${token}`,
+            "mcp-session-id": sid,
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+        });
+
+      it("refuses a POST that presents another client's session id", async () => {
+        const { url, tokenB, sid } = await twoAuthedClients();
+        const res = await listTools(url, tokenB, sid);
+        // Treated as if the session did not exist, so a prober cannot use the
+        // response to confirm the id is live.
+        expect(res.status).toBe(400);
+        expect(JSON.stringify(await res.json())).toContain("no valid session ID");
+      }, 15_000);
+
+      it("refuses a GET (SSE attach) on another client's session id", async () => {
+        const { url, tokenB, sid } = await twoAuthedClients();
+        const res = await fetch(`${url}/mcp`, {
+          method: "GET",
+          headers: { Accept: "text/event-stream", Authorization: `Bearer ${tokenB}`, "mcp-session-id": sid },
+        });
+        expect(res.status).toBe(400);
+        await res.body?.cancel();
+      }, 15_000);
+
+      it("refuses a DELETE on another client's session id, and the owner keeps working", async () => {
+        const { url, tokenA, tokenB, sid } = await twoAuthedClients();
+        const stolen = await fetch(`${url}/mcp`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${tokenB}`, "mcp-session-id": sid },
+        });
+        expect(stolen.status).toBe(400);
+        // The owner's session survived the attempted teardown.
+        const owner = await listTools(url, tokenA, sid);
+        expect(owner.status).toBe(200);
+      }, 15_000);
+
+      it("still routes the owning client to its own session", async () => {
+        const { url, tokenA, sid } = await twoAuthedClients();
+        const res = await listTools(url, tokenA, sid);
+        expect(res.status).toBe(200);
+      }, 15_000);
+    });
+
     it("serves RFC 9728 oauth-protected-resource metadata", async () => {
       const { url } = await startOauth();
       const res = await fetch(`${url}/.well-known/oauth-protected-resource`);

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -206,7 +206,15 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
   // binds one Server to one transport, so each session also gets its own Server
   // via opts.createServer. A new session is created when an unsessioned POST
   // carries an `initialize` request; subsequent requests route by session id.
-  const sessions = new Map<string, StreamableHTTPServerTransport>();
+  //
+  // XPORT-016: the session id is a routing handle, NOT a credential. Every entry
+  // records the OAuth client_id that opened it so a session can only ever be
+  // driven by its owner. Without that binding any *other* authenticated agent
+  // could present a peer's Mcp-Session-Id and attach to its transport — reading
+  // the peer's server→client SSE stream on GET, or tearing the session down on
+  // DELETE. The MCP security model is explicit that possession of a state handle
+  // must not be treated as authentication.
+  const sessions = new Map<string, { transport: StreamableHTTPServerTransport; owner: string }>();
 
   // Rate limiters — one bucket per client IP for unauthed endpoints; one
   // bucket per token (sha256-fingerprint) for authed /mcp calls.
@@ -491,14 +499,27 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
       // Route to the per-session transport. Existing session → reuse it.
       const sessionId = req.headers["mcp-session-id"];
       const sid = Array.isArray(sessionId) ? sessionId[0] : sessionId;
-      let transport: StreamableHTTPServerTransport | undefined = sid ? sessions.get(sid) : undefined;
+      const entry = sid ? sessions.get(sid) : undefined;
+      // XPORT-016: a session belongs to the client that opened it. Another
+      // agent's token is a valid credential but not a claim on this session, so
+      // treat a foreign session id as if it did not exist — that both refuses
+      // the request and avoids confirming to a prober that the id is live.
+      let transport: StreamableHTTPServerTransport | undefined =
+        entry && entry.owner === callerClientId ? entry.transport : undefined;
+      if (entry && entry.owner !== callerClientId) {
+        logger.warn(
+          `Rejected session ${sid} presented by ${callerClientId}: owned by a different OAuth client`,
+          "HTTPTransport",
+        );
+      }
 
       if (!transport) {
         // No existing session. Only an `initialize` POST may open one.
         if (req.method === "POST" && isInitializeRequest(body)) {
+          const owner = callerClientId;
           const created = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
-            onsessioninitialized: (newId) => { sessions.set(newId, created); },
+            onsessioninitialized: (newId) => { sessions.set(newId, { transport: created, owner }); },
           });
           created.onclose = () => { if (created.sessionId) sessions.delete(created.sessionId); };
           const mcp = opts.createServer ? opts.createServer() : opts.server;
@@ -566,8 +587,8 @@ export async function startHttpTransport(opts: HttpTransportOptions): Promise<Ht
     close: async () => {
       clearInterval(sweep);
       unsubGrantChanges();
-      for (const t of sessions.values()) {
-        try { await t.close(); } catch { /* best effort */ }
+      for (const { transport } of sessions.values()) {
+        try { await transport.close(); } catch { /* best effort */ }
       }
       sessions.clear();
       await new Promise<void>((resolve) => server.close(() => resolve()));


### PR DESCRIPTION
> Stacked on #262 (base is `chore/deps-security-2026-07`, since the pre-push audit gate blocks any branch built on main's current lockfile). Retarget to `main` once #262 lands.

## The defect

`src/transports/http.ts` kept one transport per MCP session in a map keyed by
`Mcp-Session-Id` **alone**, with no record of who opened it. Any *other*
authenticated agent — one holding its own valid, approved token — could present
a peer's session id and be routed straight to that peer's transport:

| Method | Effect on the peer's session |
|---|---|
| `GET` | attaches to the peer's server→client **SSE stream** |
| `DELETE` | tears the peer's session **down** |
| `POST` | drives the peer's per-session MCP `Server` instance |

The MCP security model is explicit on this point: servers **MUST NOT** treat
possession of a state handle as authentication, and **SHOULD** bind handles
server-side to the authenticated principal.

## Scope — what this is not

Tool-layer permissions were never bypassed. `runWithCaller` resolves the caller
per *request*, not per session, so the grant gate and the audit log still
attribute every tool call to the real caller's `client_id`. That bounds the
impact to **cross-agent stream disclosure and denial of service** between two
already-approved agents, rather than privilege escalation. It is still a session
hijack and still worth closing.

## The fix

Each entry now records the `client_id` that opened the session. An id presented
by a non-owner is treated as if it did not exist — that refuses the request and
avoids confirming to a prober that the id is live. The rejection is logged.

## Verification

Four regression tests (`session ownership (XPORT-016)`): non-owner `POST`, `GET`,
and `DELETE`, plus an owner no-regression control.

I verified the tests are not vacuous by reverting the ownership check and
re-running: **3 of the 4 fail** (the 4th is the owner control, which correctly
passes either way). With the fix restored, the full suite is **2863 passing**
across 134 files, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)