### PR TITLE
fix(improvement-loop): wait out transient lock contention instead of failing instantly

### DIFF
--- a/scripts/improvement-loop.mjs
+++ b/scripts/improvement-loop.mjs
@@ -39,6 +39,17 @@ const ITEM_STATUSES = new Set(["queued", "in_progress", "completed", "blocked"])
 const DEFAULT_CHECK_TIMEOUT_MS = 15 * 60 * 1000;
 const MAX_CHECK_TIMEOUT_MS = 4 * 60 * 60 * 1000;
 const LOCK_INITIALIZATION_GRACE_MS = 10 * 1000;
+/** How long to wait out a lock held by a live process before giving up. */
+const LOCK_CONTENTION_BUDGET_MS = 5 * 1000;
+/**
+ * Much shorter budget for a lock directory that exists but has no owner.json
+ * yet. That gap is the microseconds between one process's mkdir and its owner
+ * write — if the file has not appeared almost immediately, the writer died
+ * mid-initialization and waiting the full contention budget only delays a
+ * failure that is not going to resolve.
+ */
+const LOCK_INITIALIZING_WAIT_MS = 250;
+const LOCK_CONTENTION_POLL_MS = 25;
 
 function now() {
   return new Date().toISOString();
@@ -188,12 +199,38 @@ function readLockOwner(lockPath) {
   }
 }
 
