### PR TITLE
fix(security): authenticate the settings-UI singleton probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- The settings-UI singleton probe now authenticates the listener it defers to. Previously `_probeExistingMailpouchUi` treated *any* process answering `GET /api/status` with a boolean `hasConfig` field as a genuine mailpouch settings UI, and permanently adopted its URL. Since a response shape is trivial to forge, whoever bound the settings port first became the address mailpouch advertised through the tray and to agents — which is where the user is asked to type their Bridge password. The real UI now publishes a 256-bit nonce beside the config at `0o600` and echoes it on `/api/status`; the probe compares it constant-time and binds its own server on any mismatch. This closes the case of a *different* local user or a sandboxed process, which can bind loopback but cannot read the config. It does not (and cannot) defend against an attacker already running as the config's owner, who has the config and keyring regardless.
+
+  Mixed-version note: a patched process will not reuse an unpatched `mailpouch-settings` daemon, because the older daemon publishes no nonce. It falls back to binding its own port, so you may briefly see two settings UIs until both are upgraded.
+
 ## [3.2.1] — 2026-07-30
 
 ### Security

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { homedir } from "os";
 import { createConnection } from "net";
 import { spawn } from "child_process";
 import { startSettingsServer } from "./settings/server.js";
+import { instanceIdMatches } from "./settings/instance-identity.js";
 import { openBrowser } from "./settings/tui.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -2652,8 +2653,9 @@ function _tickTrayHealth(): void {
 /**
  * Probe whether a mailpouch settings UI is already serving on `port`.
  * Returns the base URL if the port is occupied by another mailpouch UI
- * (identified by a valid `/api/status` response with the expected shape),
- * or null if the port is free or occupied by something else.
+ * (proved by a `/api/status` response echoing the instance nonce published
+ * beside the 0o600 config), or null if the port is free, occupied by
+ * something else, or occupied by a listener that cannot prove identity.
  *
  * Used so we can defer to a user-run `mailpouch-settings` daemon instead
  * of retrying + warning — the common "standalone settings UI plus stdio
@@ -2685,7 +2687,13 @@ async function _probeExistingMailpouchUi(port: number): Promise<string | null> {
         res.on("end", () => {
           try {
             const parsed = JSON.parse(body) as Record<string, unknown>;
-            if (typeof parsed.hasConfig === "boolean") {
+            // Identity is the nonce, NOT the shape. `hasConfig` is a boolean
+            // any listener can echo; deferring on it let whoever bound this
+            // port first become the URL we advertise to the tray and to
+            // agents — i.e. the page that asks for the Bridge password.
+            // instanceIdMatches reads the nonce from beside the 0o600 config,
+            // which a squatting process running as another user cannot read.
+            if (instanceIdMatches(parsed.instanceId)) {
               finish(`http://localhost:${port}`);
               return;
             }
@@ -2708,9 +2716,10 @@ async function _startSettingsServerDaemon(): Promise<void> {
 
   // If a user-run `mailpouch-settings` instance is already serving on the
   // configured port, reuse it silently rather than retry-and-warn. Probes with
-  // a short GET /api/status — any non-mailpouch listener (e.g. a stray
-  // `python3 -m http.server`) responds with a different shape and falls through
-  // to the bind-then-fallback path below.
+  // a short GET /api/status — any listener that cannot echo the instance nonce
+  // (a stray `python3 -m http.server`, or a process squatting the port to be
+  // mistaken for the settings UI) falls through to the bind-then-fallback path
+  // below, so we advertise a URL we are serving ourselves.
   const existing = await _probeExistingMailpouchUi(basePort);
   if (existing) {
     _settingsUrl      = existing;

--- a/src/settings/instance-identity.test.ts
+++ b/src/settings/instance-identity.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The settings-UI singleton probe (src/index.ts) used to accept any local
+ * listener that answered GET /api/status with a boolean `hasConfig` field.
+ * Whoever bound the settings port first therefore became the URL mailpouch
+ * advertises to the tray and to agents — the page that asks for the Bridge
+ * password. These tests pin the replacement: identity is a nonce published
+ * beside the 0o600 config, not a forgeable response shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "fs";
+import { homedir, platform } from "os";
+import { join } from "path";
+import { getConfigPath } from "../config/loader.js";
+import {
+  publishInstanceId,
+  currentInstanceId,
+  clearInstanceId,
+  instanceIdMatches,
+  instancePath,
+} from "./instance-identity.js";
+
+describe("settings instance identity", () => {
+  let directory: string;
+  let previousConfigPath: string | undefined;
+
+  beforeEach(() => {
+    // MAILPOUCH_CONFIG deliberately permits only paths below $HOME.
+    directory = mkdtempSync(join(homedir(), ".mailpouch-instance-test-"));
+    previousConfigPath = process.env.MAILPOUCH_CONFIG;
+    process.env.MAILPOUCH_CONFIG = join(directory, ".mailpouch.json");
+  });
+
+  afterEach(() => {
+    clearInstanceId();
+    if (previousConfigPath === undefined) delete process.env.MAILPOUCH_CONFIG;
+    else process.env.MAILPOUCH_CONFIG = previousConfigPath;
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  it("accepts the nonce the running instance published", () => {
+    const id = publishInstanceId();
+    expect(id).toBeTruthy();
+    expect(currentInstanceId()).toBe(id);
+    expect(instanceIdMatches(id)).toBe(true);
+  });
+
+  // The whole point: a squatter can echo any SHAPE it likes, but not the value.
+  it("rejects a listener that forges the response shape but not the nonce", () => {
+    publishInstanceId();
+    expect(instanceIdMatches("attacker-supplied")).toBe(false);
+    expect(instanceIdMatches(true)).toBe(false);
+    expect(instanceIdMatches(undefined)).toBe(false);
+    expect(instanceIdMatches(null)).toBe(false);
+    expect(instanceIdMatches("")).toBe(false);
+    expect(instanceIdMatches(1234)).toBe(false);
+    expect(instanceIdMatches({})).toBe(false);
+  });
+
+  // A same-length wrong value must not slip past the length pre-check into a
+  // timingSafeEqual that would throw and get swallowed as "true".
+  it("rejects a wrong nonce of exactly the right length", () => {
+    const id = publishInstanceId();
+    expect(id).toBeTruthy();
+    const sameLengthDecoy = "f".repeat(id!.length);
+    expect(sameLengthDecoy).toHaveLength(id!.length);
+    expect(sameLengthDecoy).not.toBe(id);
+    expect(instanceIdMatches(sameLengthDecoy)).toBe(false);
+  });
+
+  it("rejects everything when no instance has published — probe binds its own", () => {
+    expect(instanceIdMatches("anything")).toBe(false);
+    expect(currentInstanceId()).toBeNull();
+  });
+
+  it("stops matching a replayed nonce once the instance shuts down", () => {
+    const id = publishInstanceId();
+    expect(instanceIdMatches(id)).toBe(true);
+    clearInstanceId();
+    expect(instanceIdMatches(id)).toBe(false);
+    expect(currentInstanceId()).toBeNull();
+  });
+
+  it("publishes a distinct nonce per instance", () => {
+    const first = publishInstanceId();
+    const second = publishInstanceId();
+    expect(first).not.toBe(second);
+    // The superseded nonce must not still be honoured.
+    expect(instanceIdMatches(first)).toBe(false);
+    expect(instanceIdMatches(second)).toBe(true);
+  });
+
+  it("writes the nonce 0o600 so another local user cannot read it", () => {
+    publishInstanceId();
+    const target = instancePath();
+    expect(existsSync(target)).toBe(true);
+    expect(readFileSync(target, "utf-8")).toHaveLength(64);
+    // Windows does not implement POSIX mode bits.
+    if (platform() !== "win32") {
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("sits beside the active config, so profiles do not share an identity", () => {
+    expect(instancePath()).toBe(join(directory, ".mailpouch.json.settings-instance"));
+    expect(getConfigPath().startsWith(directory)).toBe(true);
+  });
+
+  it("removes the file on shutdown, not just the in-memory value", () => {
+    publishInstanceId();
+    expect(existsSync(instancePath())).toBe(true);
+    clearInstanceId();
+    expect(existsSync(instancePath())).toBe(false);
+  });
+});

--- a/src/settings/instance-identity.ts
+++ b/src/settings/instance-identity.ts
@@ -1,0 +1,91 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { writeFileSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { getConfigPath } from "../config/loader.js";
+
+/**
+ * Proof-of-identity for the "is a mailpouch settings UI already on this port?"
+ * probe in src/index.ts.
+ *
+ * The probe used to accept any local listener that answered `GET /api/status`
+ * with a boolean `hasConfig` field — a shape trivial to forge. Whoever binds
+ * the settings port first therefore became the URL that mailpouch advertises
+ * to the tray and to agents, which is where a user is asked to type their
+ * Bridge password.
+ *
+ * The asymmetry a fix can stand on: any local user can bind 127.0.0.1, but the
+ * config file is 0o600. So the real UI publishes a random nonce *beside the
+ * config, at the same 0o600*, and echoes it on /api/status. A listener that
+ * cannot read the file cannot produce the nonce.
+ *
+ * ponytail: this does NOT defend against an attacker already running as the
+ * config's owner — such an attacker can read the nonce, and has the config and
+ * keyring anyway. The threat it closes is the different-local-user / sandboxed-
+ * process case. Upgrade path if that stops being enough: a peer-credential
+ * check on the socket (SO_PEERCRED / LOCAL_PEERCRED), which is unixy and does
+ * not port cleanly to Windows.
+ */
+
+/**
+ * Sits beside the config it belongs to, so a profile selected via
+ * MAILPOUCH_CONFIG gets its own identity instead of sharing one.
+ * Exported for the tests, which must not restate the naming rule.
+ */
+export function instancePath(): string {
+  const cfg = getConfigPath();
+  return join(dirname(cfg), `${basename(cfg)}.settings-instance`);
+}
+
+/**
+ * The nonce this process is currently serving, if any. The /api/status route
+ * is built long before the bind happens, so it reads through this rather than
+ * closing over a value that does not exist yet.
+ */
+let _current: string | null = null;
+
+/** Publish a fresh nonce for this process's settings server. Best-effort. */
+export function publishInstanceId(): string | null {
+  try {
+    const id = randomBytes(32).toString("hex");
+    writeFileSync(instancePath(), id, { mode: 0o600, encoding: "utf-8" });
+    _current = id;
+    return id;
+  } catch {
+    // A settings UI that cannot publish its identity still serves; it just
+    // won't be reused by another mailpouch's probe. Failing closed is right.
+    _current = null;
+    return null;
+  }
+}
+
+/** The nonce to echo on /api/status, or null if this instance has none. */
+export function currentInstanceId(): string | null {
+  return _current;
+}
+
+/** Remove this instance's nonce on shutdown so it cannot be replayed. */
+export function clearInstanceId(): void {
+  _current = null;
+  try { rmSync(instancePath(), { force: true }); } catch { /* nothing to undo */ }
+}
+
+/**
+ * Does `candidate` match the nonce currently on disk? Constant-time.
+ * False whenever the file is missing, unreadable, or the wrong shape — the
+ * caller then binds its own server, which is the safe default.
+ */
+export function instanceIdMatches(candidate: unknown): boolean {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  let expected: string;
+  try {
+    expected = readFileSync(instancePath(), "utf-8").trim();
+  } catch {
+    return false;
+  }
+  if (expected.length === 0 || candidate.length !== expected.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(candidate, "utf-8"), Buffer.from(expected, "utf-8"));
+  } catch {
+    return false;
+  }
+}

