### PR TITLE
fix(ci): build arm64 Linux and Intel macOS prebuilts on runners that exist (closes #266)

### DIFF
--- a/.github/workflows/build-native-tray.yml
+++ b/.github/workflows/build-native-tray.yml
@@ -44,10 +44,11 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             arch_label: linux-x64-gnu
+          # Built NATIVELY on an arm64 runner, not cross-compiled. See the
+          # build-deps step below for why the cross-compile approach was dropped.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             arch_label: linux-arm64-gnu
-            cross: true
           - target: x86_64-apple-darwin
             os: macos-13   # last Intel runner GitHub provides
             arch_label: darwin-x64
@@ -80,55 +81,33 @@ jobs:
       # Linux: dev headers required by tray-icon's C deps. Only
       # affects the build; end users don't need -dev packages,
       # just the runtime libs (which Ubuntu/Fedora ship by default).
-      - name: Install Linux build deps (x86_64)
-        if: matrix.os == 'ubuntu-latest' && matrix.target == 'x86_64-unknown-linux-gnu'
+      #
+      # Both Linux targets install the SAME packages natively — x86_64 on
+      # ubuntu-latest, arm64 on the ubuntu-24.04-arm runner. There is no
+      # cross-compilation.
+      #
+      # This previously cross-compiled arm64 from an amd64 runner by adding
+      # ports.ubuntu.com as an arm64 source and installing `:arm64` packages
+      # alongside the host's amd64 ones. That is inherently fragile: shared
+      # libraries like libssl3t64 are `Multi-Arch: same`, so apt requires the
+      # :amd64 and :arm64 copies to be the *identical version* — but amd64
+      # comes from archive.ubuntu.com and arm64 from ports.ubuntu.com, and the
+      # two mirrors publish security/updates pockets at different times. Any
+      # skew makes the arm64 dependency chain unsatisfiable and the job dies
+      # with "held broken packages" (see #266):
+      #
+      #   libkrb5-3:arm64 : Depends: libssl3t64:arm64 (>= 3.0.0)
+      #                     but it is not installable
+      #
+      # Nothing in this repo could fix that — it is a function of upstream
+      # mirror timing, which is why the job flapped rather than failing
+      # consistently. Building on a native arm64 runner removes the split
+      # entirely: one architecture, one mirror, no version matching.
+      - name: Install Linux build deps
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
-
-      # arm64 Linux: cross-compile via the standard
-      # `aarch64-linux-gnu-gcc` toolchain. Ubuntu's default APT mirror
-      # only carries amd64 binaries — for foreign-arch packages we
-      # have to point apt at ports.ubuntu.com (where Canonical mirrors
-      # arm64 / armhf / ppc64el / s390x). Without this the apt-get
-      # update step 404s on every arm64 Packages file.
-      - name: Install Linux build deps (arm64 cross)
-        if: matrix.cross
-        run: |
-          set -e
-          # Restrict the existing default sources to amd64-only so apt
-          # doesn't try to fetch arm64 from archive.ubuntu.com (which
-          # doesn't host them).
-          sudo sed -i 's/^Types: deb$/Types: deb\nArchitectures: amd64/' /etc/apt/sources.list.d/ubuntu.sources || true
-          # Add ports.ubuntu.com as the arm64 source.
-          sudo tee /etc/apt/sources.list.d/arm64-ports.sources >/dev/null <<'EOF'
-          Types: deb
-          URIs: http://ports.ubuntu.com/ubuntu-ports
-          Suites: noble noble-updates noble-security noble-backports
-          Components: main universe restricted multiverse
-          Architectures: arm64
-          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-          EOF
-          sudo dpkg --add-architecture arm64
-          sudo apt-get update
-          # Ubuntu 24.04 Noble split libglib2.0-dev-bin into two packages:
-          # libglib2.0-dev-bin and libglib2.0-dev-bin-linux. Both are
-          # Architecture: all, but apt's cross-arch solver fails with
-          # "held broken packages" when trying to satisfy
-          # libglib2.0-dev:arm64 → libglib2.0-dev-bin-linux:arm64 if the
-          # arch-all packages aren't already installed. Install them first
-          # (as amd64/all) so the arm64 dep chain resolves.
-          sudo apt-get install -y libglib2.0-dev-bin libglib2.0-dev-bin-linux
-          sudo apt-get install -y --allow-change-held-packages \
-            gcc-aarch64-linux-gnu \
-            libgtk-3-dev:arm64 libayatana-appindicator3-dev:arm64 libxdo-dev:arm64
-          mkdir -p ~/.cargo
-          cat >> ~/.cargo/config.toml <<EOF
-          [target.aarch64-unknown-linux-gnu]
-          linker = "aarch64-linux-gnu-gcc"
-          EOF
-          echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-          echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
       - name: Install napi-rs CLI
         working-directory: native/tray

--- a/.github/workflows/build-native-tray.yml
+++ b/.github/workflows/build-native-tray.yml
@@ -49,8 +49,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
             arch_label: linux-arm64-gnu
+          # Cross-compiled from the arm64 macOS runner. GitHub retired the
+          # macos-13 Intel image, and that label no longer schedules at all —
+          # this job sat queued forever (never once completed) and left the
+          # whole workflow permanently incomplete. Unlike the Linux case this
+          # cross-compile is safe and first-class: the macOS SDK ships both
+          # slices and Apple's clang targets x86_64 from Apple silicon
+          # natively, so no foreign sysroot or package mixing is involved.
           - target: x86_64-apple-darwin
-            os: macos-13   # last Intel runner GitHub provides
+            os: macos-latest
             arch_label: darwin-x64
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
Fixes #266, and a second failure found while verifying it. **All six targets now build — the first time this workflow has ever completed.**

## 1. arm64 Linux — #266

The job cross-compiled arm64 from an amd64 runner by adding `ports.ubuntu.com` as an arm64 source and installing `:arm64` packages beside the host's amd64 ones. That is **not fixable from inside this repo**: shared libraries like `libssl3t64` are `Multi-Arch: same`, so apt requires the `:amd64` and `:arm64` copies to be the *identical version* — but amd64 resolves from `archive.ubuntu.com` and arm64 from `ports.ubuntu.com`, and the two mirrors publish their updates/security pockets at different times. Any skew makes the arm64 chain unsatisfiable:

```
libkrb5-3:arm64 : Depends: libssl3t64:arm64 (>= 3.0.0) but it is not installable
E: Unable to correct problems, you have held broken packages.
```

That timing dependence is why it *flapped* rather than failing consistently.

GitHub now provides free `ubuntu-24.04-arm` runners for public repos, so the split is **removed rather than patched** — one architecture, one mirror, no cross-arch version matching.

*Ruled out along the way:* the hardcoded `noble` suite was **not** the cause. `ubuntu-latest` is still 24.04.4, verified against a live runner before changing anything.

## 2. Intel macOS — never ran at all

`x86_64-apple-darwin` has **never completed**. Across the last six runs it sat queued indefinitely five times and was cancelled once: GitHub retired the `macos-13` Intel image, so that label no longer schedules. The job could never start, and the workflow could never reach a conclusion — which is also why its overall status was worthless as a signal.

Now built from `macos-latest`. Unlike the Linux case this cross-compile is **first-class, not a workaround**: the macOS SDK ships both slices and Apple's clang targets x86_64 from Apple silicon natively. No foreign sysroot, no second mirror, no `Multi-Arch` matching — none of what made the Linux cross-compile fragile applies here.

## Net effect

The bespoke 25-line arm64 apt dance is gone, along with `gcc-aarch64-linux-gnu`, the `~/.cargo` linker override, and the `PKG_CONFIG_ALLOW_CROSS` / `PKG_CONFIG_PATH` exports. Both Linux legs now share the same three-package native install the x86_64 leg already used. The `cross` matrix flag has no remaining consumers and is dropped.

## Verification

Live run on this branch — **6/6 green, workflow conclusion `success`**:

| target | runner | result |
|---|---|---|
| `x86_64-unknown-linux-gnu` | ubuntu-latest | ✅ |
| `aarch64-unknown-linux-gnu` | **ubuntu-24.04-arm** | ✅ |
| `x86_64-apple-darwin` | **macos-latest** | ✅ |
| `aarch64-apple-darwin` | macos-latest | ✅ |
| `x86_64-pc-windows-msvc` | windows-latest | ✅ |
| `aarch64-pc-windows-msvc` | windows-latest | ✅ |

Each job also passes the existing "Verify .node was produced" step, so these are real artifacts, not just green boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)