### PR TITLE
fix(agents): reconcile agent list with status, add prune, fix service-account last-use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] — 2026-08-05
+
+### Fixed
+
+- **`mailpouch agent list` hid every interactive agent, making it disagree with `status`.** `list` enumerated the service-account store while `status` reported active *grants*, so a daemon serving two service accounts and five self-registered OAuth clients showed "7 agents active" next to a list of 2. Nothing was wrong with either count — they were counting different populations, and the one that mattered for review (which clients can currently reach your mail) was the one you could not see. `list` now enumerates grants, tagging each `kind=service` or `kind=interactive` and showing `calls` and last-use, so the two views reconcile. Revoked and expired grants stay hidden behind the new `prune` command.
+- **Service accounts always reported "last used: never".** `ensureActiveServiceGrant` rebuilds the grant record on every `client_credentials` login and carried `createdAt`, `approvedAt` and `totalCalls` forward but not `lastCallAt`, so each re-auth erased the timestamp while the call counter kept climbing — an account with thousands of calls looked untouched. Interactive grants never take that path, which is why only they retained timestamps. Historical values are unrecoverable; the field repopulates on each account's next call.
+- **A valueless `--flag` consumed the next flag as its value.** `parseFlags` unconditionally took the following argv entry, so `--dry-run --days 0` parsed as `dry-run="--days"` and silently dropped the retention window. A following `--`-prefixed token is now treated as the next flag.
+
+### Added
+
+- **`mailpouch agent prune [--days <n>] [--dry-run]`** clears revoked and expired grants, which previously accumulated on disk forever: `AgentGrantStore.prune()` existed but was never called from production code. Defaults to a 90-day retention window, never touches active or pending grants, and `--dry-run` previews from `listPrunable()` — the same predicate the removal runs on, so the preview cannot drift from the deletion. A bare `--days` with no value is rejected rather than falling back to a guessed window.
+
 ## [4.0.0] — 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v4.0.0-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v4.0.1-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "mailpouch — lean, permission-gated MCP access to Proton Mail via Proton Bridge, with up to 86 tools, resources, and prompts.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/agents/grant-store.test.ts
+++ b/src/agents/grant-store.test.ts
@@ -108,6 +108,18 @@ describe("AgentGrantStore", () => {
     } finally { unsub(); }
   });
 