--- a/src/settings/server.ts
+++ b/src/settings/server.ts
@@ -52,6 +52,7 @@ import {
   buildPermissions,
   configExists,
 } from "../config/loader.js";
+import { publishInstanceId, currentInstanceId, clearInstanceId } from "./instance-identity.js";
 import { checkConnections } from "./connection-check.js";
 import {
   ALL_TOOLS,
@@ -1190,15 +1191,20 @@ export function createSettingsServer(secOpts: ServerSecurityOptions): http.Serve
       }
 
       // ── GET /api/status ───────────────────────────────────────────────────
-      // `hasConfig` is the load-bearing field the singleton probe checks
-      // (src/index.ts) — keep it. The rest is the live snapshot `mailpouch
-      // status` surfaces; present only when the running instance supplied a
-      // status provider.
+      // `instanceId` is the load-bearing field the singleton probe checks
+      // (src/index.ts) — keep it. It is a nonce published at bind time beside
+      // the 0o600 config, so a listener that squatted this port cannot forge
+      // it. `hasConfig` remains for `mailpouch status` and older callers, but
+      // it is NOT an identity claim: it is a forgeable boolean. The rest is
+      // the live snapshot `mailpouch status` surfaces; present only when the
+      // running instance supplied a status provider.
       if (method === "GET" && path === "/api/status") {
         const live = secOpts.onStatus?.();
+        const instanceId = currentInstanceId();
         json(res, 200, {
           hasConfig: configExists(),
           version: _agentSetupPkgVersion,
+          ...(instanceId ? { instanceId } : {}),
           ...(live ?? {}),
         });
         return;
@@ -2997,6 +3003,11 @@ export async function startSettingsServer(
     server.listen(port, bindHost, () => resolve());
   });
 
