### PR TITLE
test(security): cover the probe call site, not just its helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { homedir } from "os";
 import { createConnection } from "net";
 import { spawn } from "child_process";
 import { startSettingsServer } from "./settings/server.js";
-import { instanceIdMatches } from "./settings/instance-identity.js";
+import { probeExistingMailpouchUi } from "./settings/probe-existing-ui.js";
 import { openBrowser } from "./settings/tui.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -2650,67 +2650,6 @@ function _tickTrayHealth(): void {
   }
 }
 
-/**
- * Probe whether a mailpouch settings UI is already serving on `port`.
- * Returns the base URL if the port is occupied by another mailpouch UI
- * (proved by a `/api/status` response echoing the instance nonce published
- * beside the 0o600 config), or null if the port is free, occupied by
- * something else, or occupied by a listener that cannot prove identity.
- *
- * Used so we can defer to a user-run `mailpouch-settings` daemon instead
- * of retrying + warning — the common "standalone settings UI plus stdio
- * MCP in separate processes" setup was previously noisy.
- */
-async function _probeExistingMailpouchUi(port: number): Promise<string | null> {
-  const http = await import("node:http");
-  return new Promise<string | null>((resolve) => {
-    let settled = false;
-    const finish = (url: string | null): void => {
-      if (settled) return;
-      settled = true;
-      resolve(url);
-    };
-    const req = http.request(
-      { host: "127.0.0.1", port, path: "/api/status", method: "GET", timeout: 750 },
-      (res) => {
-        let body = "";
-        res.setEncoding("utf8");
-        res.on("data", (chunk: string) => {
-          body += chunk;
-          // Body-size cap: a legit /api/status payload is well under 256 B.
-          // Anything >4 KB is either a chatty non-mailpouch listener or an
-          // attempt to RAM-bomb the probe; either way, abort + resolve so
-          // the Promise doesn't hang when we tear the socket down (res
-          // destroy does not reliably emit 'end' on an abort path).
-          if (body.length > 4096) { res.destroy(); finish(null); }
-        });
-        res.on("end", () => {
-          try {
-            const parsed = JSON.parse(body) as Record<string, unknown>;
-            // Identity is the nonce, NOT the shape. `hasConfig` is a boolean
-            // any listener can echo; deferring on it let whoever bound this
-            // port first become the URL we advertise to the tray and to
-            // agents — i.e. the page that asks for the Bridge password.
-            // instanceIdMatches reads the nonce from beside the 0o600 config,
-            // which a squatting process running as another user cannot read.
-            if (instanceIdMatches(parsed.instanceId)) {
-              finish(`http://localhost:${port}`);
-              return;
-            }
-          } catch { /* not JSON — not a mailpouch UI */ }
-          finish(null);
-        });
-        res.on("error",   () => finish(null));
-        res.on("close",   () => finish(null));
-        res.on("aborted", () => finish(null));
-      },
-    );
-    req.on("error", () => finish(null));
-    req.on("timeout", () => { req.destroy(); finish(null); });
-    req.end();
-  });
-}
-
 async function _startSettingsServerDaemon(): Promise<void> {
   const basePort = config.settingsPort ?? 8766;
 
@@ -2720,7 +2659,7 @@ async function _startSettingsServerDaemon(): Promise<void> {
   // (a stray `python3 -m http.server`, or a process squatting the port to be
   // mistaken for the settings UI) falls through to the bind-then-fallback path
   // below, so we advertise a URL we are serving ourselves.
-  const existing = await _probeExistingMailpouchUi(basePort);
+  const existing = await probeExistingMailpouchUi(basePort);
   if (existing) {
     _settingsUrl      = existing;
     _settingsEnabled  = true;

--- a/src/settings/probe-existing-ui.test.ts
+++ b/src/settings/probe-existing-ui.test.ts
@@ -1,0 +1,111 @@
+/**
+ * These tests exist because the *helper* being tested was not enough.
+ *
+ * instanceIdMatches() had unit tests from the day the nonce check landed, but
+ * nothing exercised the probe that calls it. Reverting the call site to the
+ * original `typeof parsed.hasConfig === "boolean"` left the whole suite green
+ * while restoring the vulnerability: whoever bound the settings port first
+ * became the URL mailpouch advertises to the tray and to agents — the page
+ * where the user is asked to type their Bridge password.
+ *
+ * So each test here stands up a REAL listener on a real port and asserts what
+ * the probe decides about it. Reverting the identity check turns the first
+ * test red, which is the only property that makes this suite worth running.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { mkdtempSync, rmSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { probeExistingMailpouchUi } from "./probe-existing-ui.js";
+import { publishInstanceId, clearInstanceId } from "./instance-identity.js";
+
+/** Stand up a listener that answers GET /api/status with `payload`. */
+async function listener(payload: string | (() => string)): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    if (req.url !== "/api/status") { res.statusCode = 404; res.end(); return; }
+    res.setHeader("content-type", "application/json");
+    res.end(typeof payload === "function" ? payload() : payload);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+describe("settings-UI probe identity", () => {
+  let directory: string;
+  let previousConfigPath: string | undefined;
+  let stop: (() => Promise<void>) | null = null;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(homedir(), ".mailpouch-probe-test-"));
+    previousConfigPath = process.env.MAILPOUCH_CONFIG;
+    process.env.MAILPOUCH_CONFIG = join(directory, ".mailpouch.json");
+  });
+
+  afterEach(async () => {
+    if (stop) { await stop(); stop = null; }
+    clearInstanceId();
+    if (previousConfigPath === undefined) delete process.env.MAILPOUCH_CONFIG;
+    else process.env.MAILPOUCH_CONFIG = previousConfigPath;
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  // THE regression test. This is the exact payload the original bug accepted.
+  it("refuses a squatter that echoes hasConfig but has no nonce", async () => {
+    publishInstanceId(); // a real UI is registered, but not the squatter
+    const l = await listener(JSON.stringify({ hasConfig: true, version: "3.2.1" }));
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBeNull();
+  });
+
+  it("refuses a squatter that guesses a wrong nonce", async () => {
+    publishInstanceId();
+    const l = await listener(JSON.stringify({ hasConfig: true, instanceId: "f".repeat(64) }));
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBeNull();
+  });
+
+  it("accepts the genuine UI echoing the published nonce", async () => {
+    const id = publishInstanceId();
+    const l = await listener(JSON.stringify({ hasConfig: true, instanceId: id }));
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBe(`http://localhost:${l.port}`);
+  });
+
+  it("refuses a listener that is not serving JSON at all", async () => {
+    publishInstanceId();
+    const l = await listener("<html>not mailpouch</html>");
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBeNull();
+  });
+
+  it("refuses a listener that floods the probe with a huge body", async () => {
+    const id = publishInstanceId();
+    // Valid nonce, but buried past the 4 KB cap — the cap must win.
+    const l = await listener(() => " ".repeat(8192) + JSON.stringify({ instanceId: id }));
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBeNull();
+  });
+
+  it("returns null when nothing is listening on the port", async () => {
+    publishInstanceId();
+    // Bind and immediately release, so the port is almost certainly free.
+    const l = await listener("{}");
+    const freePort = l.port;
+    await l.close();
+    expect(await probeExistingMailpouchUi(freePort)).toBeNull();
+  });
+
+  it("refuses even a correct-looking response when no instance has published", async () => {
+    // No publishInstanceId() — nothing legitimate is running.
+    const l = await listener(JSON.stringify({ hasConfig: true, instanceId: "a".repeat(64) }));
+    stop = l.close;
+    expect(await probeExistingMailpouchUi(l.port)).toBeNull();
+  });
+});

--- a/src/settings/probe-existing-ui.ts
+++ b/src/settings/probe-existing-ui.ts
@@ -1,0 +1,69 @@
+import http from "node:http";
+import { instanceIdMatches } from "./instance-identity.js";
+
+/**
+ * Probe whether a mailpouch settings UI is already serving on `port`.
+ * Returns the base URL if the port is occupied by another mailpouch UI
+ * (proved by a `/api/status` response echoing the instance nonce published
+ * beside the 0o600 config), or null if the port is free, occupied by
+ * something else, or occupied by a listener that cannot prove identity.
+ *
+ * Used so we can defer to a user-run `mailpouch-settings` daemon instead
+ * of retrying + warning — the common "standalone settings UI plus stdio
+ * MCP in separate processes" setup was previously noisy.
+ *
+ * Lives here rather than in index.ts so it can be tested against a real
+ * listener: index.ts calls main() at import time, so a test that imported
+ * it would boot the whole MCP server. That is exactly why the identity
+ * check went untested when it was first written — the helper had unit
+ * tests, but the decision that *uses* it did not, so reverting this to the
+ * old `typeof parsed.hasConfig === "boolean"` check left the suite green.
+ */
+export async function probeExistingMailpouchUi(port: number): Promise<string | null> {
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (url: string | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(url);
+    };
+    const req = http.request(
+      { host: "127.0.0.1", port, path: "/api/status", method: "GET", timeout: 750 },
+      (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => {
+          body += chunk;
+          // Body-size cap: a legit /api/status payload is well under 256 B.
+          // Anything >4 KB is either a chatty non-mailpouch listener or an
+          // attempt to RAM-bomb the probe; either way, abort + resolve so
+          // the Promise doesn't hang when we tear the socket down (res
+          // destroy does not reliably emit 'end' on an abort path).
+          if (body.length > 4096) { res.destroy(); finish(null); }
+        });
+        res.on("end", () => {
+          try {
+            const parsed = JSON.parse(body) as Record<string, unknown>;
+            // Identity is the nonce, NOT the shape. `hasConfig` is a boolean
+            // any listener can echo; deferring on it let whoever bound this
+            // port first become the URL we advertise to the tray and to
+            // agents — i.e. the page that asks for the Bridge password.
+            // instanceIdMatches reads the nonce from beside the 0o600 config,
+            // which a squatting process running as another user cannot read.
+            if (instanceIdMatches(parsed.instanceId)) {
+              finish(`http://localhost:${port}`);
+              return;
+            }
+          } catch { /* not JSON — not a mailpouch UI */ }
+          finish(null);
+        });
+        res.on("error",   () => finish(null));
+        res.on("close",   () => finish(null));
+        res.on("aborted", () => finish(null));
+      },
+    );
+    req.on("error", () => finish(null));
+    req.on("timeout", () => { req.destroy(); finish(null); });
+    req.end();
+  });
+}