+  it("ensureActiveServiceGrant preserves call counters across client_credentials re-auth", () => {
+    const s = new AgentGrantStore(path);
+    const args = { clientId: "pmc_cnt", clientName: "cron", preset: "full" as const };
+    s.ensureActiveServiceGrant(args);
+    s.recordCall("pmc_cnt");
+    const afterCall = s.get("pmc_cnt");
+    expect(afterCall?.lastCallAt).toBeDefined();
+    s.ensureActiveServiceGrant(args); // re-auth must not reset "last used" to never
+    expect(s.get("pmc_cnt")?.lastCallAt).toBe(afterCall?.lastCallAt);
+    expect(s.get("pmc_cnt")?.totalCalls).toBe(1);
+  });
+
   it("ensureActiveServiceGrant re-activating a non-active grant DOES notify (grant-approved)", () => {
     const s = new AgentGrantStore(path);
     s.createPending({ clientId: "pmc_cc2", clientName: "cowork" }); // pending, not active

--- a/src/agents/grant-store.ts
+++ b/src/agents/grant-store.ts
@@ -239,6 +239,10 @@ export class AgentGrantStore {
         createdAt: existing?.createdAt ?? now,
         approvedAt: existing?.approvedAt ?? now,
         totalCalls: existing?.totalCalls ?? 0,
+        // Carried forward with totalCalls: this rebuild runs on every
+        // client_credentials login, so dropping it reset service accounts to
+        // "last used: never" no matter how many calls they had made.
+        lastCallAt: existing?.lastCallAt,
         transport: "http",
         credentialKind: "service_account",
         note: LEGACY_SERVICE_ACCOUNT_GRANT_NOTE,
@@ -449,21 +453,29 @@ export class AgentGrantStore {
     return rows;
   }
 
+  /**
+   * The grants {@link prune} would drop. Exposed so a caller can preview the
+   * removal (`agent prune --dry-run`) against the same predicate that performs
+   * it — a second copy of this rule silently drifts from the real one.
+   */
+  listPrunable(retainDays = 90, now = Date.now()): AgentGrant[] {
+    const cutoff = now - retainDays * 24 * 60 * 60_000;
+    return [...this.grants.values()].filter(g => {
+      if (g.status !== "revoked" && g.status !== "expired") return false;
+      const endAt = g.revokedAt ?? g.approvedAt ?? g.createdAt;
+      // Inclusive: retainDays=0 means "everything already revoked", which is
+      // otherwise a coin flip against a same-millisecond cutoff.
+      return Date.parse(endAt) <= cutoff;
+    });
+  }
+
   /** Drop revoked/expired grants older than `retainDays` days. */
   prune(retainDays = 90, now = Date.now()): number {
     return this.mutate(() => {
-      const cutoff = now - retainDays * 24 * 60 * 60_000;
-      let removed = 0;
-      for (const [k, g] of this.grants) {
-        if (g.status !== "revoked" && g.status !== "expired") continue;
-        const endAt = g.revokedAt ?? g.approvedAt ?? g.createdAt;
-        if (Date.parse(endAt) < cutoff) {
-          this.grants.delete(k);
-          removed++;
-        }
-      }
-      if (removed > 0) this.persist();
-      return removed;
+      const doomed = this.listPrunable(retainDays, now);
+      for (const g of doomed) this.grants.delete(g.clientId);
+      if (doomed.length > 0) this.persist();
+      return doomed.length;
     });
   }
 }

--- a/src/cli/agent-cli.test.ts
+++ b/src/cli/agent-cli.test.ts
@@ -83,6 +83,54 @@ describe("mailpouch agent CLI", () => {
     expect(printed).toContain("status=active");
   });
 
+  it("list includes interactive grants that have no service account", async () => {
+    const h = harness();
+    await runAgentCli(["issue", "--name", "svc", "--preset", "full"], h.deps);
+    h.agentGrants.createPending({ clientId: "pmc_interactive", clientName: "Some MCP App" });
+    h.agentGrants.approve({ clientId: "pmc_interactive", preset: "read_only" });
+    h.out.length = 0;
+    expect(await runAgentCli(["list"], h.deps)).toBe(0);
+    const printed = h.out.join("\n");
+    expect(printed).toContain('"Some MCP App"');
+    expect(printed).toContain("kind=interactive");
+    expect(printed).toContain("kind=service");
+    expect(printed).toMatch(/2 agent\(s\): 1 service account\(s\), 1 interactive/);
+  });
+
+  it("prune drops old revoked grants but keeps active ones", async () => {
+    const h = harness();
+    await runAgentCli(["issue", "--name", "gone", "--preset", "full"], h.deps);
+    await runAgentCli(["issue", "--name", "kept", "--preset", "full"], h.deps);
+    const [a, b] = h.serviceAccounts.list();
+    await runAgentCli(["revoke", a.clientId], h.deps);
+    h.out.length = 0;
+
+    // --dry-run must not mutate, and must not swallow the flag that follows it.
+    expect(await runAgentCli(["prune", "--dry-run", "--days", "0"], h.deps)).toBe(0);
+    expect(h.out.join("\n")).toContain(a.clientId);
+    expect(h.agentGrants.get(a.clientId)).toBeDefined();
+
+    h.out.length = 0;
+    expect(await runAgentCli(["prune", "--days", "0"], h.deps)).toBe(0);
+    expect(h.out.join("\n")).toMatch(/Removed 1 revoked\/expired grant/);
+    expect(h.agentGrants.get(a.clientId)).toBeUndefined();
+    expect(h.agentGrants.get(b.clientId)?.status).toBe("active");
+  });
+
+  it("prune rejects a negative --days with exit code 2", async () => {
+    const h = harness();
+    expect(await runAgentCli(["prune", "--days", "-1"], h.deps)).toBe(2);
+  });
+
+  it("prune rejects a valueless --days rather than guessing a retention window", async () => {
+    const h = harness();
+    await runAgentCli(["issue", "--name", "x", "--preset", "full"], h.deps);
+    const id = h.serviceAccounts.list()[0].clientId;
+    await runAgentCli(["revoke", id], h.deps);
+    expect(await runAgentCli(["prune", "--days"], h.deps)).toBe(2);
+    expect(h.agentGrants.get(id)).toBeDefined(); // nothing removed
+  });
+
   it("revoke removes the account and revokes the grant", async () => {
     const h = harness();
     await runAgentCli(["issue", "--name", "kill", "--preset", "full"], h.deps);

--- a/src/cli/agent-cli.ts
+++ b/src/cli/agent-cli.ts
@@ -5,6 +5,7 @@
  *   mailpouch agent issue  --name <n> --preset <preset> [--expires <iso>] [--folder a,b]
  *   mailpouch agent list
  *   mailpouch agent revoke <client_id>
+ *   mailpouch agent prune  [--days <n>] [--dry-run]
  *
  * Runs as a short-lived process distinct from the MCP daemon: it edits the
  * on-disk service-account + grant stores directly. `issue`/`list` are fully
@@ -15,6 +16,7 @@
 
 import type { ServiceAccountStore } from "../agents/service-account-store.js";
 import type { AgentGrantStore } from "../agents/grant-store.js";
+import { isServiceAccountGrant } from "../agents/grant-store.js";
 import { PERMISSION_PRESETS, type PermissionPreset } from "../config/schema.js";
 import type { GrantConditions } from "../agents/types.js";
 
@@ -29,7 +31,8 @@ export interface AgentCliDeps {
 const USAGE = `Usage:
   mailpouch agent issue --name <name> --preset <${PERMISSION_PRESETS.join("|")}> [--expires <iso8601>] [--folder a,b,c]
   mailpouch agent list
-  mailpouch agent revoke <client_id>`;
+  mailpouch agent revoke <client_id>
+  mailpouch agent prune [--days <n>] [--dry-run]`;
 
 /** Parse `--flag value` / `--flag=value` pairs and positional args from argv. */
 function parseFlags(args: string[]): { flags: Record<string, string>; positional: string[] } {
@@ -42,8 +45,15 @@ function parseFlags(args: string[]): { flags: Record<string, string>; positional
       if (eq >= 0) {
         flags[a.slice(2, eq)] = a.slice(eq + 1);
       } else {
-        flags[a.slice(2)] = args[i + 1] ?? "";
-        i++;
+        // A following "--flag" is the next flag, not this one's value, so
+        // valueless switches like --dry-run don't swallow it.
+        const next = args[i + 1];
+        if (next === undefined || next.startsWith("--")) {
+          flags[a.slice(2)] = "";
+        } else {
+          flags[a.slice(2)] = next;
+          i++;
+        }
       }
     } else {
       positional.push(a);
@@ -106,16 +116,22 @@ export async function runAgentCli(argv: string[], deps: AgentCliDeps): Promise<n
     }
 
     case "list": {
-      const accounts = deps.serviceAccounts.list();
-      if (accounts.length === 0) { out("No service accounts. Create one with `mailpouch agent issue`."); return 0; }
-      out(`${accounts.length} service account(s):`);
+      // Lists every grant, not just service accounts: interactive OAuth clients
+      // (an MCP app that self-registered) hold grants with no credential record,
+      // and omitting them made `status`'s active count look inconsistent with this.
+      const grants = deps.agentGrants.list().filter(g => g.status !== "revoked" && g.status !== "expired");
+      if (grants.length === 0) { out("No agents. Create a service account with `mailpouch agent issue`."); return 0; }
+      const serviceCount = grants.filter(isServiceAccountGrant).length;
+      out(`${grants.length} agent(s): ${serviceCount} service account(s), ${grants.length - serviceCount} interactive`);
       out("");
-      for (const a of accounts) {
-        const grant = deps.agentGrants.get(a.clientId);
-        const status = grant?.status ?? "(no grant)";
-        const expires = a.conditions?.expiresAt ? ` expires=${a.conditions.expiresAt}` : "";
-        out(`  ${a.clientId}  "${a.clientName}"  preset=${a.preset}  status=${status}${expires}`);
+      for (const g of grants) {
+        const kind = isServiceAccountGrant(g) ? "service" : "interactive";
+        const expires = g.conditions?.expiresAt ? ` expires=${g.conditions.expiresAt}` : "";
+        const lastCall = g.lastCallAt ? ` last=${g.lastCallAt}` : " last=never";
+        out(`  ${g.clientId}  "${g.clientName}"  kind=${kind}  preset=${g.preset}  status=${g.status}  calls=${g.totalCalls}${lastCall}${expires}`);
       }
+      out("");
+      out("Revoked/expired grants are hidden; clear them with `mailpouch agent prune`.");
       return 0;
     }
 
@@ -127,6 +143,27 @@ export async function runAgentCli(argv: string[], deps: AgentCliDeps): Promise<n
       if (!existed && !grant) { err(`error: no service account or grant found for ${clientId}.`); return 1; }
       out(`Revoked ${clientId}: service account ${existed ? "removed" : "absent"}, grant ${grant ? "revoked" : "absent"}.`);
       out("A running daemon drops the live token on its next grant-store sync or restart.");
+      return 0;
+    }
+
+    case "prune": {
+      // A bare `--days` must not fall through to the default: on a removal
+      // path, silently pruning at 90 (or at 0, via Number("")) is the kind of
+      // guess that deletes the wrong records.
+      if (flags.days !== undefined && flags.days.trim() === "") {
+        err("error: --days requires a value."); return 2;
+      }
+      const days = flags.days ? Number(flags.days) : 90;
+      if (!Number.isFinite(days) || days < 0) { err("error: --days must be a non-negative number."); return 2; }
+      if ("dry-run" in flags) {
+        const stale = deps.agentGrants.listPrunable(days);
+        out(`${stale.length} revoked/expired grant(s) older than ${days} day(s) would be removed:`);
+        for (const g of stale) out(`  ${g.clientId}  "${g.clientName}"  status=${g.status}`);
+        return 0;
+      }
+      const removed = deps.agentGrants.prune(days);
+      out(`Removed ${removed} revoked/expired grant(s) older than ${days} day(s).`);
+      out("Active and pending grants are never pruned — revoke them first.");
       return 0;
     }
 


### PR DESCRIPTION
## Summary

Three defects in the agent-grant layer, surfaced while diagnosing why the daemon reported "7 agents active" next to a two-line `agent list`.

- **`agent list` hid every interactive agent.** It enumerated the service-account store while `status` counted active *grants*. Both counts were correct but described different populations — and the invisible one was the security-relevant view: which clients can currently reach the mailbox. `list` now enumerates grants, tagged `kind=service`/`kind=interactive` with call counts and last use.
- **Service accounts always reported "last used: never".** `ensureActiveServiceGrant` rebuilds its record on every `client_credentials` login and carried `createdAt`/`approvedAt`/`totalCalls` forward but dropped `lastCallAt`, so each re-auth erased the timestamp while the counter kept climbing. An account with 2,339 calls looked untouched. Interactive grants skip that path, which is why only they kept timestamps. Historical values are unrecoverable; the field repopulates on next call.
- **A valueless `--flag` swallowed the next flag.** `parseFlags` unconditionally consumed the following argv entry, so `--dry-run --days 0` parsed as `dry-run="--days"` and silently dropped the retention window.

## Added

`mailpouch agent prune [--days <n>] [--dry-run]` clears revoked/expired grants, which accumulated on disk forever — `AgentGrantStore.prune()` existed but was never called from production code. Defaults to 90-day retention, never touches active or pending grants.

Two guards on that deletion path:
- `--dry-run` previews from `listPrunable()`, the same predicate removal runs on, so the preview cannot drift from the deletion. (A duplicated predicate had already drifted once during development.)
- A bare `--days` is rejected rather than falling back to a guessed window — `Number("")` is `0`, which would have pruned everything.

## Test plan

- [x] `npm run preship` full gate PASS (24 min) — typecheck, lint, version-sync, secrets, npm-audit, license-inventory, build, unit, tarball-smoke, Greenmail E2E, **live Bridge E2E**
- [x] Unit suite 2878 passing across 136 files
- [x] `lastCallAt` regression test verified to fail against unpatched source, pass with the fix
- [x] Verified against a real grant store: `list` reconciles with `status`; `prune --days 30 --dry-run` previews 17 stale grants without deleting; `prune --days` rejected

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] No new attack surface — `prune` only removes already-revoked/expired records and cannot touch active or pending grants
- [x] Dependencies unchanged
- [x] No Docker changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)