### PR TITLE
chore(deps): clear all npm audit findings, bump imapflow to 1.6.5

### DIFF
--- a/LICENSES.json
+++ b/LICENSES.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-30",
-  "rootPackage": "mailpouch@3.2.0",
+  "generatedAt": "2026-08-05",
+  "rootPackage": "mailpouch@3.2.1",
   "deps": [
     {
       "name": "@hono/node-server",
@@ -289,7 +289,7 @@
     },
     {
       "name": "fast-uri",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "license": "BSD-3-Clause"
     },
     {
@@ -369,7 +369,7 @@
     },
     {
       "name": "hono",
-      "version": "4.12.27",
+      "version": "4.13.0",
       "license": "MIT"
     },
     {
@@ -399,7 +399,7 @@
     },
     {
       "name": "imapflow",
-      "version": "1.6.1",
+      "version": "1.6.5",
       "license": "MIT"
     },
     {
@@ -414,7 +414,7 @@
     },
     {
       "name": "ip-address",
-      "version": "10.2.0",
+      "version": "10.4.0",
       "license": "MIT"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "better-sqlite3": "^12.11.1",
-        "imapflow": "^1.6.1",
+        "imapflow": "^1.6.5",
         "mailparser": "^3.9.14",
         "nodemailer": "~9.0.1"
       },
@@ -1674,9 +1674,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "funding": [
         {
           "type": "github",
@@ -1903,9 +1903,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2025,9 +2025,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/imapflow": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.6.1.tgz",
-      "integrity": "sha512-lBkh0ZcKeYHDS3sWfxEcD7j24frrrn4wtbe0UUtLqdLwMSvm9Mygx8j7ZtzWgnvqI7V1DkNfcsidJ/qasb7FBA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.6.5.tgz",
+      "integrity": "sha512-5XgLcfl6blDju2SP7TgTv4WIlTt7zxXYcfjznJFmfFrogHR2XzHGlS9s2wdqxv9ZJ5CPaRnig7KaK7qNoJPmlg==",
       "license": "MIT",
       "dependencies": {
         "@zone-eu/mailsplit": "5.4.14",
@@ -2053,9 +2053,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2875,9 +2875,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2895,7 +2895,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
     "better-sqlite3": "^12.11.1",
-    "imapflow": "^1.6.1",
+    "imapflow": "^1.6.5",
     "mailparser": "^3.9.14",
     "nodemailer": "~9.0.1"
   },


### PR DESCRIPTION
## Why every open PR was red

The `ship-readiness gate` was failing on **all three** open dependabot PRs, and the failure had nothing to do with their contents. `npm-audit` in `preship:fast` had started picking up newly published advisories against transitive deps:

| Package | Severity | Advisory |
|---|---|---|
| `fast-uri` <4.1.2 | HIGH | host confusion via backslash authority introducer |
| `ip-address` <=10.3.0 | HIGH | leading-zero octet / CIDR suffix / NAT64 SSRF + trust-boundary bypasses |
| `hono` <4.12.34 | MODERATE | ReDoS in CORS middleware via `Access-Control-Request-Headers` |

`npm audit fix` clears all three (plus a `postcss` patch). `npm audit` now reports **0 vulnerabilities**.

## Also here

- `imapflow` 1.6.1 → 1.6.5, superseding #274.
- `LICENSES.json` refreshed. All four bumped packages keep their existing licenses (BSD-3-Clause / MIT) — no new obligations. Dependabot doesn't regenerate that inventory, which is the *second* reason its PRs gate red even once the audit is clean.

## Verification

`npm run preship:fast` passes locally end to end — typecheck, lint, version-sync, secrets, npm-audit, license-inv, build, unit, tarball-smoke.

Supersedes #274 and #275. #273 (better-sqlite3 13.x) is a separate call — it fails Node 20 on every platform, and `engines.node` is `>=20.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)