### PR TITLE
release: explicit, recorded Bridge E2E waiver for manual dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,13 @@ on:
         description: Existing v<package-version> tag to publish
         required: true
         type: string
+      waive_bridge_e2e:
+        description: >-
+          Publish WITHOUT live Proton Bridge E2E evidence. Only for releases where no
+          disposable Bridge account is available. CI and preship attestations still apply.
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   verify-release:
@@ -44,6 +51,9 @@ jobs:
         GITHUB_API_URL: ${{ github.api_url }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         GITHUB_TOKEN: ${{ github.token }}
+        # Only ever set by an explicit manual dispatch — the `release: published`
+        # trigger has no inputs, so that path can never waive.
+        MAILPOUCH_WAIVE_BRIDGE_E2E: ${{ inputs.waive_bridge_e2e }}
       run: node scripts/check-release-attestations.mjs "$COMMIT_SHA"
 
     - name: Use Node.js

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,6 +33,32 @@ local Proton Bridge E2E, then posts `success`/`failure` for `HEAD`. It scrubs
 > **must** point at a disposable Proton account — never a real mailbox. There is currently no
 > disposable account provisioned on this machine; the `~/.mailpouch-e2e-*.json` files are
 > leftover harness configs derived from the live account, **not** safe targets.
+>
+> This is not theoretical: the v3.2.0 attestation run (2026-07-14) was pointed at the live
+> mailbox and left 13 `mpE2E-*` scratch mailboxes behind, which were still there on
+> 2026-07-30 and had to be cleaned up by hand.
+
+Note this is a **local, manual** step — there is no `bridge-e2e` workflow. A commit therefore
+has *no* Bridge status until someone runs the script against that exact SHA. "Missing status"
+means the E2E never ran for those bytes, which is different from the E2E failing.
+
+### Waiving the Bridge E2E
+
+When no disposable account is available, a release can be published without Bridge evidence —
+but only as a deliberate, recorded act:
+
+```bash
+gh workflow run publish.yml -f release_tag=vX.Y.Z -f waive_bridge_e2e=true
+```
+
+The waiver is a **`workflow_dispatch` input only**. It is not a repo variable and not a
+default, so it shows up in the run's inputs and cannot become ambient state that quietly
+erodes the gate. The `release: published` trigger has no inputs, so the automatic path stays
+strict. CI and preship attestations are **never** waivable.
+
+Do **not** hand-POST a green `proton-bridge-e2e` status instead. That would make the gate look
+satisfied while proving nothing, and would devalue every future release's attestation. Waiving
+prints a loud `release-attestation WAIVED` line in the job log; forging prints `OK`.
 
 ## npm authentication — trusted publishing (OIDC)
 

--- a/scripts/check-release-attestations.mjs
+++ b/scripts/check-release-attestations.mjs
@@ -51,8 +51,27 @@ for (const workflow of REQUIRED_RELEASE_WORKFLOWS) {
   );
 }
 
-const combinedStatus = await github(`/commits/${sha}/status?per_page=100`);
-const bridge = requireSuccessfulBridgeStatus({ expectedSha: sha, combinedStatus });
-process.stdout.write(
-  `release-attestation OK: Proton Bridge E2E (${bridge.url ?? "no URL"})\n`,
-);
+// The Bridge E2E attestation can be waived, but ONLY by an explicit act at
+// release time — `waive_bridge_e2e: true` on a manual workflow_dispatch. It is
+// deliberately not a repo variable or a default: a waiver has to be a decision
+// someone makes and that shows up in the run's inputs, not ambient state that
+// quietly erodes the gate. The `release: published` trigger cannot set it, so
+// the normal path stays strict.
+//
+// The alternative — hand-POSTing a green `proton-bridge-e2e` status — is worse
+// in the way that matters: it makes every future release's attestation
+// unfalsifiable-looking but meaningless. Waiving loudly keeps the signal honest.
+//
+// CI and preship attestations above are NEVER waivable.
+if (process.env.MAILPOUCH_WAIVE_BRIDGE_E2E === "true") {
+  process.stdout.write(
+    "release-attestation WAIVED: Proton Bridge E2E was explicitly waived for this release " +
+      `(commit ${sha}). No live Proton Bridge evidence exists for these bytes.\n`,
+  );
+} else {
+  const combinedStatus = await github(`/commits/${sha}/status?per_page=100`);
+  const bridge = requireSuccessfulBridgeStatus({ expectedSha: sha, combinedStatus });
+  process.stdout.write(
+    `release-attestation OK: Proton Bridge E2E (${bridge.url ?? "no URL"})\n`,
+  );
+}


### PR DESCRIPTION
Unblocks the v3.2.1 release. No disposable Proton account is available, so there is no way to produce Bridge evidence for the release SHA.

## First, the premise

**Nothing is failing on the Bridge E2E.** The status is *missing*, not failed:

```
Error: Missing mailpouch/proton-bridge-e2e status for release commit c2e422e...
```

There is no `bridge-e2e` workflow — it's a **local, manual** script (`attest-bridge-e2e.mjs`) that runs the full destructive Bridge E2E and then posts the status. A commit has no Bridge status until someone runs it against that exact SHA. It last ran successfully for **v3.2.0 on 2026-07-14** (`mailpouch/proton-bridge-e2e=success`), so the machinery works — it simply has never been pointed at these bytes.

## Why not just post the status

Because it takes ten seconds and it would be the worst possible outcome. A forged green status makes the gate *look* satisfied while proving nothing, and quietly devalues every future release's attestation — including ones where the E2E really did run. The gate's only value is that a green status means the E2E executed.

## The approach

Make waiving explicit, narrow, and loud:

- `waive_bridge_e2e` is a **`workflow_dispatch` input only** — not a repo variable, not a default. It appears in the run's recorded inputs and can't decay into ambient state that erodes the gate over time.
- The **`release: published` trigger has no inputs**, so the automatic path stays strict permanently.
- The checker logs `release-attestation WAIVED: ... No live Proton Bridge evidence exists for these bytes` — the log distinguishes a waiver from a pass. Forging prints `OK`; waiving cannot be mistaken for evidence.
- Strict `=== "true"` compare, so a stray truthy value doesn't silently waive.
- **CI and preship attestations remain non-waivable.**

## Verified — all three paths, against the real release SHA

| Case | Result |
|---|---|
| waiver off | still fails on the missing status ✅ |
| `MAILPOUCH_WAIVE_BRIDGE_E2E=true` | passes, logs `WAIVED` ✅ |
| `MAILPOUCH_WAIVE_BRIDGE_E2E=yes` | still fails — not truthy-coerced ✅ |

CI and preship both reported `OK` in every case, confirming only the Bridge branch is affected.

## Docs

`docs/releasing.md` gains the waiver procedure, and records why the disposable-account rule exists in concrete terms: the v3.2.0 attestation run was pointed at the live mailbox and left **13 `mpE2E-*` scratch mailboxes** behind, still present on 2026-07-30 and cleaned up by hand.

## Release command

```bash
gh workflow run publish.yml -f release_tag=v3.2.1 -f waive_bridge_e2e=true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)