### PR TITLE
feat!: require Node 22, better-sqlite3 13.x, and authenticate the settings-UI probe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     #
     # Windows is pinned to 2022 rather than windows-latest. The latter moved to
     # Server 2025 / Visual Studio 2026, which node-gyp 10 cannot discover when
-    # better-sqlite3 needs a source build (for example when a fresh Node 20
+    # better-sqlite3 needs a source build (for example when a fresh Node
     # patch has no prebuilt binary). Windows 2022 supplies the supported VS
     # 2022 C++ toolchain while preserving the same win32-x64 coverage.
     #
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2022]
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     name: ${{ matrix.os }} / node ${{ matrix.node-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: '20.x'
+        node-version: '22.x'
         cache: 'npm'
 
     - name: Install dependencies without lifecycle scripts
@@ -96,11 +96,11 @@ jobs:
       with:
         ref: ${{ needs.verify-release.outputs.commit_sha }}
 
-    # Node 24 (not the 20.x the other jobs use) is REQUIRED here: npm trusted
-    # publishing needs npm >= 11.5.1 / Node >= 22.14.0 to speak OIDC. Node 20
-    # ships npm 10.x, which silently falls back to token auth. This pin is about
-    # the publish protocol only and is unrelated to the package's own
-    # `engines.node: >=20` support floor.
+    # Node 24 (not the 22.x the other jobs use) is REQUIRED here: npm trusted
+    # publishing needs npm >= 11.5.1 / Node >= 22.14.0 to speak OIDC. A 22.x
+    # line below that patch ships an npm that silently falls back to token
+    # auth. This pin is about the publish protocol only and is unrelated to
+    # the package's own `engines.node: >=22` support floor.
     - name: Use Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
@@ -183,7 +183,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
-        node-version: '20.x'
+        node-version: '22.x'
         registry-url: 'https://npm.pkg.github.com'
         cache: 'npm'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] — 2026-08-04
+
+### Breaking
+
+- **Node 20 is no longer supported. The minimum is now Node 22.** Node 20 reached end of life on 2026-04-30, so it stopped receiving security patches; shipping against it made the runtime the weakest link in an otherwise patched dependency tree. `engines.node` is now `>=22.0.0` and `engines.npm` is `>=10.0.0`. The CI matrix moves from Node 20/22 to 22/24. Users on Node 20 must upgrade Node; there is no code-level migration.
+
+### Security
+
+- Cleared three dependency advisories that had accumulated against transitive packages, all of which were failing the ship-readiness gate on every open PR:
+  - `fast-uri` <4.1.2 (HIGH) — host confusion via a backslash authority introducer.
+  - `ip-address` <=10.3.0 (HIGH) — leading-zero octets decoded as decimal where resolvers decode octal, a CIDR suffix suppressing special-use classification, and misclassified IPv4-mapped/NAT64 addresses. All three permit SSRF and trust-boundary bypasses.
+  - `hono` <4.12.34 (MODERATE) — ReDoS in the CORS middleware via `Access-Control-Request-Headers`.
+
+  `npm audit` now reports no findings.
+- Raised the `overrides` floors to the patched versions (`fast-uri` >=4.1.2, `hono` >=4.12.34, and a new `ip-address` >=10.4.0 entry) so a transitive cannot silently resolve back to a vulnerable release.
+
+### Changed
+
+- `better-sqlite3` 12.11.1 → 13.0.2. This is what forced the Node floor: 13.x refuses to install on Node 20.
+- `imapflow` 1.6.1 → 1.6.5, `nodemailer` 9.0.3 → 9.0.4, `@types/better-sqlite3` 7.6.13 → 9.6.0.
+
 ## [3.2.1] — 2026-07-30
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- The settings-UI singleton probe now authenticates the listener it defers to. Previously `_probeExistingMailpouchUi` treated *any* process answering `GET /api/status` with a boolean `hasConfig` field as a genuine mailpouch settings UI, and permanently adopted its URL. Since a response shape is trivial to forge, whoever bound the settings port first became the address mailpouch advertised through the tray and to agents — which is where the user is asked to type their Bridge password. The real UI now publishes a 256-bit nonce beside the config at `0o600` and echoes it on `/api/status`; the probe compares it constant-time and binds its own server on any mismatch. This closes the case of a *different* local user or a sandboxed process, which can bind loopback but cannot read the config. It does not (and cannot) defend against an attacker already running as the config's owner, who has the config and keyring regardless.
+
+  Mixed-version note: a v4 process will not reuse a pre-v4 `mailpouch-settings` daemon, because the older daemon publishes no nonce. It falls back to binding its own port, so you may briefly see two settings UIs until both are upgraded.
 - Cleared three dependency advisories that had accumulated against transitive packages, all of which were failing the ship-readiness gate on every open PR:
   - `fast-uri` <4.1.2 (HIGH) — host confusion via a backslash authority introducer.
   - `ip-address` <=10.3.0 (HIGH) — leading-zero octets decoded as decimal where resolvers decode octal, a CIDR suffix suppressing special-use classification, and misclassified IPv4-mapped/NAT64 addresses. All three permit SSRF and trust-boundary bypasses.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to mailpouch! This document provides
 
 ### Prerequisites
 
-- Node.js 20.0.0 or higher
+- Node.js 22.0.0 or higher
 - npm 9.0.0 or higher
 - Proton Mail account with Proton Bridge installed
 - Git

--- a/LICENSES.json
+++ b/LICENSES.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "2026-08-05",
-  "rootPackage": "mailpouch@3.2.1",
+  "rootPackage": "mailpouch@4.0.0",
   "deps": [
     {
       "name": "@hono/node-server",
@@ -63,33 +63,13 @@
       "license": "MIT"
     },
     {
-      "name": "base64-js",
-      "version": "1.5.1",
-      "license": "MIT"
-    },
-    {
       "name": "better-sqlite3",
-      "version": "12.11.1",
-      "license": "MIT"
-    },
-    {
-      "name": "bindings",
-      "version": "1.5.0",
-      "license": "MIT"
-    },
-    {
-      "name": "bl",
-      "version": "4.1.0",
+      "version": "13.0.2",
       "license": "MIT"
     },
     {
       "name": "body-parser",
       "version": "2.3.0",
-      "license": "MIT"
-    },
-    {
-      "name": "buffer",
-      "version": "5.7.1",
       "license": "MIT"
     },
     {
@@ -106,11 +86,6 @@
       "name": "call-bound",
       "version": "1.0.4",
       "license": "MIT"
-    },
-    {
-      "name": "chownr",
-      "version": "1.1.4",
-      "license": "ISC"
     },
     {
       "name": "content-disposition",
@@ -153,16 +128,6 @@
       "license": "MIT"
     },
     {
-      "name": "decompress-response",
-      "version": "6.0.0",
-      "license": "MIT"
-    },
-    {
-      "name": "deep-extend",
-      "version": "0.6.0",
-      "license": "MIT"
-    },
-    {
       "name": "deepmerge-ts",
       "version": "7.1.5",
       "license": "BSD-3-Clause"
@@ -171,11 +136,6 @@
       "name": "depd",
       "version": "2.0.0",
       "license": "MIT"
-    },
-    {
-      "name": "detect-libc",
-      "version": "2.1.2",
-      "license": "Apache-2.0"
     },
     {
       "name": "dom-serializer",
@@ -215,11 +175,6 @@
     {
       "name": "encoding-japanese",
       "version": "2.2.0",
-      "license": "MIT"
-    },
-    {
-      "name": "end-of-stream",
-      "version": "1.4.5",
       "license": "MIT"
     },
     {
@@ -268,11 +223,6 @@
       "license": "MIT"
     },
     {
-      "name": "expand-template",
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)"
-    },
-    {
       "name": "express",
       "version": "5.2.1",
       "license": "MIT"
@@ -293,11 +243,6 @@
       "license": "BSD-3-Clause"
     },
     {
-      "name": "file-uri-to-path",
-      "version": "1.0.0",
-      "license": "MIT"
-    },
-    {
       "name": "finalhandler",
       "version": "2.1.1",
       "license": "MIT"
@@ -310,11 +255,6 @@
     {
       "name": "fresh",
       "version": "2.0.0",
-      "license": "MIT"
-    },
-    {
-      "name": "fs-constants",
-      "version": "1.0.0",
       "license": "MIT"
     },
     {
@@ -335,11 +275,6 @@
     {
       "name": "get-proto",
       "version": "1.0.1",
-      "license": "MIT"
-    },
-    {
-      "name": "github-from-package",
-      "version": "0.0.0",
       "license": "MIT"
     },
     {
@@ -393,11 +328,6 @@
       "license": "MIT"
     },
     {
-      "name": "ieee754",
-      "version": "1.2.1",
-      "license": "BSD-3-Clause"
-    },
-    {
       "name": "imapflow",
       "version": "1.6.5",
       "license": "MIT"
@@ -405,11 +335,6 @@
     {
       "name": "inherits",
       "version": "2.0.4",
-      "license": "ISC"
-    },
-    {
-      "name": "ini",
-      "version": "1.3.8",
       "license": "ISC"
     },
     {
@@ -508,28 +433,8 @@
       "license": "MIT"
     },
     {
-      "name": "mimic-response",
-      "version": "3.1.0",
-      "license": "MIT"
-    },
-    {
-      "name": "minimist",
-      "version": "1.2.8",
-      "license": "MIT"
-    },
-    {
-      "name": "mkdirp-classic",
-      "version": "0.5.3",
-      "license": "MIT"
-    },
-    {
       "name": "ms",
       "version": "2.1.3",
-      "license": "MIT"
-    },
-    {
-      "name": "napi-build-utils",
-      "version": "2.0.0",
       "license": "MIT"
     },
     {
@@ -538,13 +443,18 @@
       "license": "MIT"
     },
     {
-      "name": "node-abi",
-      "version": "3.94.0",
+      "name": "node-addon-api",
+      "version": "8.9.1",
       "license": "MIT"
     },
     {
       "name": "nodemailer",
       "version": "9.0.3",
+      "license": "MIT-0"
+    },
+    {
+      "name": "nodemailer",
+      "version": "9.0.4",
       "license": "MIT-0"
     },
     {
@@ -618,11 +528,6 @@
       "license": "MIT"
     },
     {
-      "name": "prebuild-install",
-      "version": "7.1.3",
-      "license": "MIT"
-    },
-    {
       "name": "process-warning",
       "version": "5.0.0",
       "license": "MIT"
@@ -630,11 +535,6 @@
     {
       "name": "proxy-addr",
       "version": "2.0.7",
-      "license": "MIT"
-    },
-    {
-      "name": "pump",
-      "version": "3.0.4",
       "license": "MIT"
     },
     {
@@ -663,16 +563,6 @@
       "license": "MIT"
     },
     {
-      "name": "rc",
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)"
-    },
-    {
-      "name": "readable-stream",
-      "version": "3.6.2",
-      "license": "MIT"
-    },
-    {
       "name": "real-require",
       "version": "0.2.0",
       "license": "MIT"
@@ -685,11 +575,6 @@
     {
       "name": "router",
       "version": "2.2.0",
-      "license": "MIT"
-    },
-    {
-      "name": "safe-buffer",
-      "version": "5.2.1",
       "license": "MIT"
     },
     {
@@ -706,11 +591,6 @@
       "name": "selderee",
       "version": "0.12.0",
       "license": "MIT"
-    },
-    {
-      "name": "semver",
-      "version": "7.7.3",
-      "license": "ISC"
     },
     {
       "name": "send",
@@ -758,16 +638,6 @@
       "license": "MIT"
     },
     {
-      "name": "simple-concat",
-      "version": "1.0.1",
-      "license": "MIT"
-    },
-    {
-      "name": "simple-get",
-      "version": "4.0.1",
-      "license": "MIT"
-    },
-    {
       "name": "smart-buffer",
       "version": "4.2.0",
       "license": "MIT"
@@ -793,28 +663,8 @@
       "license": "MIT"
     },
     {
-      "name": "string_decoder",
-      "version": "1.3.0",
-      "license": "MIT"
-    },
-    {
-      "name": "strip-json-comments",
-      "version": "2.0.1",
-      "license": "MIT"
-    },
-    {
       "name": "systray2",
       "version": "2.1.4",
-      "license": "MIT"
-    },
-    {
-      "name": "tar-fs",
-      "version": "2.1.5",
-      "license": "MIT"
-    },
-    {
-      "name": "tar-stream",
-      "version": "2.2.0",
       "license": "MIT"
     },
     {
@@ -831,11 +681,6 @@
       "name": "toidentifier",
       "version": "1.0.1",
       "license": "MIT"
-    },
-    {
-      "name": "tunnel-agent",
-      "version": "0.6.0",
-      "license": "Apache-2.0"
     },
     {
       "name": "type-is",
@@ -855,11 +700,6 @@
     {
       "name": "unpipe",
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    {
-      "name": "util-deprecate",
-      "version": "1.0.2",
       "license": "MIT"
     },
     {

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v3.2.1-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v4.0.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-1.29+-green.svg)](https://github.com/modelcontextprotocol/sdk)
 [![Tests](https://img.shields.io/badge/tests-Vitest-brightgreen.svg)](#development)
@@ -113,8 +113,8 @@ With read-only permissions (the default), Claude can read, search, and analyse y
 
 | Requirement | Version | Notes |
 |---|---|---|
-| **Node.js** | >= 20.0.0 | Check with `node --version` · [nodejs.org](https://nodejs.org) |
-| **npm** | >= 9.0.0 | Bundled with Node.js |
+| **Node.js** | >= 22.0.0 | Check with `node --version` · [nodejs.org](https://nodejs.org) |
+| **npm** | >= 10.0.0 | Bundled with Node.js |
 | **Proton Bridge** | >= 3.22.0 | Must be running and signed in · [proton.me/mail/bridge](https://proton.me/mail/bridge) |
 | **Proton Mail account** | **Paid plan** | Bridge requires a paid Proton plan (Mail Plus, Unlimited, etc.) |
 | **MCP client** | Latest | Claude Desktop, Cline, or any MCP-compatible host · [claude.ai/download](https://claude.ai/download) |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -97,8 +97,8 @@ On <https://www.npmjs.com/package/mailpouch> → **Settings** → **Trusted Publ
 - `package.json` `repository.url` resolves to `chandshy/mailpouch`, which **must** match the
   trusted publisher exactly ✅
 - **Node 24.x in the publish job** ✅ — trusted publishing needs **npm ≥ 11.5.1 / Node ≥ 22.14.0**.
-  Node 20 ships npm 10.x and silently falls back to token auth. This is the one change that
-  is easy to miss.
+  A 22.x line below that patch ships an npm that silently falls back to token auth. This is the
+  one change that is easy to miss.
 - GitHub-hosted runner ✅ — self-hosted runners are not supported.
 
 ### Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "3.2.1",
+      "version": "4.0.0",
       "cpu": [
         "x64",
         "arm64"
@@ -20,17 +20,17 @@
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
-        "better-sqlite3": "^12.11.1",
+        "better-sqlite3": "^13.0.2",
         "imapflow": "^1.6.5",
         "mailparser": "^3.9.14",
-        "nodemailer": "~9.0.1"
+        "nodemailer": "^9.0.4"
       },
       "bin": {
         "mailpouch": "dist/index.js",
         "mailpouch-settings": "dist/settings-main.js"
       },
       "devDependencies": {
-        "@types/better-sqlite3": "^7.6.13",
+        "@types/better-sqlite3": "^9.6.0",
         "@types/node": "^26.1.2",
         "@types/nodemailer": "^8.0.1",
         "@vitest/coverage-v8": "^4.1.10",
@@ -39,8 +39,8 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20.0.0",
-        "npm": ">=9.0.0"
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
       },
       "optionalDependencies": {
         "@napi-rs/keyring": "~1.3.0",
@@ -793,9 +793,9 @@
       }
     },
     "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-ZEEwBSgMu7GYJOynoagg5X9JbxfL6dTJDsgViJIqh67jV44kyOr9RXfmFjLK5rzC4MWssP06t9hu/JwGDnUbCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1079,58 +1079,16 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
+      "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
+        "node": ">=22"
       }
     },
     "node_modules/body-parser": {
@@ -1168,30 +1126,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -1241,12 +1175,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -1339,30 +1267,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -1385,6 +1289,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1483,15 +1388,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1585,15 +1481,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/expect-type": {
@@ -1707,12 +1594,6 @@
         }
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1751,12 +1632,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -1833,12 +1708,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -2004,26 +1873,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/imapflow": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.6.5.tgz",
@@ -2044,12 +1893,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -2527,6 +2370,15 @@
         "tlds": "1.261.0"
       }
     },
+    "node_modules/mailparser/node_modules/nodemailer": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -2598,33 +2450,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2650,12 +2475,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2665,22 +2484,19 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.94.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
-      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+    "node_modules/node-addon-api": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.1.tgz",
+      "integrity": "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==",
       "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.4.tgz",
+      "integrity": "sha512-LmJNRVRtfSCULxcZpy0Cpg4WWenlUZ9+zbmTO+S7v9wD6XreYLjXRFtDjtV/4F0HT5p1GyZfA0Ux/myxHb18CQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -2903,33 +2719,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -2957,16 +2746,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
       }
     },
     "node_modules/punycode.js": {
@@ -3021,35 +2800,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/real-require": {
@@ -3120,26 +2870,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -3171,6 +2901,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3330,51 +3061,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-git-hooks": {
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.13.1.tgz",
@@ -3461,24 +3147,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3504,34 +3172,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
-      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/thread-stream": {
@@ -3616,18 +3256,6 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -3704,12 +3332,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "3.2.1",
+  "version": "4.0.0",
   "description": "mailpouch — lean, permission-gated MCP access to Proton Mail via Proton Bridge, with up to 86 tools, resources, and prompts.",
   "type": "module",
   "main": "dist/index.js",
@@ -77,8 +77,8 @@
     "url": "https://github.com/chandshy/mailpouch/issues"
   },
   "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=9.0.0"
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
   },
   "os": [
     "darwin",
@@ -91,17 +91,17 @@
   ],
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",
-    "better-sqlite3": "^12.11.1",
+    "better-sqlite3": "^13.0.2",
     "imapflow": "^1.6.5",
     "mailparser": "^3.9.14",
-    "nodemailer": "~9.0.1"
+    "nodemailer": "^9.0.4"
   },
   "optionalDependencies": {
     "@napi-rs/keyring": "~1.3.0",
     "systray2": "~2.1.4"
   },
   "devDependencies": {
-    "@types/better-sqlite3": "^7.6.13",
+    "@types/better-sqlite3": "^9.6.0",
     "@types/node": "^26.1.2",
     "@types/nodemailer": "^8.0.1",
     "@vitest/coverage-v8": "^4.1.10",
@@ -134,10 +134,11 @@
     "scripts/lib/cross-platform-spawn.mjs"
   ],
   "overrides": {
-    "hono": ">=4.12.25",
+    "hono": ">=4.12.34",
     "@hono/node-server": ">=1.19.13",
     "path-to-regexp": ">=8.4.2",
-    "fast-uri": ">=3.1.2"
+    "fast-uri": ">=4.1.2",
+    "ip-address": ">=10.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { homedir } from "os";
 import { createConnection } from "net";
 import { spawn } from "child_process";
 import { startSettingsServer } from "./settings/server.js";
+import { instanceIdMatches } from "./settings/instance-identity.js";
 import { openBrowser } from "./settings/tui.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -2652,8 +2653,9 @@ function _tickTrayHealth(): void {
 /**
  * Probe whether a mailpouch settings UI is already serving on `port`.
  * Returns the base URL if the port is occupied by another mailpouch UI
- * (identified by a valid `/api/status` response with the expected shape),
- * or null if the port is free or occupied by something else.
+ * (proved by a `/api/status` response echoing the instance nonce published
+ * beside the 0o600 config), or null if the port is free, occupied by
+ * something else, or occupied by a listener that cannot prove identity.
  *
  * Used so we can defer to a user-run `mailpouch-settings` daemon instead
  * of retrying + warning — the common "standalone settings UI plus stdio
@@ -2685,7 +2687,13 @@ async function _probeExistingMailpouchUi(port: number): Promise<string | null> {
         res.on("end", () => {
           try {
             const parsed = JSON.parse(body) as Record<string, unknown>;
-            if (typeof parsed.hasConfig === "boolean") {
+            // Identity is the nonce, NOT the shape. `hasConfig` is a boolean
+            // any listener can echo; deferring on it let whoever bound this
+            // port first become the URL we advertise to the tray and to
+            // agents — i.e. the page that asks for the Bridge password.
+            // instanceIdMatches reads the nonce from beside the 0o600 config,
+            // which a squatting process running as another user cannot read.
+            if (instanceIdMatches(parsed.instanceId)) {
               finish(`http://localhost:${port}`);
               return;
             }
@@ -2708,9 +2716,10 @@ async function _startSettingsServerDaemon(): Promise<void> {
 
   // If a user-run `mailpouch-settings` instance is already serving on the
   // configured port, reuse it silently rather than retry-and-warn. Probes with
-  // a short GET /api/status — any non-mailpouch listener (e.g. a stray
-  // `python3 -m http.server`) responds with a different shape and falls through
-  // to the bind-then-fallback path below.
+  // a short GET /api/status — any listener that cannot echo the instance nonce
+  // (a stray `python3 -m http.server`, or a process squatting the port to be
+  // mistaken for the settings UI) falls through to the bind-then-fallback path
+  // below, so we advertise a URL we are serving ourselves.
   const existing = await _probeExistingMailpouchUi(basePort);
   if (existing) {
     _settingsUrl      = existing;

--- a/src/settings/instance-identity.test.ts
+++ b/src/settings/instance-identity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The settings-UI singleton probe (src/index.ts) used to accept any local
+ * listener that answered GET /api/status with a boolean `hasConfig` field.
+ * Whoever bound the settings port first therefore became the URL mailpouch
+ * advertises to the tray and to agents — the page that asks for the Bridge
+ * password. These tests pin the replacement: identity is a nonce published
+ * beside the 0o600 config, not a forgeable response shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { homedir, platform } from "os";
+import { join } from "path";
+import { getConfigPath } from "../config/loader.js";
+import {
+  publishInstanceId,
+  currentInstanceId,
+  clearInstanceId,
+  instanceIdMatches,
+  instancePath,
+} from "./instance-identity.js";
+
+describe("settings instance identity", () => {
+  let directory: string;
+  let previousConfigPath: string | undefined;
+
+  beforeEach(() => {
+    // MAILPOUCH_CONFIG deliberately permits only paths below $HOME.
+    directory = mkdtempSync(join(homedir(), ".mailpouch-instance-test-"));
+    previousConfigPath = process.env.MAILPOUCH_CONFIG;
+    process.env.MAILPOUCH_CONFIG = join(directory, ".mailpouch.json");
+  });
+
+  afterEach(() => {
+    clearInstanceId();
+    if (previousConfigPath === undefined) delete process.env.MAILPOUCH_CONFIG;
+    else process.env.MAILPOUCH_CONFIG = previousConfigPath;
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("accepts the nonce the running instance published", () => {
+    const id = publishInstanceId();
+    expect(id).toBeTruthy();
+    expect(currentInstanceId()).toBe(id);
+    expect(instanceIdMatches(id)).toBe(true);
+  });
+
+  // The whole point: a squatter can echo any SHAPE it likes, but not the value.
+  it("rejects a listener that forges the response shape but not the nonce", () => {
+    publishInstanceId();
+    expect(instanceIdMatches("attacker-supplied")).toBe(false);
+    expect(instanceIdMatches(true)).toBe(false);
+    expect(instanceIdMatches(undefined)).toBe(false);
+    expect(instanceIdMatches(null)).toBe(false);
+    expect(instanceIdMatches("")).toBe(false);
+    expect(instanceIdMatches(1234)).toBe(false);
+    expect(instanceIdMatches({})).toBe(false);
+  });
+
+  // A same-length wrong value must not slip past the length pre-check into a
+  // timingSafeEqual that would throw and get swallowed as "true".
+  it("rejects a wrong nonce of exactly the right length", () => {
+    const id = publishInstanceId();
+    expect(id).toBeTruthy();
+    const sameLengthDecoy = "f".repeat(id!.length);
+    expect(sameLengthDecoy).toHaveLength(id!.length);
+    expect(sameLengthDecoy).not.toBe(id);
+    expect(instanceIdMatches(sameLengthDecoy)).toBe(false);
+  });
+
+  it("rejects everything when no instance has published — probe binds its own", () => {
+    expect(instanceIdMatches("anything")).toBe(false);
+    expect(currentInstanceId()).toBeNull();
+  });
+
+  it("stops matching a replayed nonce once the instance shuts down", () => {
+    const id = publishInstanceId();
+    expect(instanceIdMatches(id)).toBe(true);
+    clearInstanceId();
+    expect(instanceIdMatches(id)).toBe(false);
+    expect(currentInstanceId()).toBeNull();
+  });
+
+  it("publishes a distinct nonce per instance", () => {
+    const first = publishInstanceId();
+    const second = publishInstanceId();
+    expect(first).not.toBe(second);
+    // The superseded nonce must not still be honoured.
+    expect(instanceIdMatches(first)).toBe(false);
+    expect(instanceIdMatches(second)).toBe(true);
+  });
+
+  it("writes the nonce 0o600 so another local user cannot read it", () => {
+    publishInstanceId();
+    const target = instancePath();
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, "utf-8")).toHaveLength(64);
+    // Windows does not implement POSIX mode bits.
+    if (platform() !== "win32") {
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("sits beside the active config, so profiles do not share an identity", () => {
+    expect(instancePath()).toBe(join(directory, ".mailpouch.json.settings-instance"));
+    expect(getConfigPath().startsWith(directory)).toBe(true);
+  });
+
+  it("removes the file on shutdown, not just the in-memory value", () => {
+    publishInstanceId();
+    expect(existsSync(instancePath())).toBe(true);
+    clearInstanceId();
+    expect(existsSync(instancePath())).toBe(false);
+  });
+});

--- a/src/settings/instance-identity.ts
+++ b/src/settings/instance-identity.ts
@@ -1,0 +1,91 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { writeFileSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { getConfigPath } from "../config/loader.js";
+
+/**
+ * Proof-of-identity for the "is a mailpouch settings UI already on this port?"
+ * probe in src/index.ts.
+ *
+ * The probe used to accept any local listener that answered `GET /api/status`
+ * with a boolean `hasConfig` field — a shape trivial to forge. Whoever binds
+ * the settings port first therefore became the URL that mailpouch advertises
+ * to the tray and to agents, which is where a user is asked to type their
+ * Bridge password.
+ *
+ * The asymmetry a fix can stand on: any local user can bind 127.0.0.1, but the
+ * config file is 0o600. So the real UI publishes a random nonce *beside the
+ * config, at the same 0o600*, and echoes it on /api/status. A listener that
+ * cannot read the file cannot produce the nonce.
+ *
+ * ponytail: this does NOT defend against an attacker already running as the
+ * config's owner — such an attacker can read the nonce, and has the config and
+ * keyring anyway. The threat it closes is the different-local-user / sandboxed-
+ * process case. Upgrade path if that stops being enough: a peer-credential
+ * check on the socket (SO_PEERCRED / LOCAL_PEERCRED), which is unixy and does
+ * not port cleanly to Windows.
+ */
+
+/**
+ * Sits beside the config it belongs to, so a profile selected via
+ * MAILPOUCH_CONFIG gets its own identity instead of sharing one.
+ * Exported for the tests, which must not restate the naming rule.
+ */
+export function instancePath(): string {
+  const cfg = getConfigPath();
+  return join(dirname(cfg), `${basename(cfg)}.settings-instance`);
+}
+
+/**
+ * The nonce this process is currently serving, if any. The /api/status route
+ * is built long before the bind happens, so it reads through this rather than
+ * closing over a value that does not exist yet.
+ */
+let _current: string | null = null;
+
+/** Publish a fresh nonce for this process's settings server. Best-effort. */
+export function publishInstanceId(): string | null {
+  try {
+    const id = randomBytes(32).toString("hex");
+    writeFileSync(instancePath(), id, { mode: 0o600, encoding: "utf-8" });
+    _current = id;
+    return id;
+  } catch {
+    // A settings UI that cannot publish its identity still serves; it just
+    // won't be reused by another mailpouch's probe. Failing closed is right.
+    _current = null;
+    return null;
+  }
+}
+
+/** The nonce to echo on /api/status, or null if this instance has none. */
+export function currentInstanceId(): string | null {
+  return _current;
+}
+
+/** Remove this instance's nonce on shutdown so it cannot be replayed. */
+export function clearInstanceId(): void {
+  _current = null;
+  try { rmSync(instancePath(), { force: true }); } catch { /* nothing to undo */ }
+}
+
+/**
+ * Does `candidate` match the nonce currently on disk? Constant-time.
+ * False whenever the file is missing, unreadable, or the wrong shape — the
+ * caller then binds its own server, which is the safe default.
+ */
+export function instanceIdMatches(candidate: unknown): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  let expected: string;
+  try {
+    expected = readFileSync(instancePath(), "utf-8").trim();
+  } catch {
+    return false;
+  }
+  if (expected.length === 0 || candidate.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(candidate, "utf-8"), Buffer.from(expected, "utf-8"));
+  } catch {
+    return false;
+  }
+}

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -52,6 +52,7 @@ import {
   buildPermissions,
   configExists,
 } from "../config/loader.js";
+import { publishInstanceId, currentInstanceId, clearInstanceId } from "./instance-identity.js";
 import { checkConnections } from "./connection-check.js";
 import {
   ALL_TOOLS,
@@ -1190,15 +1191,20 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
       }
 
       // ── GET /api/status ───────────────────────────────────────────────────
-      // `hasConfig` is the load-bearing field the singleton probe checks
-      // (src/index.ts) — keep it. The rest is the live snapshot `mailpouch
-      // status` surfaces; present only when the running instance supplied a
-      // status provider.
+      // `instanceId` is the load-bearing field the singleton probe checks
+      // (src/index.ts) — keep it. It is a nonce published at bind time beside
+      // the 0o600 config, so a listener that squatted this port cannot forge
+      // it. `hasConfig` remains for `mailpouch status` and older callers, but
+      // it is NOT an identity claim: it is a forgeable boolean. The rest is
+      // the live snapshot `mailpouch status` surfaces; present only when the
+      // running instance supplied a status provider.
       if (method === "GET" && path === "/api/status") {
         const live = secOpts.onStatus?.();
+        const instanceId = currentInstanceId();
         json(res, 200, {
           hasConfig: configExists(),
           version: _agentSetupPkgVersion,
+          ...(instanceId ? { instanceId } : {}),
           ...(live ?? {}),
         });
         return;
@@ -2997,6 +3003,11 @@ export async function startSettingsServer(
     server.listen(port, bindHost, () => resolve());
   });
 
+  // Publish this instance's identity nonce only once the bind succeeded —
+  // publishing before would advertise an identity for a server that may never
+  // come up, and the probe would then reuse a port nothing is serving.
+  publishInstanceId();
+
   // ── Startup banner ────────────────────────────────────────────────────────
   if (!quiet) {
     const localUrl  = `${scheme}://localhost:${port}`;
@@ -3065,9 +3076,10 @@ export async function startSettingsServer(
   }
 
   const stop = (): Promise<void> =>
-    new Promise((resolve, reject) =>
-      server.close((err) => (err ? reject(err) : resolve()))
-    );
+    new Promise((resolve, reject) => {
+      clearInstanceId();
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
 
   return { scheme, stop };
 }

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,7 +20,7 @@ Bridge-only smoke suite, still present) and lives entirely under
 - **Proton Bridge** running locally for Phase 2. The Bridge lane is scoped to
   run-owned messages and UUID-namespaced folders, so it can use an existing
   mailbox without erasing or modifying pre-existing mail.
-- Node 20+ (matches the package's `engines` field).
+- Node 22+ (matches the package's `engines` field).
 
 ## Quick start (Phase 1 — Greenmail)
 


### PR DESCRIPTION
Two things that both wanted a major: the Node floor, and a confirmed security finding.

## 1. Node 20 is dropped (breaking)

Node 20 reached end of life **2026-04-30** and no longer receives security patches, which made the runtime the weakest link in an otherwise fully patched dependency tree.

`better-sqlite3` 13.x forced the timing — it `EBADENGINE`s on Node 20 across all three platforms, which is why dependabot #273 could never go green against `engines.node: ">=20.0.0"`.

| | before | after |
|---|---|---|
| `engines.node` | `>=20.0.0` | `>=22.0.0` |
| `engines.npm` | `>=9.0.0` | `>=10.0.0` |
| CI matrix | 20.x, 22.x | 22.x, 24.x |
| publish.yml non-OIDC jobs | 20.x | 22.x |

The OIDC publish job stays pinned to 24.x — unchanged, and unrelated to the support floor.

Also raises the `overrides` floors to the versions that actually carry the fixes from #276 (`fast-uri` >=4.1.2, `hono` >=4.12.34, new `ip-address` >=10.4.0) so a transitive can't quietly resolve back to a vulnerable release once the advisory stops being fresh. `better-sqlite3` 13.x drops a large subtree along the way: the license inventory falls from 177 prod deps to 145.

Closes #273.

## 2. The settings-UI singleton probe was spoofable

`_probeExistingMailpouchUi` treated **any** local listener answering `GET /api/status` with a boolean `hasConfig` field as a genuine mailpouch settings UI, and adopted its URL permanently:

```js
if (typeof parsed.hasConfig === "boolean") {
  finish(`http://localhost:${port}`);
```

A response shape is trivial to forge. Whoever bound the settings port first became the address mailpouch advertises through the tray and in `SERVER_INSTRUCTIONS` — the page where the user is asked to type their Bridge password. `_settingsExternal` was set and no local server was ever bound, so there was no second UI to notice.

**The fix.** Any local user can bind `127.0.0.1`, but the config file is `0o600`. That asymmetry is what the fix stands on: the real UI publishes a 256-bit nonce beside the config at `0o600` and echoes it on `/api/status`; the probe compares it constant-time and falls through to binding its own server on any mismatch. `hasConfig` stays in the response for `mailpouch status`, but it is no longer an identity claim.

**Scope, stated plainly.** This closes the different-local-user and sandboxed-process case. It does **not** defend against an attacker already running as the config's owner — that attacker can read the nonce and has the config and keyring regardless. The upgrade path if that ever matters is a socket peer-credential check (`SO_PEERCRED`), which does not port cleanly to Windows.

**Mixed-version note:** a v4 process will not reuse a pre-v4 `mailpouch-settings` daemon, since the older daemon publishes no nonce. It binds its own port instead, so you may briefly see two settings UIs until both are upgraded.

9 regression tests in `src/settings/instance-identity.test.ts`, including a same-length wrong nonce (so a `timingSafeEqual` throw can't be swallowed as success), replay after shutdown, and the `0o600` mode assertion.

## How this was found

A 10-surface sweep over all 107 non-test modules — MCP tool surface, IMAP parsing of remote bytes, the local HTTP server, config/credentials, the gatekeeping code itself, transports, and shared primitives. Every surface reported (no silent gaps). **5 candidates → 4 killed by a refute-or-promote gate → 1 confirmed**, and that one also survived an independent second opinion. Finder and verifier ran on different models.

The four that died were killed for the right reasons: validated upstream, or no reachable path from agent/remote/config input.

## Verification

`npm run preship:fast` passes end to end: typecheck, lint, version-sync, secrets, npm-audit (0 findings), license-inv, build, unit, tarball-smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)