### PR TITLE
fix(e2e): let the live-Bridge lane create its own scratch mailboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.0] — 2026-08-05
 
+### Fixed
+
+- **The `remove_label` data-loss regression test can now actually run.** Unlabelling is `\Deleted` + `EXPUNGE` against `Labels/<name>`, non-destructive only because Proton Bridge maps that to "remove this label" — the one invariant in the codebase whose correctness is owned entirely by upstream. A regression test was added in 3.2.1 to guard it, but it could never execute: the live-Bridge lane set `allowMailboxCreate: mode === "greenmail"`, so creating the token-scoped `Labels/` scratch mailbox it needs was refused and it errored at setup on every run. Being the only test in the suite that creates a scratch mailbox, nothing else revealed the breakage. The fixture may now create its own ownership-scoped scratch mailboxes; `assertScratch` plus exclusive-create still confine that to the `mpE2E-<uuid>` namespace and cannot adopt an existing mailbox, and the MCP-level refusal of `create_folder`/`delete_folder`/`rename_folder` in `bridge-safety.ts` is untouched. The suite now passes 9/9 against live Bridge v3.25.0, including the unlabel-survival assertion.
+
 ### Breaking
 
 - **Node 20 is no longer supported. The minimum is now Node 22.** Node 20 reached end of life on 2026-04-30 and no longer receives security patches, which made the runtime the weakest link in an otherwise fully patched tree. `engines.node` is now `>=22.0.0` and `engines.npm` is `>=10.0.0`; the CI matrix moves from Node 20/22 to 22/24. There is no code-level migration — users on Node 20 must upgrade Node.

--- a/docs/audit-2026-07-30.md
+++ b/docs/audit-2026-07-30.md
@@ -40,6 +40,17 @@ from `Labels/<name>` while surviving in its source folder. **The invariant holds
 asserts both halves — absent from the label *and still present in INBOX*. Bridge-only by
 necessity.
 
+> **Correction (2026-08-05).** The claim above was premature when written. The test could not
+> execute: `mcp-client.ts` set `allowMailboxCreate: mode === "greenmail"`, so the live-Bridge
+> lane refused to create the token-scoped `Labels/` scratch mailbox the test needs, and it
+> errored at setup on every run. It was the only test in the suite calling `scratch.create()`,
+> so nothing else surfaced the breakage. The invariant was genuinely verified by hand that day,
+> but the regression test guarding it had never run. Fixed by allowing the fixture to create
+> its own ownership-scoped scratch mailboxes; `assertScratch` + exclusive-create still confine
+> that to the `mpE2E-<uuid>` namespace, and the MCP-level refusal of `create_folder` in
+> `bridge-safety.ts` is unaffected. **Verified running and passing 9/9 against live Bridge
+> v3.25.0 on 2026-08-05.**
+
 **Action:** run the safe-bridge lane on every Bridge upgrade. This is the one invariant in
 the codebase whose correctness is owned entirely by upstream.
 

--- a/test/e2e/mcp-client.ts
+++ b/test/e2e/mcp-client.ts
@@ -906,7 +906,27 @@ export async function startE2E(opts: StartE2EOptions = {}): Promise<E2EHarness> 
       tls: imapTls,
       allowWipe,
       allowCreateSystemFolders: mode === "greenmail",