### PR DESCRIPTION
## The gap

The settings-UI nonce check (#278) shipped with unit tests for `instanceIdMatches()` and **none for the code that calls it**. That gap was load-bearing — reverting the call site to the original:

```js
if (typeof parsed.hasConfig === "boolean")
```

left the entire suite **green** while restoring the vulnerability, because no test ever stood up a listener on the settings port. A security control whose removal is invisible to the test suite is a control on a timer.

## Why it was untested

Nothing tested it because nothing *could*: `index.ts` calls `main()` at import time, so any test importing it boots the whole MCP server. The probe therefore moves to `src/settings/probe-existing-ui.ts` **unchanged** — pure code motion, no behavior change — and `index.ts` imports it.

## The tests

Each binds a real listener on a real port and asserts what the probe decides about it:

| Listener | Expected |
|---|---|
| echoes `{hasConfig:true}`, no nonce | refused |
| guesses a wrong nonce (right length) | refused |
| echoes the genuine published nonce | **accepted** |
| correct-looking response, nothing published | refused |
| serves HTML, not JSON | refused |
| valid nonce buried past the 4 KB body cap | refused |
| nothing listening | refused |

## Verified to have teeth, not assumed

Reverting the check to the `hasConfig` test turns exactly **3 of these red** — the three covering the vulnerability:

```
× refuses a squatter that echoes hasConfig but has no nonce
× refuses a squatter that guesses a wrong nonce
× refuses even a correct-looking response when no instance has published
  Tests  3 failed | 4 passed (7)
```

That check was run and then reverted; the merged code has the nonce check intact.

## How it was found

A **second** sweep round, run because one round of static review is evidence of no findings above its bar, not proof of correctness. Round 1 swept by surface (one agent per directory bundle) and structurally could not see this. Round 2 swept by *lens* across the whole repo, and this came from the lens "security controls with no test that would fail if the control were deleted."

Round 2: 6 lenses, all reported, 3 candidates → 2 killed by the gate → 1 confirmed (this one), which also survived an independent second opinion on a different model from the finder.

## Verification

`npm run preship:fast` passes end to end. Separately, the full **Greenmail E2E suite passes locally: 80 passed, 18 skipped, 13 files** — dynamic coverage the sweep itself could not provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)