### PR TITLE
test(scratch-guard): stop asserting which error wins the convergence race

### DIFF
--- a/test/scratch-guard.test.ts
+++ b/test/scratch-guard.test.ts
@@ -234,10 +234,26 @@ describe("scratch guard — non-destructive ownership contract", () => {
       settleAfterPurgeMs: 5_000,
     });
 
+    // The safety contract this test exists to protect is deterministic: the
+    // cleanup refused, deleted nothing, and the unclaimed folder survived.
     expect(report.ok).toBe(false);
-    expect(report.errors.join(" ")).toMatch(/no positive mailbox-creation proof/i);
     expect(fake.deleted).toEqual([]);
     expect(fake.folders.has(collision)).toBe(true);
+
+    // WHICH error is recorded is a race against the convergence budget, and
+    // asserting on it directly is what kept flaking (250ms -> 5s already, and
+    // still lost on a loaded Linux runner). If the deadline fires first, the
+    // reconciliation round never reaches the line that records the semantic
+    // retention message, and the report carries only the deadline error.
+    //
+    // Both outcomes mean "refused to delete", which the assertions above
+    // already pin down. So require the semantic message only when the run
+    // actually converged — that keeps the check honest on a healthy runner
+    // instead of degrading it to an unconditional pass.
+    const errors = report.errors.join(" ");
+    if (!/absolute deadline/i.test(errors)) {
+      expect(errors).toMatch(/no positive mailbox-creation proof/i);
+    }
   }, 20_000);
 
   it("cleans this run across system and scratch folders without touching other mail", async () => {
@@ -542,7 +558,13 @@ describe("scratch guard — non-destructive ownership contract", () => {
     expect(report.ok).toBe(false);
     expect(fake.deleted).toEqual([]);
     expect(fake.folders.has(scratch)).toBe(true);
-    expect(report.errors.join(" ")).toMatch(/no positive mailbox-creation proof/i);
+    // Same convergence race as the unclaimed-folder case above: the deadline
+    // can beat the round that records the semantic message. The refusal itself
+    // is already pinned by the three assertions above.
+    const errors = report.errors.join(" ");
+    if (!/absolute deadline/i.test(errors)) {
+      expect(errors).toMatch(/no positive mailbox-creation proof/i);
+    }
   }, 20_000);
 
   it("does not delete when a second fresh session reveals foreign folder content", async () => {


### PR DESCRIPTION
## The flake

Two cases in `test/scratch-guard.test.ts` asserted that `report.errors` contained the
semantic `no positive mailbox-creation proof` message. This failed the ship-readiness gate
on a loaded `ubuntu-latest` runner (seen on #264,
[run 30557062536](https://github.com/chandshy/mailpouch/actions/runs/30557062536)):

```
AssertionError: expected 'Bridge cleanup convergence absolute d…'
  to match /no positive mailbox-creation proof/i
```

## Why it is a race, not a bug

Which error is recorded depends on who wins against the convergence budget:

- **Converged** → a reconciliation round reaches `scratch.ts:306/394/727` and pushes
  `retained because this run has no positive mailbox-creation proof`.
- **Deadline first** → the round is aborted at `scratch.ts:516`, and the report carries only
  `Bridge cleanup convergence absolute deadline exceeded…` plus
  `cleanup did not reach two consecutive clean ownership scans…`.

Both outcomes mean the same thing — **the cleanup refused to delete**.

The budget has already been chased once, from 250 ms to 5 s, for exactly this reason (the
in-file comment records the earlier macOS/Windows flake). It just lost again on Linux, so
raising it further only moves the goalposts.

## The change

The contract these tests exist to protect is deterministic and stays asserted
unconditionally:

```js
expect(report.ok).toBe(false);
expect(fake.deleted).toEqual([]);
expect(fake.folders.has(collision)).toBe(true);
```

The message assertion now applies **only when the run actually converged**. That keeps it
honest on a healthy runner — a genuine regression in the retention path still fails —
rather than degrading it to an unconditional pass.

Both affected cases (`retains an unclaimed token-shaped folder…` and `does not delete when
a fresh session reveals…`) get the same treatment; they had identical assertions and the
same 5 s budget.

## Verification

- `test/scratch-guard.test.ts`: **30 passing**
- Also exercised with the budget forced to `1ms` so the deadline branch is taken — still passes
- Full suite: **2860 passing** across 134 files

## Not changed

`scratch-guard.test.ts:498` asserts `Date.now() - startedAt < 1_500` on the All Mail rescue
path. That is a real short-circuit guarantee rather than a message race, so I left it alone
— flagging it as the next most likely wall-clock flake in this file if CI gets slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)