-      allowMailboxCreate: mode === "greenmail",
+      // The live-Bridge lane must be able to create its OWN token-scoped
+      // scratch mailboxes, or ScratchSession — which this harness constructs
+      // for every bridge run — can never create anything, and any test that
+      // needs a scratch Labels/ mailbox dies at setup. That is exactly what
+      // happened to the remove_label unlabel-survival regression test: it is
+      // Bridge-only by necessity (Greenmail cannot express the invariant, as
+      // there a Labels/ mailbox is an ordinary folder), so it errored on every
+      // run and never actually guarded the invariant it was written for.
+      //
+      // This does NOT loosen the live-mailbox safety model. Two other guards
+      // remain, and they are the ones doing the work:
+      //   - createMailbox still requires assertScratch(path, ownershipToken)
+      //     and exclusive creation whenever allowCreateSystemFolders is false
+      //     (which it is, above, for bridge) — so creation is confined to the
+      //     mpE2E-<uuid> namespace and can never adopt a pre-existing mailbox.
+      //   - the MCP-level refusal of create_folder/delete_folder/rename_folder
+      //     lives in bridge-safety.ts and is untouched by this flag, so the
+      //     "refuses live folder creation before MCP dispatch" test still holds.
+      // `safe` is always true for bridge (see the guard above rejecting
+      // safe:false), so this reads as "greenmail, or an ownership-scoped run".
+      allowMailboxCreate: mode === "greenmail" || safe,
       requireUidPlusForMutations: mode === "bridge",
       ownershipManifestRoot: bridgeAuthorityScope?.scopeRoot,
     });


### PR DESCRIPTION
## The `remove_label` regression test could never run

Unlabelling is `\Deleted` + `EXPUNGE` against `Labels/<name>`. That is non-destructive **only** because Proton Bridge maps it onto "remove this label" rather than "delete this message" — the one invariant in this codebase whose correctness is owned entirely by upstream, and one Bridge has churned three times across v3.24.0–v3.24.1.

A regression test was added in 3.2.1 to guard it, and `docs/audit-2026-07-30.md` recorded the gap as **closed**.

It was not closed. `mcp-client.ts` set:

```ts
allowMailboxCreate: mode === "greenmail",
```

so the live-Bridge lane refused to create the token-scoped `Labels/` scratch mailbox the test needs, and it threw at setup on **every** run:

```
Error: Live Bridge fixture mailbox creation is disabled: Labels/mpE2E-…-1
  ❯ ImapFixtures.createMailbox  imap-fixtures.ts:381
  ❯ ScratchSession.create       scratch.ts:184
  ❯ safe-bridge.e2e.test.ts:214
```

The test is Bridge-only **by necessity** — Greenmail cannot express the invariant, because there a `Labels/` mailbox is an ordinary folder and a destructive expunge is indistinguishable from a correct detach. It was also the only test in the suite calling `scratch.create()`, so nothing else surfaced the breakage.

## This does not loosen the live-mailbox safety model

Two guards do the real work, and both remain:

| Guard | Still active? |
|---|---|
| `createMailbox` requires `assertScratch(path, ownershipToken)` + exclusive creation while `allowCreateSystemFolders` is false (it is, for bridge) — confines creation to `mpE2E-<uuid>` and can never adopt a pre-existing mailbox | **yes** |
| MCP-level refusal of `create_folder` / `delete_folder` / `rename_folder` in `bridge-safety.ts` — a different layer entirely, unaffected by this fixture flag | **yes** |

I initially believed this flag and the MCP refusal were the same guard, and said so. They are not: test `refuses live folder creation before MCP dispatch` goes through `h.call("create_folder")` → `bridge-safety.ts:300`, while `allowMailboxCreate` gates the fixture's own IMAP setup. That test still passes.

Corroborating the intent: `bridge-safety.ts:292` handles `bulk_remove_label` by calling `requireCreatedScratch(ctx, folder, "label source")` — the safety layer already *expects* a created scratch label mailbox to exist.

## Verified against the live account

**9/9 pass on Bridge v3.25.0**, including `remove_label detaches the label and leaves the message alive in its source folder` — which asserts both absence from the label *and* survival in INBOX. Previously: 5 passed, 1 failed at setup.

## Docs

`docs/audit-2026-07-30.md` gets a dated **correction** rather than a silent edit. Its "closed by a regression test" claim was premature, and that should stay legible to anyone who relied on it.

## Cleanup note

The run retained two empty scratch folders by design (live cleanup never issues IMAP mailbox DELETE):
`Folders/mpE2E-50bfc890-e648-477a-bdc6-983e92c582a7-cleanup-rescue` and `Labels/mpE2E-50bfc890-e648-477a-bdc6-983e92c582a7-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)