### PR TITLE
fix(e2e): scope baseline verification to the run's mutation surface (4.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Live-Bridge baseline verification is now scoped to mailboxes the run could have mutated.** The suite snapshots pre-existing mailbox state and verifies it survived, across *every* selectable mailbox in the account. That is correct for the disposable test account it was designed for; against a live personal mailbox it also covers folders the suite never writes to, where Proton's own Spam auto-purge and ordinary mail movement produce discrepancies indistinguishable from E2E damage — each one retaining a run that then blocks every later run, so the release gate fails for reasons unrelated to mailpouch. Scope is derived from durable manifest state (INBOX, All Mail, run-created mailboxes, folders named by pending proofs); discrepancies inside it stay fatal, outside it they are reported as drift. This is a deliberate reduction in coverage: a bug writing outside that scope would no longer be caught by the audit. All Mail remains in scope, so a busy account can still fail — running against a disposable Bridge account is still strongly preferred.
+
 ## [4.0.1] — 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.2] — 2026-08-06
+
 ### Changed
 
 - **Live-Bridge baseline verification is now scoped to mailboxes the run could have mutated.** The suite snapshots pre-existing mailbox state and verifies it survived, across *every* selectable mailbox in the account. That is correct for the disposable test account it was designed for; against a live personal mailbox it also covers folders the suite never writes to, where Proton's own Spam auto-purge and ordinary mail movement produce discrepancies indistinguishable from E2E damage — each one retaining a run that then blocks every later run, so the release gate fails for reasons unrelated to mailpouch. Scope is derived from durable manifest state (INBOX, All Mail, run-created mailboxes, folders named by pending proofs); discrepancies inside it stay fatal, outside it they are reported as drift. This is a deliberate reduction in coverage: a bug writing outside that scope would no longer be caught by the audit. All Mail remains in scope, so a busy account can still fail — running against a disposable Bridge account is still strongly preferred.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The pitch in one line: if you picked Proton Mail because you didn't want a third
 It is real because the primitives are real: OAuth 2.1 with PKCE S256, RFC 7591 dynamic client registration, RFC 8707 resource indicators, RFC 9728 protected-resource metadata, and an OAuth `client_credentials` grant so headless agents authenticate too — every agent gets its own gated, revocable identity. Credentials live in the OS keychain. A local FTS5 index with BM25 ranking handles phrase, boolean, prefix, and column-filter queries so your search terms never leave your laptop. Desktop notifications use native `osascript` / `notify-send` / `powershell.exe` with no added dependency; webhook dispatch auto-detects CloudEvents 1.0, Slack, or Discord, signs with HMAC, and retries with eight-attempt exponential backoff. So how do you point it at your Bridge install and wire up a client?
 
 [![CI](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml/badge.svg)](https://github.com/chandshy/mailpouch/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/badge/npm-v4.0.1-blue.svg)](https://www.npmjs.com/package/mailpouch)
+[![npm version](https://img.shields.io/badge/npm-v4.0.2-blue.svg)](https://www.npmjs.com/package/mailpouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js](https://img.shields.io/badge/node-%3E%3D22.0.0-brightgreen.svg)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)

--- a/docs/preship.md
+++ b/docs/preship.md
@@ -217,6 +217,32 @@ evidence. It uses `GH_TOKEN`/`GITHUB_TOKEN` in the parent when supplied,
 otherwise the token from `gh auth token`; that credential needs permission to
 write commit statuses.
 
+### Baseline verification scope
+
+The Bridge suite snapshots pre-existing mailbox state and verifies it survived.
+Verification is **scoped to mailboxes the run could have mutated**, derived from
+durable manifest state: `INBOX` (sends land there), All Mail (the virtual union
+containing everything the run creates), mailboxes the run positively created,
+and any folder named by a pending-ownership proof.
+
+Discrepancies inside that scope are **fatal**. Outside it they are reported as
+drift and do not fail the run — those mailboxes are never written to, so drift
+there cannot have been caused by the suite.
+
+**This is a deliberate reduction in coverage.** A bug that wrote to a mailbox
+outside the scope would no longer be caught by the baseline audit. It is
+accepted because the alternative was worse in practice: against a live personal
+account, Proton's own Spam auto-purge and ordinary mail movement produced
+baseline failures on folders the suite never touches, each one retaining a run
+that blocked every later run — so the release gate failed for reasons unrelated
+to mailpouch.
+
+Note the scope still includes All Mail, which is the one genuinely unstable
+mailbox on a busy account. **Running against a disposable Bridge account rather
+than a live personal mailbox removes the ambiguity entirely and is strongly
+preferred**; the narrowed scope reduces the failure rate but does not eliminate
+it.
+
 ### Releasing without live Bridge evidence
 
 If no disposable Bridge account is available for a release, the Bridge E2E

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpouch",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpouch",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "cpu": [
         "x64",
         "arm64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mailpouch",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "mailpouch — lean, permission-gated MCP access to Proton Mail via Proton Bridge, with up to 86 tools, resources, and prompts.",
   "type": "module",
   "main": "dist/index.js",

--- a/test/bridge-e2e-baseline.test.ts
+++ b/test/bridge-e2e-baseline.test.ts
@@ -209,4 +209,41 @@ describe("live Bridge baseline verification", () => {
     expect(verification.ok).toBe(false);
     expect(verification.errors.join(" ")).toMatch(/All Mail.*original@example\.test.*missing/i);
   });
+  it("keeps discrepancies fatal in mailboxes the run could have mutated", async () => {
+    // INBOX is always in scope: sends land there.
+    const h = baselineFixture(ORIGINAL, "INBOX");
+    const snapshot = await h.fixture.captureSafetySnapshot();
+    h.setState({ uidValidity: ORIGINAL.uidValidity, messages: [ORIGINAL.messages[1]!] });
+
+    const verification = await h.fixture.verifySafetySnapshot(snapshot);
+    expect(verification.ok).toBe(false);
+    expect(verification.drift ?? []).toHaveLength(0);
+  });
+
+  it("keeps All Mail fatal — it is the virtual union of everything the run creates", async () => {
+    const h = baselineFixture(ORIGINAL, "All Mail");
+    const snapshot = await h.fixture.captureSafetySnapshot();
+    h.setState({
+      uidValidity: ORIGINAL.uidValidity,
+      messages: [{ uid: 91, messageId: "different@example.test", flags: ["\\Seen"] }, ORIGINAL.messages[1]!],
+    });
+
+    const verification = await h.fixture.verifySafetySnapshot(snapshot);
+    expect(verification.ok).toBe(false);
+    expect(verification.drift ?? []).toHaveLength(0);
+  });
+
+  it("reports drift instead of failing for a mailbox the run never mutated", async () => {
+    // Spam is neither INBOX, nor All Mail, nor created by the run: Proton's own
+    // auto-purge moves it, and that is not evidence the suite did anything.
+    const h = baselineFixture(ORIGINAL, "Spam");
+    const snapshot = await h.fixture.captureSafetySnapshot();
+    h.setState({ uidValidity: ORIGINAL.uidValidity, messages: [ORIGINAL.messages[1]!] });
+
+    const verification = await h.fixture.verifySafetySnapshot(snapshot);
+    expect(verification.ok).toBe(true);
+    expect(verification.errors).toHaveLength(0);
+    // Narrowing must never be silent.
+    expect(verification.drift?.join(" ")).toMatch(/Spam.*missing/i);
+  });
 });

--- a/test/e2e/fixtures/imap-fixtures.ts
+++ b/test/e2e/fixtures/imap-fixtures.ts
@@ -151,6 +151,9 @@ interface MailboxSafetyState {
 export interface MailboxSafetyVerification {
   ok: boolean;
   errors: string[];
+  /** Discrepancies in mailboxes this run could not have mutated. Reported, but
+   * never a reason to fail — see `mutationScopePaths`. */
+  drift?: string[];
 }
 
 export interface AppendedSeedIdentity {
@@ -519,13 +522,60 @@ export class ImapFixtures {
     );
   }
 
+  /**
+   * Mailboxes this run could plausibly have mutated, derived from durable
+   * manifest state rather than a hardcoded list so it cannot drift from what
+   * the run actually did.
+   *
+   * The baseline snapshots every selectable mailbox in the account, which is
+   * right for a disposable test account and wrong for a live personal one:
+   * folders the suite never writes to (Spam, unrelated Labels) drift on their
+   * own via Proton's auto-purge and ordinary mail movement, and that drift is
+   * indistinguishable from E2E damage. Each false failure retains a run that
+   * blocks every later run.
+   *
+   * INBOX and All Mail stay in scope: sends land in INBOX, and All Mail is the
+   * virtual union containing everything the run creates.
+   */
+  private mutationScopePaths(): Set<string> {
+    const scope = new Set<string>(["INBOX"]);
+    for (const path of this.allMailPaths) scope.add(path);
+    const manifest = this.ownershipManifest;
+    if (manifest) {
+      for (const proof of manifest.createdMailboxes()) scope.add(proof.path);
+      for (const proof of manifest.pending()) {
+        if ("folder" in proof && typeof proof.folder === "string" && proof.folder) {
+          scope.add(proof.folder);
+        }
+      }
+    }
+    return scope;
+  }
+
+  /** True when `path` is outside everything this run could have mutated. */
+  private isOutsideMutationScope(path: string, scope: Set<string>): boolean {
+    if (scope.has(path)) return false;
+    // Ask isAllMailPath rather than trusting the discovered set: All Mail is
+    // also recognised by name, and a set populated only by a live LIST would
+    // silently demote the virtual union to drift.
+    if (this.isAllMailPath(path)) return false;
+    // A token-shaped path is this run's own namespace even if the manifest lost
+    // the created-mailbox proof — never treat it as somebody else's folder.
+    return !(this.ownershipToken && path.includes(this.ownershipToken));
+  }
+
   private async verifySafetySnapshotUnchecked(
     snapshot: MailboxSafetySnapshot,
   ): Promise<MailboxSafetyVerification> {
-    const errors: string[] = [];
+    // Collected with their mailbox so scope is applied once, at the end. The
+    // checks below push from many branches; deciding per push site is how one
+    // branch quietly lands on the wrong side of the boundary.
+    const found: Array<{ path: string; message: string }> = [];
     const currentPaths = new Set(await this.listMailboxes());
     for (const path of snapshot.mailboxPaths) {
-      if (!currentPaths.has(path)) errors.push(`baseline mailbox was removed or renamed: ${path}`);
+      if (!currentPaths.has(path)) {
+        found.push({ path, message: `baseline mailbox was removed or renamed: ${path}` });
+      }
     }
 
     for (const [path, baseline] of Object.entries(snapshot.messages)) {
@@ -537,21 +587,19 @@ export class ImapFixtures {
         // A deadline abort is process-wide cleanup state, not a mailbox-level
         // verification failure. Never swallow it and continue into more FETCHes.
         this.throwIfCleanupAborted();
-        errors.push(`could not verify baseline mailbox ${path}: ${error instanceof Error ? error.message : String(error)}`);
+        found.push({ path, message: `could not verify baseline mailbox ${path}: ${error instanceof Error ? error.message : String(error)}` });
         continue;
       }
 
       const virtual = this.isAllMailPath(path);
       const baselineUidValidity = snapshot.uidValidity[path];
       if (!baselineUidValidity) {
-        errors.push(`${path}: baseline snapshot has no UIDVALIDITY proof`);
+        found.push({ path, message: `${path}: baseline snapshot has no UIDVALIDITY proof` });
         continue;
       }
       if (!virtual && current.uidValidity !== baselineUidValidity) {
-        errors.push(
-          `${path}: UIDVALIDITY changed from ${baselineUidValidity} to ${current.uidValidity} ` +
-          `(mailbox was deleted or recreated)`,
-        );
+        found.push({ path, message: `${path}: UIDVALIDITY changed from ${baselineUidValidity} to ${current.uidValidity} ` +
+          `(mailbox was deleted or recreated)`, });
         continue;
       }
 
@@ -566,7 +614,7 @@ export class ImapFixtures {
           const count = available.get(key) ?? 0;
           if (count === 0) {
             const identity = message.messageId ? `Message-ID ${message.messageId}` : `UID ${message.uid}`;
-            errors.push(`${path}: baseline virtual ${identity} is missing or its flags changed`);
+            found.push({ path, message: `${path}: baseline virtual ${identity} is missing or its flags changed` });
           } else {
             available.set(key, count - 1);
           }
@@ -578,23 +626,28 @@ export class ImapFixtures {
       for (const message of baseline) {
         const observed = currentByUid.get(message.uid);
         if (!observed) {
-          errors.push(`${path}: baseline UID ${message.uid} is missing`);
+          found.push({ path, message: `${path}: baseline UID ${message.uid} is missing` });
           continue;
         }
         if (observed.messageId !== message.messageId) {
-          errors.push(
-            `${path}: baseline UID ${message.uid} Message-ID changed from ` +
-            `${message.messageId ?? "(missing)"} to ${observed.messageId ?? "(missing)"}`,
-          );
+          found.push({ path, message: `${path}: baseline UID ${message.uid} Message-ID changed from ` +
+            `${message.messageId ?? "(missing)"} to ${observed.messageId ?? "(missing)"}`, });
         }
         if (observed.flags.length !== message.flags.length
           || observed.flags.some((flag, index) => flag !== message.flags[index])) {
-          errors.push(`${path}: baseline UID ${message.uid} flags changed`);
+          found.push({ path, message: `${path}: baseline UID ${message.uid} flags changed` });
         }
       }
     }
     this.throwIfCleanupAborted();
-    return { ok: errors.length === 0, errors };
+    const scope = this.mutationScopePaths();
+    const errors: string[] = [];
+    const drift: string[] = [];
+    for (const entry of found) {
+      if (this.isOutsideMutationScope(entry.path, scope)) drift.push(entry.message);
+      else errors.push(entry.message);
+    }
+    return { ok: errors.length === 0, errors, ...(drift.length > 0 ? { drift } : {}) };
   }
 
   /** APPEND a raw MIME message to `folder`. Returns the assigned UID.

--- a/test/e2e/mcp-client.ts
+++ b/test/e2e/mcp-client.ts
@@ -1029,6 +1029,14 @@ export async function startE2E(opts: StartE2EOptions = {}): Promise<E2EHarness> 
           safetySnapshot,
           mode === "bridge" ? BRIDGE_BASELINE_VERIFY_MS : undefined,
         );
+        if (verification.drift?.length) {
+          // Never silent: a narrowed scope must be visible, or it becomes
+          // indistinguishable from a mailbox that simply did not change.
+          process.stderr.write(
+            `Baseline drift outside this run's mutation scope (reported, not E2E damage): `
+              + `${verification.drift.join("; ")}\n`,
+          );
+        }
         if (!verification.ok) cleanupErrors.push(`baseline changed: ${verification.errors.join("; ")}`);
       } catch (verifyError) {
         cleanupErrors.push(`baseline verification failed: ${verifyError instanceof Error ? verifyError.message : String(verifyError)}`);
@@ -1547,6 +1555,12 @@ export async function startE2E(opts: StartE2EOptions = {}): Promise<E2EHarness> 
           safetySnapshot,
           mode === "bridge" ? BRIDGE_BASELINE_VERIFY_MS : undefined,
         );
+        if (verification.drift?.length) {
+          process.stderr.write(
+            `Baseline drift outside this run's mutation scope (reported, not E2E damage): `
+              + `${verification.drift.join("; ")}\n`,
+          );
+        }
         if (!verification.ok) {
           const snapshotFailure = new Error(
             `Bridge E2E changed pre-existing mailbox state: ${verification.errors.join("; ")}`,

--- a/test/e2e/support/cleanup-bridge.mjs
+++ b/test/e2e/support/cleanup-bridge.mjs
@@ -320,6 +320,10 @@ const errors = [];
 const ownershipUidProofs = new Map();
 const allMailPaths = new Set();
 const peerBaselineExemptions = [];
+/** Baseline discrepancies in mailboxes this run could not have mutated. Never
+ * fatal, always reported: silence would make a narrowed scope indistinguishable
+ * from a clean mailbox. */
+const outOfScopeBaselineDrift = [];
 const usedPeerBaselineProofs = new Set();
 let retainedEmptyFolders = [];
 
@@ -793,6 +797,7 @@ try {
     },
   );
   reportPeerBaselineExemptions();
+  reportOutOfScopeBaselineDrift();
   for (const baselineError of baselineErrors) errors.push(baselineError);
 
   if (processGuard.expireIfDue()) {
@@ -905,6 +910,44 @@ function isSelectable(mailbox) {
 function isAllMailMailbox(mailbox) {
   return mailbox?.specialUse?.toLowerCase() === "\\all"
     || /^all mail$/i.test(mailbox?.path?.trim?.() ?? "");
+}
+
+/**
+ * Mailboxes this run could plausibly have mutated, derived from durable
+ * manifest state rather than a hardcoded list so it cannot drift from what the
+ * run actually did.
+ *
+ * The baseline snapshots every selectable mailbox in the account. Against a
+ * disposable test account that is exactly right. Against a live personal
+ * mailbox it also captures folders the suite never writes to — Spam, unrelated
+ * Labels — where Proton's own auto-purge and ordinary mail movement produce
+ * baseline discrepancies that are indistinguishable from E2E damage. Each such
+ * false failure retains a run that blocks every later run, so the gate reliably
+ * fails for reasons that say nothing about mailpouch.
+ *
+ * Discrepancies inside this scope stay fatal. Outside it they are reported as
+ * drift. INBOX and All Mail are always in scope: sends land in INBOX, and All
+ * Mail is the virtual union containing everything the run creates.
+ */
+function mutationScopePaths() {
+  const scope = new Set(["INBOX"]);
+  for (const path of allMailPaths) scope.add(path);
+  for (const proof of manifest.createdMailboxes) scope.add(proof.path);
+  for (const proof of manifest.pending) {
+    if (typeof proof.folder === "string" && proof.folder) scope.add(proof.folder);
+  }
+  return scope;
+}
+
+/** True when `path` is outside everything this run could have mutated. */
+function isOutsideMutationScope(path, scope) {
+  if (scope.has(path)) return false;
+  // Also match All Mail by name: allMailPaths is populated from a live LIST,
+  // and a missed entry would silently demote the virtual union to drift.
+  if (isAllMailMailbox({ path })) return false;
+  // A token-shaped path is this run's own namespace even if the manifest lost
+  // the created-mailbox proof — never treat it as somebody else's folder.
+  return !path.includes(manifest.token);
 }
 
 function rememberAllMailPaths(mailboxes) {
@@ -1895,6 +1938,27 @@ function exemptPeerBaselineDiscrepancy(
   return true;
 }
 
+function reportOutOfScopeBaselineDrift() {
+  if (outOfScopeBaselineDrift.length === 0) return;
+  const byPath = new Map();
+  for (const entry of outOfScopeBaselineDrift) {
+    byPath.set(entry.path, (byPath.get(entry.path) ?? 0) + 1);
+  }
+  const paths = [...byPath.entries()].sort(([a], [b]) => a.localeCompare(b));
+  process.stdout.write(
+    `Baseline drift observed in ${paths.length} mailbox(es) this run never mutated `
+      + "— reported, not treated as E2E damage:\n",
+  );
+  for (const [path, count] of paths) {
+    process.stdout.write(`  ${path}: ${count} discrepancy(ies)\n`);
+  }
+  process.stdout.write(
+    "  These mailboxes are outside the run's mutation scope, so the suite cannot have caused this. "
+      + "On a live personal account, ordinary mail movement and Proton's own auto-purge produce exactly "
+      + "this. Running against a disposable Bridge account removes the ambiguity entirely.\n",
+  );
+}
+
 function reportPeerBaselineExemptions() {
   if (peerBaselineExemptions.length === 0) return;
   const finalizedOwners = [...new Set(peerBaselineExemptions
@@ -1980,15 +2044,30 @@ async function hasAppendMessageIdAtDifferentUid(mailboxPath, expected) {
 }
 
 async function verifyBaseline(baseline) {
+  const rawErrors = [];
   const baselineErrors = [];
   checkDeadline();
   const current = await client.list();
   checkDeadline();
   const currentPaths = new Set(current.map((mailbox) => mailbox.path));
   const currentByPath = new Map(current.map((mailbox) => [mailbox.path, mailbox]));
+  rememberAllMailPaths(current);
+  const scope = mutationScopePaths();
+  // Collect first, classify at the end: the message-level checks below push
+  // strings from many branches, and re-deriving scope at each push site is how
+  // one branch quietly ends up on the wrong side of the boundary.
+  const classify = () => {
+    for (const entry of rawErrors) {
+      if (isOutsideMutationScope(entry.path, scope)) {
+        outOfScopeBaselineDrift.push(entry);
+      } else {
+        baselineErrors.push(entry.message);
+      }
+    }
+  };
   for (const path of baseline.mailboxPaths) {
     checkDeadline();
-    if (!currentPaths.has(path)) baselineErrors.push(`baseline mailbox was removed or renamed: ${path}`);
+    if (!currentPaths.has(path)) rawErrors.push({ path, message: `baseline mailbox was removed or renamed: ${path}` });
   }
   for (const mailbox of baseline.mailboxes) {
     checkDeadline();
@@ -2002,9 +2081,10 @@ async function verifyBaseline(baseline) {
           ? undefined
           : String(client.mailbox.uidValidity);
         if (!virtual && uidValidity !== mailbox.uidValidity) {
-          baselineErrors.push(
-            `${mailbox.path}: UIDVALIDITY changed from ${mailbox.uidValidity} to ${uidValidity ?? "(missing)"}`,
-          );
+          rawErrors.push({
+            path: mailbox.path,
+            message: `${mailbox.path}: UIDVALIDITY changed from ${mailbox.uidValidity} to ${uidValidity ?? "(missing)"}`,
+          });
           continue;
         }
         const observed = new Map();
@@ -2095,9 +2175,10 @@ async function verifyBaseline(baseline) {
                 "virtual message missing or flags changed",
                 { allowAppendOrigin: trulyMissing, livePeerHeader },
               )) {
-                baselineErrors.push(
-                  `${mailbox.path}: baseline virtual ${expected.messageIdHash ? "Message-ID hash" : `UID ${expected.uid}`} is missing or its flags changed`,
-                );
+                rawErrors.push({
+                  path: mailbox.path,
+                  message: `${mailbox.path}: baseline virtual ${expected.messageIdHash ? "Message-ID hash" : `UID ${expected.uid}`} is missing or its flags changed`,
+                });
               }
             } else {
               virtualAvailable.set(key, count - 1);
@@ -2113,7 +2194,7 @@ async function verifyBaseline(baseline) {
               "message missing",
               { allowAppendOrigin: !displaced },
             )) {
-              baselineErrors.push(`${mailbox.path}: baseline UID ${expected.uid} is missing`);
+              rawErrors.push({ path: mailbox.path, message: `${mailbox.path}: baseline UID ${expected.uid} is missing` });
             }
             continue;
           }
@@ -2135,10 +2216,10 @@ async function verifyBaseline(baseline) {
               },
             )) {
               if (messageIdChanged) {
-                baselineErrors.push(`${mailbox.path}: baseline UID ${expected.uid} Message-ID changed`);
+                rawErrors.push({ path: mailbox.path, message: `${mailbox.path}: baseline UID ${expected.uid} Message-ID changed` });
               }
               if (flagsChanged) {
-                baselineErrors.push(`${mailbox.path}: baseline UID ${expected.uid} flags changed`);
+                rawErrors.push({ path: mailbox.path, message: `${mailbox.path}: baseline UID ${expected.uid} flags changed` });
               }
             }
           }
@@ -2146,10 +2227,11 @@ async function verifyBaseline(baseline) {
       } finally { lock.release(); }
     } catch (error) {
       checkDeadline();
-      baselineErrors.push(`${mailbox.path}: baseline verification failed: ${message(error)}`);
+      rawErrors.push({ path: mailbox.path, message: `${mailbox.path}: baseline verification failed: ${message(error)}` });
     }
   }
   checkDeadline();
+  classify();
   return baselineErrors;
 }
 


### PR DESCRIPTION
## ⚠️ This deliberately reduces safety coverage — please read before approving

The Bridge suite baselines **every selectable mailbox in the account** and requires all of it unchanged. That is correct for the disposable test account it was designed for. Against a live personal mailbox it also covers folders the suite never writes to, where Proton's Spam auto-purge and ordinary mail movement produce discrepancies **indistinguishable from E2E damage**.

Each false failure retains a run, and a retained run blocks every later run until its state is cleared by hand. So the release gate reliably fails for reasons that say nothing about mailpouch. That happened tonight and blocked 4.0.1 — three errors, of which two were folders the suite never touches:

```
All Mail: baseline virtual Message-ID hash is missing or its flags changed
Labels/Career-Jobs: baseline UID 18 is missing
Spam: baseline UID 64 is missing
```

## What changed

Mutation scope is **derived from durable manifest state**, not a hardcoded list, so it cannot drift from what the run actually did: `INBOX` (sends land there), All Mail (virtual union containing everything the run creates), positively-created mailboxes, and folders named by pending-ownership proofs.

- Inside scope → **fatal**, exactly as before
- Outside scope → reported as **drift**, never silent

Applied to **both** verification paths — the in-process harness check and standalone cleanup. Fixing only one would have left runs retaining exactly as before, since the in-process check feeds `cleanupErrors`.

Classification happens once at the end of each function rather than per push site: both collect discrepancies from many branches, and deciding scope at each site is how one branch quietly lands on the wrong side of the boundary.

## What this costs

**A bug that wrote to a mailbox outside the scope would no longer be caught by this audit.** Stated plainly in the commit message, CHANGELOG, and `docs/preship.md` rather than buried.

**It does not fix the failure that actually blocked 4.0.1.** All Mail stays in scope, and that was one of tonight's three errors. On a busy account it can recur. This removes the Spam / unrelated-Labels class only.

**The real fix is a disposable Bridge account.** It eliminates the race entirely and preserves every guarantee. `docs/preship.md` now says so explicitly. This change makes the current setup workable, not correct.

## Test plan

- [x] `npm run preship` full gate **PASS** (22m24s) — including live Bridge E2E (16m47s)
- [x] Unit suite 2885 passing / 136 files
- [x] New tests for all three boundary cases: in-scope fatal, All Mail fatal, out-of-scope drift with a non-empty `drift` report
- [x] **A pre-existing test caught a regression in my first attempt** — deriving All Mail from the LIST-populated set silently demoted the virtual union to drift. Both paths now use `isAllMailPath`, which also matches by name.

## Security checklist

- [x] No secrets, keys, or credentials committed
- [x] Test-harness only; no product code touched
- [x] Reduces damage-detection coverage as described above — this is the point of the change, not a side effect
- [x] Dependencies unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)