+  // Publish this instance's identity nonce only once the bind succeeded —
+  // publishing before would advertise an identity for a server that may never
+  // come up, and the probe would then reuse a port nothing is serving.
+  publishInstanceId();
+
   // ── Startup banner ────────────────────────────────────────────────────────
   if (!quiet) {
     const localUrl  = `${scheme}://localhost:${port}`;
@@ -3065,9 +3076,10 @@ export async function startSettingsServer(
   }
 
   const stop = (): Promise<void> =>
-    new Promise((resolve, reject) =>
-      server.close((err) => (err ? reject(err) : resolve()))
-    );
+    new Promise((resolve, reject) => {
+      clearInstanceId();
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
 
   return { scheme, stop };
 }


### PR DESCRIPTION
## The defect

`_probeExistingMailpouchUi` (`src/index.ts`) treated **any** local listener answering `GET /api/status` with a boolean `hasConfig` field as a genuine mailpouch settings UI, and adopted its URL permanently:

```js
if (typeof parsed.hasConfig === "boolean") {
  finish(`http://localhost:${port}`);
```

A response shape is trivial to forge. Whoever bound the settings port first became the address mailpouch advertises through the tray and in `SERVER_INSTRUCTIONS` — the page where the user is asked to type their Bridge password. `_settingsExternal` was set and no local server was ever bound, so there was no second UI to notice the discrepancy.

**Concretely:** a process binds `127.0.0.1:8766` before mailpouch starts and answers `/api/status` with `{"hasConfig":true}`. `_startSettingsServerDaemon()` logs *"Reusing existing Settings UI"* and never binds its own.

## The fix

Any local user can bind `127.0.0.1`, but the config file is `0o600`. That asymmetry is the whole basis: the real UI publishes a 256-bit nonce beside the config at `0o600` and echoes it on `/api/status`; the probe compares it constant-time and falls through to binding its own server on any mismatch.

`hasConfig` stays in the response for `mailpouch status` and older callers, but it is no longer an identity claim. The nonce is published only *after* a successful bind (publishing earlier would advertise an identity for a server that may never come up) and removed on shutdown so it can't be replayed.

## Scope — stated plainly

This closes the **different-local-user** and sandboxed-process case. It does **not** defend against an attacker already running as the config's owner: they can read the nonce, and they have the config and keyring regardless. The upgrade path if that ever matters is a socket peer-credential check (`SO_PEERCRED`/`LOCAL_PEERCRED`), which doesn't port cleanly to Windows. Both limits are recorded in the module comment rather than left for a reader to discover.

**Mixed-version note:** a patched process will not reuse an unpatched `mailpouch-settings` daemon, since the older daemon publishes no nonce — it binds its own port instead, so you may briefly see two settings UIs until both are upgraded.

## Tests

9 cases in `src/settings/instance-identity.test.ts`, including:
- a forged response shape (`true`, `"attacker-supplied"`, `{}`, `null`) rejected
- a **same-length wrong nonce**, so a `timingSafeEqual` throw can't be swallowed as success
- replay after shutdown stops matching, and the file is actually removed
- the `0o600` mode assertion (skipped on Windows, which has no POSIX mode bits)
- the path sits beside the *active* config, so `MAILPOUCH_CONFIG` profiles don't share an identity

## How it was found

A 10-surface sweep over all 107 non-test modules — MCP tool surface, IMAP parsing of remote bytes, the local HTTP server, config/credentials, the gatekeeping code itself, transports, shared primitives. Every surface reported (no silent gaps). **5 candidates → 4 killed by a refute-or-promote gate → 1 confirmed**, which also survived an independent second opinion. Finder and verifier ran on different models. The four deaths were legitimate: validated upstream, or no reachable path from agent/remote/config input.

## Verification

`npm run preship:fast` passes end to end: typecheck, lint, version-sync, secrets, npm-audit, license-inv, build, unit, tarball-smoke.

No infrastructure changes — no workflow, CI matrix, engine, or dependency edits in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)