+/** Block the calling thread. acquireLock is synchronous, so this cannot await. */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 function acquireLock(root, { initializing = false } = {}) {
   const p = initializing ? paths(root) : requireLayout(root);
   if (initializing) requireDirectory(p.directory, "Improvement-loop directory");
   const lockPath = p.lock;
   const token = randomUUID();
-  for (let attempt = 0; attempt < 4; attempt++) {
+  // Contention by a LIVE holder is transient and must be waited out, not
+  // failed on. Commands hold this lock only for short mutate() sections —
+  // `validate` in particular deliberately releases it while checks run — so a
+  // second command frequently arrives microseconds into someone else's
+  // critical section. The previous code failed instantly in that case: the
+  // retry loop looked like it handled contention, but every branch called
+  // fail(), which exits the process, so nothing was ever retried except an
+  // lstat error. That surfaced as a flaky "block exited 1" on loaded Windows
+  // CI runners, where the window between a snapshot becoming visible on disk
+  // and its writer releasing the lock is widest.
+  //
+  // Waiting is bounded so a genuinely long-running loop still reports the same
+  // "already running" error, just after a grace period instead of immediately.
+  const startedAt = Date.now();
+  const waitOrFail = (message, budgetMs) => {
+    if (Date.now() - startedAt < budgetMs) {
+      sleepSync(LOCK_CONTENTION_POLL_MS);
+      return;
+    }
+    fail(message);
+  };
+  for (;;) {
     try {
       mkdirSync(lockPath, { mode: 0o700 });
       const owner = { pid: process.pid, token, createdAt: now() };
@@ -209,6 +246,9 @@ function acquireLock(root, { initializing = false } = {}) {
       try {
         lockStat = lstatSync(lockPath);
       } catch {
+        // Released between mkdir and lstat — retry immediately, but still
+        // under the deadline so a pathological churn cannot spin forever.
+        waitOrFail("Could not acquire the improvement-loop lock.", LOCK_CONTENTION_BUDGET_MS);
         continue;
       }
       if (!lockStat.isDirectory() || lockStat.isSymbolicLink()) {
@@ -216,22 +256,24 @@ function acquireLock(root, { initializing = false } = {}) {
       }
       const owner = readLockOwner(lockPath);
       if (owner && isProcessAlive(owner.pid)) {
-        fail(`Improvement loop is already running (pid ${owner.pid}).`);
+        waitOrFail(`Improvement loop is already running (pid ${owner.pid}).`, LOCK_CONTENTION_BUDGET_MS);
+        continue;
       }
       // A process may have created the directory but not written owner.json.
       // Treat that short window as contended rather than deleting a live lock.
       if (!owner && Date.now() - lockStat.mtimeMs < LOCK_INITIALIZATION_GRACE_MS) {
-        fail("Improvement loop lock is being initialized; retry shortly.");
+        waitOrFail("Improvement loop lock is being initialized; retry shortly.", LOCK_INITIALIZING_WAIT_MS);
+        continue;
       }
       // Do not automatically reclaim a dead or malformed owner. Two
       // contenders can otherwise race between stale detection and replacement,
       // allowing one to remove the other's newly acquired lock. Failing closed
-      // leaves an operator an explicit, auditable recovery decision.
+      // leaves an operator an explicit, auditable recovery decision. This case
+      // is NOT retried — a stale lock never clears on its own.
       const detail = owner ? `stale owner pid ${owner.pid}` : "missing or invalid owner metadata";
       fail(`Improvement-loop lock has ${detail}. Confirm no loop process is running, then remove ${lockPath} manually before retrying.`);
     }
   }
-  fail("Could not acquire the improvement-loop lock.");
 }
 
 function normalizeCheck(value, itemId, index) {

--- a/test/improvement-loop.test.ts
+++ b/test/improvement-loop.test.ts
@@ -54,7 +54,7 @@ function auditPath(name: string): string {
   return join(".improvement-loop", "audits", name);
 }
 
-function makeItem(id: string, command = [process.execPath, "-e", "process.exit(0)"]) {
+function makeItem(id: string, command = [process.execPath, "-e", "process.exit(0)"], timeoutMs = 1_000) {
   return {
     id,
     priority: "P1",
@@ -62,7 +62,7 @@ function makeItem(id: string, command = [process.execPath, "-e", "process.exit(0
     area: "test",
     summary: `Exercise ${id} safely.`,
     acceptanceCriteria: ["A focused regression passes."],
-    validation: [{ label: "check", command, timeoutMs: 1_000 }],
+    validation: [{ label: "check", command, timeoutMs }],
     status: "queued",
     createdAt: "2026-07-11T00:00:00.000Z",
   };
@@ -87,7 +87,15 @@ async function waitFor(condition: () => boolean, timeoutMs = 3_000): Promise<voi
 }
 
 afterEach(() => {
-  for (const root of temporaryRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+  // maxRetries is load-bearing on Windows. These tests spawn real Node
+  // processes inside the temp root; a child that has just been killed or has
+  // just exited can still hold a handle briefly, and the directory removal
+  // then fails with `EBUSY: resource busy or locked, rmdir`, failing an
+  // otherwise-passing test from teardown. `force` only suppresses ENOENT, not
+  // EBUSY — retrying is Node's documented remedy for exactly this case.
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
 });
 
 describe("improvement-loop runner", () => {
@@ -227,17 +235,49 @@ describe("improvement-loop runner", () => {
   it("releases the state lock while validation runs, so a material blocker can win safely", async () => {
     const root = createRoot();
     expectOk(run(root, "init"));
-    const slow = [process.execPath, "-e", "setTimeout(() => process.exit(0), 1500)"];
-    const audit = writeAudit(root, "slow.json", [makeItem("LOOP-001", slow)]);
+
+    // The check blocks until the test creates this file, rather than sleeping
+    // for a fixed period. The old form slept 1500ms against a 1000ms validation
+    // timeout, so the "validation is still running" precondition held only by
+    // wall-clock luck. Gating on a file makes it true by construction on any
+    // runner at any speed, which is what this test actually needs to assert.
+    //
+    // (The flake this test exhibited on Windows CI was NOT caused by that
+    // window closing — it was `acquireLock` failing instantly when `validate`
+    // still held the lock. That is fixed in scripts/improvement-loop.mjs; this
+    // gate removes the remaining timing assumption rather than papering over it.)
+    //
+    // The self-imposed deadline is a backstop so a bug here can never hang the
+    // suite — it is not the mechanism, and is far longer than the gate ever
+    // stays closed in practice.
+    const release = join(root, "release-validation");
+    const gated = [
+      process.execPath,
+      "-e",
+      `const fs=require("node:fs");const f=${JSON.stringify(release)};` +
+        "const deadline=Date.now()+30000;" +
+        "(function poll(){ if (fs.existsSync(f) || Date.now() > deadline) process.exit(0); setTimeout(poll, 25); })();",
+    ];
+    const audit = writeAudit(root, "slow.json", [makeItem("LOOP-001", gated, 30_000)]);
     expectOk(run(root, "re-audit", "--audit", audit, "--summary", "Initial audit."));
     expectOk(run(root, "import", audit, "--approve-commands"));
     expectOk(run(root, "begin", "LOOP-001"));
 
     const validating = runAsync(root, "validate", "LOOP-001");
     await waitFor(() => Boolean(readSnapshot(root).state.validationRun));
+
+    // The check is still running and cannot finish yet, so this exercises the
+    // real property: the state lock is NOT held for the duration of validation.
     expectOk(run(root, "block", "LOOP-001", "--summary", "External dependency is unavailable."));
+
+    writeFileSync(release, "go");
     const result = await validating;
+
+    // Non-zero because the run is DISCARDED (the active item was blocked while
+    // checks ran), not because the check failed or timed out — the check now
+    // exits 0. See the `validation_discarded` path in scripts/improvement-loop.mjs.
     expect(result.code).not.toBe(0);
+    expect(result.stdout).toContain("Validation discarded");
     expect(readSnapshot(root).backlog.items[0].status).toBe("blocked");
     expect(readSnapshot(root).state.validationRun).toBeNull();
   });


### PR DESCRIPTION
Fixes the flaky `improvement-loop runner > releases the state lock while validation runs` failure that has blocked merges twice today (node 20 this morning, node 22 on #271).

**The test was reporting a real robustness bug in the runner.** It was not itself flaky.

## Root cause

`acquireLock` *looks* like it retries — it has a `for (attempt < 4)` loop — but **every branch inside calls `fail()`, which throws out of the process.** Nothing was ever retried except an `lstat` error. A command arriving while another held the lock died instantly with `Improvement loop is already running (pid …)`.

That is precisely what the test does. It waits until `validationRun` is visible in the snapshot, then runs `block`. But the snapshot is written **inside** `validate`'s first `mutate()` section and the lock is released *after* it — so there is always a window where the state is on disk but the lock is still held. On a loaded Windows runner (slow fsync/rename, Defender in the path) that window widens enough for `block` to land in it and exit 1 — the `expected 1 to be +0` on CI.

## Fix

Bounded waiting, split by case so each matches its actual physics:

| Case | Behaviour |
|---|---|
| Live holder | wait up to **5s** — transient, a real command is mid-work |
| Lock dir with no `owner.json` | wait only **250ms** — that gap is the microseconds between `mkdir` and the owner write; if it hasn't appeared the writer died and waiting cannot help |
| Stale / malformed owner | **unchanged** — still fails closed immediately, since a stale lock never clears on its own |

That last row matters: the existing fail-closed design (deliberate, so two contenders can't race between stale detection and replacement) is preserved exactly.

## Verified both directions

Against a lock held by a genuinely live process and released after 1.2s:

```
old code: exit 1 after   30ms   ("already running")
new code: exit 0 after  842ms   (waited, then proceeded)
```

And with a lock that is **never** released, it still fails — bounded at ~5.0s, no hang.

## Two further fixes in the test itself

- The check now **blocks on a file the test creates** instead of sleeping 1500ms against a 1000ms validation timeout, so "validation is still running" is true *by construction* on any runner rather than by wall-clock luck.
- `afterEach` passes `maxRetries`/`retryDelay` to `rmSync`. These tests spawn real Node processes inside the temp root, and one that has just exited can still hold a handle — the separate `EBUSY: resource busy or locked, rmdir` teardown failure seen this morning. `force` suppresses `ENOENT`, not `EBUSY`; retrying is Node's documented remedy.

## Note on process

My first diagnosis was wrong — I assumed the 1000ms validation window was closing before `block` could spawn. I tested it by injecting a 3s delay before `block`: **the old test still passed**, refuting that theory, which is what sent me to `acquireLock` and the real cause. The gate change is kept because it removes a genuine timing assumption, but it is not what fixed the flake, and its comment says so.

## Verification

typecheck clean · **2864 tests passing** (134 files) · the previously-flaky file run repeatedly, green each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)