### PR TITLE
docs: reconcile help with current behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing to mailpouch! This document provides
 ### Prerequisites
 
 - Node.js 22.0.0 or higher
-- npm 9.0.0 or higher
+- npm 10.0.0 or higher
 - Proton Mail account with Proton Bridge installed
 - Git
 
@@ -102,7 +102,7 @@ feat: add email filtering by date range
 
 ```
 src/
-├── index.ts                    # Unified daemon: MCP server (76 tools, Resources, Prompts) + settings HTTP server + system tray
+├── index.ts                    # Unified daemon: MCP server (up to 86 tools: 83 canonical + 3 meta-tools, Resources, Prompts) + settings HTTP server + system tray
 ├── settings-main.ts            # Standalone settings-UI CLI entry point — hosts the persistent tray icon via mailpouch-settings
 ├── accounts/
 │   ├── registry.ts             # Multi-account CRUD + per-account keychain routing

--- a/HELP.md
+++ b/HELP.md
@@ -42,7 +42,7 @@ Prefer the command line? `npx -y mailpouch setup --username you@proton.me --pass
 
 ### CLI commands
 
-Run any of these as `npx -y mailpouch <command>` — the `npx -y` form works even when the global `mailpouch` bin isn't on your `PATH`, and these commands **print and exit** (they never start a server):
+Run any of these as `npx -y mailpouch <command>` — the `npx -y` form works even when the global `mailpouch` bin isn't on your `PATH`. The help, setup, doctor, status, and agent operations **print and exit**; `daemon` remains running as the shared HTTP server:
 
 | Command | What it does |
 |---|---|
@@ -50,7 +50,7 @@ Run any of these as `npx -y mailpouch <command>` — the `npx -y` form works eve
 | `mailpouch status [--json]` | Is mailpouch running (PID, ports), connection state, approved-agent counts, Bridge reachability — read-only |
 | `mailpouch doctor [--json]` | Diagnose the install/connection and print the next step (exit 0 when ready) |
 | `mailpouch setup …` | Configure Bridge credentials non-interactively |
-| `mailpouch agent <issue\|list\|revoke>` | Manage headless service accounts |
+| `mailpouch agent <issue\|list\|revoke\|prune>` | Manage headless service accounts; `prune` accepts `--days N` (default 90) and `--dry-run` |
 | `mailpouch daemon [--host H] [--port P]` | Run the shared HTTP daemon (forces HTTP transport) |
 
 Running `mailpouch` with **no command** starts the MCP server on stdio — that's what an MCP client (e.g. Claude Desktop) spawns; you don't run it by hand. An unrecognized command prints an error and exits rather than starting a server.
@@ -164,7 +164,7 @@ codes; both require `{ confirmed: true }` on every call.
 
 Open **Settings → Setup tab** → toggle **Desktop notifications for agent permission requests**.
 
-When enabled (default), mailpouch fires a native OS notification whenever an agent submits a permission escalation request. The notification title is the agent's client ID; the body summarises the requested preset.
+When an unrecognized agent connection creates a pending grant, mailpouch normally surfaces a native on-screen **Approve/Deny** dialog. If the dialog is disabled or the host is detected as headless/unavailable before launch, mailpouch opens the browser approval window and, when desktop notifications are enabled (default), fires a native OS notification. If a dialog was launched but fails or times out, mailpouch falls back to the browser approval window without a desktop toast. Grant-state notifications use a fixed per-state title (for example, `mailpouch — agent awaiting approval`) and the agent's client name as the body; they do not include the requested preset. This is separate from `request_permission_escalation`: escalation requests are recorded for approval in the Agents tab or terminal and do not themselves trigger this desktop notification.
 
 Platforms: `osascript` (macOS), `notify-send` (Linux), `powershell.exe` (Windows). No extra dependencies.
 
@@ -275,7 +275,7 @@ These tools work on locally-cached data and are always available in Read-Only an
 
 Open **Settings → Agents tab**.
 
-When an agent first connects via HTTP transport, it appears here as a pending approval. You can:
+When an unrecognized interactive agent first connects via HTTP or local stdio transport, it appears here as a pending approval. Pre-approved service accounts issued with `mailpouch agent issue` are active immediately and do not appear as pending. You can:
 
 - **Approve** with a preset (read_only / supervised / full)
 - Set an **expiry** (default 24h; max 7d)
@@ -286,7 +286,7 @@ When an agent first connects via HTTP transport, it appears here as a pending ap
 
 **Revoke** at any time — takes effect on the next tool call.
 
-Agents connecting over stdio always use the global preset; grants only apply to HTTP transport clients.
+Agents connecting over HTTP and local stdio are gated by grants by default. Set `gateLocalAgents: false` (or `MAILPOUCH_TRUST_LOCAL=1`) to restore the legacy behavior in which local stdio agents use only the global preset without a local grant gate.
 
 ---
 
@@ -327,12 +327,14 @@ By default mailpouch uses stdio (for Claude Desktop). To expose it over HTTP for
 
 ```json
 {
-  "remoteMode": "http",
-  "remoteHost": "0.0.0.0",
-  "remotePort": 8788,
-  "remoteOauthEnabled": true,
-  "remoteTlsCertPath": "/path/to/cert.pem",
-  "remoteTlsKeyPath": "/path/to/key.pem"
+  "connection": {
+    "remoteMode": true,
+    "remoteHost": "0.0.0.0",
+    "remotePort": 8788,
+    "remoteOauthEnabled": true,
+    "remoteTlsCertPath": "/path/to/cert.pem",
+    "remoteTlsKeyPath": "/path/to/key.pem"
+  }
 }
 ```
 
@@ -371,7 +373,7 @@ Everything shares the one connection — nothing fights over the mailbox.
 
 While the shared mailpouch is running, the "Connect an app" chooser only offers the shared option (the per-computer one is turned off, because it would conflict). Adding or replacing a headless login takes effect right away — no restart. Revoking one removes its login for good; to bring it back, issue a new one.
 
-See [README.md — Remote HTTP Mode](README.md#remote-http-mode) for the full guide.
+See [README.md — Remote HTTP Mode](README.md#remote--http-transport) for the full guide.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You remain the operator of your Proton account. Running this server against your
 
 Proton Mail encrypts your email end-to-end, which means no third-party API can read it. [Proton Bridge](https://proton.me/mail/bridge) solves this by decrypting email locally. This MCP server connects to Bridge and gives Claude (or any MCP host) structured, permission-gated access to your inbox.
 
-Your emails are decrypted on your own machine by Proton Bridge. This server never persists email content — everything stays in memory and is cleared on restart. You control exactly what the AI can do through a preset permission system with human-gated escalation for anything sensitive.
+Your emails are decrypted on your own machine by Proton Bridge. Message content is normally cached in memory and cleared on restart, but scheduled outbound messages persist recipients, subjects, and bodies in `~/.mailpouch-scheduled.json`. The optional local FTS5 index uses `~/.mailpouch-fts.db` (or `MAILPOUCH_FTS_DB`) as its base/legacy path, then stores live account indexes under the derived private `<base-name>.accounts/<account-hash>.db` locations. Protect or clear those stores as appropriate. You control exactly what the AI can do through a preset permission system with human-gated escalation for anything sensitive.
 
 ---
 
@@ -82,7 +82,7 @@ That's it. The sections below cover everything in depth.
 - **MCP Resources** — individual emails and folders addressable via `email://` and `folder://` URIs.
 - **Scheduled email delivery** — queue emails for future sending; survives server restarts. Plus `remind_if_no_reply` for outbound follow-ups gated on inbox replies.
 - **Optional companion services** — SimpleLogin alias management (16 tools, requires API key) and Proton Pass via pass-cli (4 tools, requires PAT) are omitted from `ListTools` until configured; local FTS5 full-text index remains available when `better-sqlite3` is installed.
-- **TLS-strict by default** — refuses to connect to localhost Bridge without a pinned cert, requires Bridge ≥ `3.22.0`, exponential backoff on SMTP abuse-signal responses.
+- **TLS-strict by default** — refuses to connect to localhost Bridge without a pinned cert, recommends Bridge ≥ `3.22.0` (older detected versions warn but do not block connection), and uses exponential backoff on SMTP abuse-signal responses.
 - **Multi-account** — configure more than one Proton / IMAP account; a running daemon hot-swaps the active account, while standalone settings and failed live rebinds explicitly request a restart. Tools accept an optional `account_id` argument to route a single call to a specific account. See [`src/accounts/`](src/accounts/).
 - **Per-agent grants** — each MCP client (identified by its OAuth `client_id`) is gated by its own approvable grant, with optional folder allowlists, IP pins, per-tool rate caps, expiry, and account binding. Separate from the global preset and the escalation flow. See [`src/agents/`](src/agents/).
 - **Live notifications** — desktop toasts (no extra deps) and outbound webhooks (CloudEvents / Slack / Discord, HMAC-signed, retried) fire on grant-state changes. See [`src/notifications/`](src/notifications/).
@@ -115,7 +115,7 @@ With read-only permissions (the default), Claude can read, search, and analyse y
 |---|---|---|
 | **Node.js** | >= 22.0.0 | Check with `node --version` · [nodejs.org](https://nodejs.org) |
 | **npm** | >= 10.0.0 | Bundled with Node.js |
-| **Proton Bridge** | >= 3.22.0 | Must be running and signed in · [proton.me/mail/bridge](https://proton.me/mail/bridge) |
+| **Proton Bridge** | 3.22.0 recommended minimum | Must be running and signed in; older detected versions warn but do not block connection · [proton.me/mail/bridge](https://proton.me/mail/bridge) |
 | **Proton Mail account** | **Paid plan** | Bridge requires a paid Proton plan (Mail Plus, Unlimited, etc.) |
 | **MCP client** | Latest | Claude Desktop, Cline, or any MCP-compatible host · [claude.ai/download](https://claude.ai/download) |
 
@@ -622,7 +622,7 @@ Canonical code: [`src/notifications/desktop.ts`](src/notifications/desktop.ts), 
 
 ### Bridge version warning on startup
 
-- The server issues an IMAP `ID` request after connect and warns when Bridge is older than **3.22.0** (the minimum supported). Upgrade from the Bridge app → **Check for updates**.
+- The server issues an IMAP `ID` request after connect and warns when Bridge is older than **3.22.0** (the recommended minimum); the version probe is warn-only and does not block connection. Upgrade from the Bridge app → **Check for updates**.
 
 ### Tool list looks short / missing tools
 
@@ -694,7 +694,7 @@ src/
     security.ts               # CSRF, origin validation, TLS
     tui.ts                    # Terminal UI for settings
   transports/
-    http.ts                   # HTTP transport (bearer + optional OAuth)
+    http.ts                   # HTTP transport with required OAuth 2.1 authentication
     oauth-handlers.ts         # /.well-known + /oauth/* (RFC 7591/8414/9728)
     oauth-store.ts            # Client / authorization-code / token store
     rate-limit.ts             # Token-bucket per-caller limiter

--- a/README_FIRST_AI.md
+++ b/README_FIRST_AI.md
@@ -62,8 +62,11 @@ understand context before attempting any action that modifies email state.
 | `send_only` | Reading unlimited; send/forward/schedule 50/hr, `remind_if_no_reply` 100/hr; actions, deletion, folder writes, and bulk ops disabled |
 | `supervised` | All tools enabled; reading unlimited; sending 200/hr, schedule 100/hr, bulk actions 100/hr, deletion 20/hr, folder delete 20/hr, server lifecycle 5/hr |
 | `full` | All tools, no rate limits |
+| `custom` | Per-tool enablement and rate limits; any tool can be enabled or disabled individually |
 
-The current preset is enforced server-side — you cannot bypass it. If a tool
+The current preset is enforced server-side — you cannot bypass it. `custom` is
+also a valid preset for the category surfaces below when the individual tools
+are enabled. If a tool
 returns `"Blocked: ..."`, the human needs to change the preset in the settings
 UI (`http://localhost:8766`) or approve an escalation request.
 
@@ -71,7 +74,7 @@ UI (`http://localhost:8766`) or approve an escalation request.
 
 ## Tool reference
 
-### Reading — always available
+### Reading — always available in built-in presets (or `custom` when enabled)
 
 #### `get_emails`
 Fetch a page of emails from a folder.
@@ -239,7 +242,7 @@ workflows.
 
 ---
 
-### Analytics — always available
+### Analytics — full category in `read_only`, `supervised`, and `full`; `send_only` exposes only `get_contacts`; `custom` when enabled
 
 #### `get_email_stats`
 Fast summary: total emails in cache, unread count, starred count, sent count,
@@ -264,7 +267,7 @@ busiest" analysis.
 
 ---
 
-### System — always available
+### System — full category in `read_only`, `supervised`, and `full`; `send_only` exposes connection status, sync, logs, and `start_bridge`; `custom` when enabled
 
 #### `get_connection_status`
 Check whether SMTP and IMAP are reachable. Returns connection health,
@@ -297,7 +300,7 @@ Returns `{ version: string }`.
 
 ---
 
-### Sending — requires `supervised`, `send_only`, or `full`
+### Sending — requires `supervised`, `send_only`, `full`, or `custom`
 
 #### `send_email`
 Send a new email.
@@ -348,7 +351,7 @@ Send a test email to verify SMTP is working. Returns `{ success, messageId }`.
 
 ---
 
-### Drafts & Scheduling — requires `supervised`, `send_only`, or `full`
+### Drafts & Scheduling — requires `supervised`, `send_only`, `full`, or `custom`
 
 #### `save_draft`
 Save an email as a draft without sending it. Writes to the Drafts folder via
@@ -409,12 +412,13 @@ the email was already sent or the ID is not found).
 Queue a follow-up reminder that fires if no reply arrives within N days.
 
 ```
-emailId      string  UID of the sent email to watch.
-withinDays   number  Days to wait for a reply before triggering. Min 1, max 30.
-reminderNote string  Optional note to surface in the reminder notification.
+email_id     string  Required IMAP UID of the sent email to watch.
+after_days   number  Required days from the message's send date until the reminder fires. Number 1–365.
+folder       string  Optional source folder containing the message (default: Sent).
+note         string  Optional note to surface in the reminder notification.
 ```
 
-Returns `{ success: true, reminderId: "<uuid>" }`. Reminders persist
+Returns `{ id, recipient, subject, fireAt }`. Reminders persist
 across server restarts (JSONL store). Only fires if no reply is detected
 in the inbox.
 
@@ -426,7 +430,7 @@ Returns `{ reminders: [...], count }`.
 Cancel a pending follow-up reminder before it fires.
 
 ```
-reminderId  string  UUID from remind_if_no_reply.
+reminder_id  string  UUID from the `id` returned by `remind_if_no_reply`.
 ```
 
 #### `check_reminders`
@@ -435,7 +439,7 @@ every 60 s). Returns `{ checked, fired, count }`.
 
 ---
 
-### Actions — requires `supervised` or `full`
+### Actions — requires `supervised`, `full`, or `custom`
 
 #### `mark_email_read`
 ```
@@ -447,6 +451,20 @@ isRead   boolean  Default true.
 ```
 emailId    string   UID.
 isStarred  boolean  Default true.
+```
+
+#### `mark_answered`
+```
+emailId       string   UID.
+answered      boolean  Default true; set false to clear the flag.
+sourceFolder  string   Optional source folder for a UID outside INBOX.
+```
+
+#### `mark_forwarded`
+```
+emailId       string   UID.
+forwarded     boolean  Default true; set false to clear the keyword.
+sourceFolder  string   Optional source folder for a UID outside INBOX.
 ```
 
 #### `move_email`
@@ -467,7 +485,9 @@ emailId  string
 #### `move_to_trash`
 Move an email to the Trash folder.
 ```
-emailId  string
+emailId       string
+confirmed     boolean  Required as true unless MCP elicitation supplies approval.
+sourceFolder  string   Optional source folder for a UID outside INBOX.
 ```
 
 #### `move_to_spam`
@@ -542,7 +562,7 @@ Returns `{ success, failed, errors }`.
 
 ---
 
-### Folders — requires `supervised` or `full`
+### Folders — requires `supervised`, `full`, or `custom`
 
 #### `create_folder`
 Create a folder or label. Use `Folders/Name` for custom folders,
@@ -572,9 +592,9 @@ Refresh the folder list from IMAP. Returns `{ success, folderCount }`.
 
 ---
 
-### Deletion — requires `full` (capped at 20/hr in `supervised`)
+### Deletion — available in `supervised` (capped at 20/hr), `full`, or `custom` when enabled
 
-**Deletion moves mail to Trash — it is never permanently deleted. Mail stays recoverable from Trash (Proton purges Trash on its own schedule). An email already in Trash is left in place.** Move-to-Trash is verified-landing, so a no-op from a union mailbox (e.g. All Mail) is reported as a failure rather than a silent success — pass the message's real `sourceFolder`.
+**Deletion moves mail to Trash — it is recoverable there and is not immediately purged. Proton may purge Trash on its own schedule; `empty_trash` permanently purges it. An email already in Trash is left in place.** Move-to-Trash is verified-landing, so a no-op from a union mailbox (e.g. All Mail) is reported as a failure rather than a silent success — pass the message's real `sourceFolder`.
 
 #### `delete_email`
 ```
@@ -588,6 +608,17 @@ emailIds      string[]  Max 200.
 sourceFolder  string    Recommended for non-INBOX UIDs.
 ```
 Returns `{ success, failed, errors }`.
+
+#### `empty_trash`
+Permanently purge every message in Trash. This is irreversible and requires
+explicit confirmation.
+```
+confirmed  boolean  Required as true unless MCP elicitation supplies approval.
+```
+
+`delete_email` and `bulk_delete_emails` move mail to Trash and it remains
+recoverable there (subject to Proton's Trash-retention policy). `empty_trash`
+permanently purges Trash; deleting a folder is also irreversible.
 
 #### Legacy `bulk_delete`
 Direct-call alias for `bulk_delete_emails`, retained for compatibility but not
@@ -690,7 +721,8 @@ item_id  string  ID from pass_list or pass_search.
 ### Bridge & Server Control
 
 #### `start_bridge`
-Launch Proton Mail Bridge if it is not already running. Always available in all presets.
+Launch Proton Mail Bridge if it is not already running. Enabled by default in
+the built-in presets; a `custom` per-tool configuration can disable it.
 Waits up to 15 s for SMTP (port 1025) and IMAP (port 1143) to become reachable before returning.
 
 Returns `{ success: true }` if ports are up, or `{ success: false, reason: "..." }` if Bridge
@@ -776,7 +808,7 @@ account IDs are available.
 
 | Item | Limit |
 |---|---|
-| Email body in tool responses | Truncated at 2 000 chars for list views; full body from `get_email_by_id` |
+| Email body preview in tool responses | Approximately 300 chars in list views; full body from `get_email_by_id` (separate prompt-input paths may use larger truncation limits) |
 | Email cache size | 500 emails max (FIFO eviction) |
 | Bulk operation IDs | Max 200 per call |
 | Emails per page | Max 200 per `get_emails` call |
@@ -832,10 +864,11 @@ on failure. Common patterns:
 3. **Never loop on rate-limited errors.** If you receive a rate-limit error,
    stop and inform the user rather than retrying repeatedly.
 
-4. **Confirm before deleting or stopping the server.** Deletion is permanent. Always confirm with the
-   user before calling `delete_email`, `delete_folder`, `bulk_delete_emails`,
+4. **Confirm before deleting or stopping the server.** `delete_email` and `bulk_delete_emails` move mail to recoverable Trash; `empty_trash` and folder deletion are irreversible. Always confirm with the
+   user before calling `delete_email`, `delete_folder`, `bulk_delete_emails`, `empty_trash`,
    `shutdown_server`, or `restart_server`, even if they asked for it — mistakes
-   are not recoverable and server shutdown terminates your connection.
+   involving `empty_trash` or folder deletion are not recoverable; server shutdown
+   terminates your connection.
 
 5. **Be transparent about escalation.** When calling `request_escalation`,
    give the human a specific, honest reason. After submitting, clearly tell
@@ -845,7 +878,8 @@ on failure. Common patterns:
    task. Use `cursor` to page through results incrementally.
 
 7. **Do not store or reproduce credentials.** You will never see the user's
-   Bridge password or SMTP token — they are stored in the config file and
+   Bridge password or SMTP token — they normally live in the OS keychain, with
+   a protected config fallback when keychain storage is unavailable, and are
    injected by the server. Do not ask the user to provide them in chat.
 
 8. **Prefer `reply_to_email` over `send_email` for replies.** It correctly

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.x.x   | :white_check_mark: |
-| 2.x.x   | :white_check_mark: (security fixes only) |
+| 4.x.x   | :white_check_mark: |
 | 1.x.x   | :x:                |
 
 ## Reporting a Vulnerability
@@ -64,8 +63,7 @@ The server implements an 11-layer defense-in-depth security model:
 
 ### 8. Config File Isolation
 - Atomic writes with mode 0600
-- Preset and tool names validated on load
-- No unknown keys allowed (defense-in-depth)
+- Preset and tool names are validated on load; connection values are merged with defaults and unrecognized connection fields are not used
 
 ### 9. Memory Safety
 - Email cache capped at 500 entries AND 50 MB (dual eviction policy; whichever limit is reached first triggers FIFO eviction)
@@ -101,7 +99,7 @@ When using this MCP server:
 ### Network Security
 - Use **localhost (127.0.0.1)** for Proton Bridge connections
 - Export and configure the **Bridge TLS certificate** for production use
-- The server accepts self-signed certificates for localhost only when no cert is configured
+- Localhost Bridge connections fail closed when no pinned certificate can be loaded for new/current configurations; explicitly enable **Allow insecure Bridge connection** (or `MAILPOUCH_INSECURE_BRIDGE=1`) to disable certificate validation for that launch. A legacy `configVersion: 1` file with no certificate and no explicit `allowInsecureBridge` is grandfathered into insecure mode by the loader for compatibility; an explicit flag or certificate prevents that exception.
 
 ### Access Control
 - Config file at `~/.mailpouch.json` is written with mode 0600
@@ -114,7 +112,7 @@ When using this MCP server:
 ### Data Protection
 - Email data is **cached in memory** only (cleared on restart, capped at 500 entries per fetch)
 - **Scheduled emails** are persisted to `~/.mailpouch-scheduled.json` (mode 0600, atomic writes) so they survive restarts. This file contains email metadata (recipients, subject, body) — protect it accordingly.
-- No persistent storage of email content beyond the scheduled email queue
+- The optional FTS5 index uses `~/.mailpouch-fts.db` (or `MAILPOUCH_FTS_DB`) as its base/legacy path and stores live account indexes under the derived private `<base-name>.accounts/<account-hash>.db` locations. It persists indexed subject and body content; entries remain until removed or the index is rebuilt/cleared. Protect or delete the configured store according to your retention needs.
 - Logs are sanitized (no full email bodies)
 - Audit log contains escalation metadata only (no email content)
 

--- a/docs/preship.md
+++ b/docs/preship.md
@@ -35,12 +35,12 @@ MAILPOUCH_E2E_BRIDGE_CONFIG=/path/to/config.json node scripts/attest-bridge-e2e.
 | `license-inv` | Prod-dep license inventory at `LICENSES.json` is up to date | yes on drift |
 | `build` | `tsc` produces a working `dist/` | yes |
 | `unit` | `vitest run` (excludes `test/agent-harness.test.ts`) | yes |
+| `tarball-smoke` | `npm pack` → install in temp dir → `mailpouch --version` boots and prints the right version | yes |
 
 ### preship — adds, after preship:fast
 
 | Step | What it checks | Hard fail? |
 |------|----------------|-----------|
-| `tarball-smoke` | `npm pack` → install in temp dir → `mailpouch --version` boots and prints the right version | yes |
 | `e2e:greenmail` | Phase-1 E2E suite via Greenmail Docker container | yes |
 | `e2e:bridge` | Phase-2 E2E suite via real Proton Bridge | yes (locally); CI sets `PRESHIP_NO_BRIDGE=1` to skip |
 

--- a/docs/proton-bridge-imap.md
+++ b/docs/proton-bridge-imap.md
@@ -158,15 +158,19 @@ The MCP server resolves the drafts folder path using this priority:
 
 ## IMAP IDLE Support
 
-Proton Bridge does NOT implement native IMAP IDLE server push. The IMAP service uses polling:
-- Bridge polls the Proton API for new events every ~20 seconds
-- Changes (new emails, flag updates, folder moves) appear in IMAP after the next poll cycle
-- The older Bridge codebase (v1.x) had an IDLE handler; the current architecture (Gluon-based) uses polling
+MailPouch starts a dedicated imapflow IDLE watcher for each configured account. The watcher
+selects `INBOX`, listens for IMAP `EXISTS` and `EXPUNGE` events, and invalidates the account's
+cached inbox entries when those notifications arrive. It reconnects with backoff after a
+transient connection drop and stops on an authentication failure.
+
+Bridge still polls the Proton API for upstream events (about every 20 seconds), so that poll
+interval can delay when a Proton-side change becomes visible to the local IMAP server. That
+upstream latency is separate from MailPouch's IMAP IDLE watcher and its cache invalidation.
 
 Practical implication for the MCP server:
-- Do not use imapflow's IDLE capability expecting real-time delivery notifications
-- Sync operations will reflect state as of the last poll (up to ~20 second delay)
-- This is acceptable for an MCP server use-case where explicit sync is triggered on demand
+- IDLE notifications invalidate the local inbox cache, but do not bypass Bridge's upstream sync delay
+- Explicit sync operations still reflect the state currently visible through Bridge's IMAP service
+- The watcher covers each configured account, including accounts that are not active in the UI
 
 ## IMAP SEARCH Capabilities
 
@@ -260,25 +264,24 @@ Emails with labels appear in multiple IMAP folders simultaneously (their primary
 ### 3. Initial Sync Latency
 On first connect after installing Bridge or adding an account, IMAP will return empty or partial mailboxes until sync completes. There is no Bridge API to check sync progress.
 
-### 4. No Body-Text IMAP SEARCH
-Bridge does not index message content for IMAP SEARCH. `BODY` and `TEXT` search criteria return no results or fall back to a linear scan. Full-text search requires fetching and parsing message bodies locally.
+### 4. IDLE and upstream polling
+MailPouch keeps a per-account IMAP IDLE watcher for `INBOX` `EXISTS`/`EXPUNGE` notifications and
+uses them to invalidate its cache. Bridge's upstream Proton-event polling (about every 20 seconds)
+can still delay when a remote change reaches IMAP.
 
-### 5. IDLE Not Implemented (Polling Only)
-Bridge does not push IMAP IDLE notifications. Any IDLE subscription silently degrades to polling. The ~20 second poll interval means new messages may not appear immediately.
-
-### 6. Connection Drops on Bridge Restart
+### 5. Connection Drops on Bridge Restart
 If Bridge is restarted while an IMAP connection is open, the TCP connection drops. imapflow will fire an `error` event and the `isConnected` flag will become stale. The MCP server handles this with `ensureConnection()` and `reconnect()`, but there is a window where operations fail before reconnection succeeds.
 
-### 7. Folder Path Case Sensitivity
+### 6. Folder Path Case Sensitivity
 IMAP folder paths on Bridge are case-sensitive. `Sent` and `sent` are different paths. The MCP server uses exact paths as returned by the server's `LIST` command.
 
-### 8. Combined Mode Hides Per-Address Segregation
+### 7. Combined Mode Hides Per-Address Segregation
 In combined mode, all addresses share one IMAP mailbox. There is no way via standard IMAP to filter by which address a message was delivered to — all messages for all addresses appear together.
 
-### 9. Labels Lost on Move to Trash
+### 8. Labels Lost on Move to Trash
 When an email is moved to Trash via Bridge/IMAP, all its Proton labels are removed. This is by design (matching Proton web behavior) but may surprise users who move emails to Trash and then restore them — the labels will not be restored.
 
-### 10. Cannot MOVE Out of the "All Mail" Union (COPY Instead)
+### 9. Cannot MOVE Out of the "All Mail" Union (COPY Instead)
 `All Mail` (`\All`) is a union view of every message, not a real location, and has no "remove" operation. A MOVE whose source is `All Mail` is accepted but silently does nothing (or errors into a system folder). To file an All-Mail-only (archived) message into a folder, **COPY** it to the `Folders/<name>` mailbox (which applies the exclusive folder label) and verify it landed. See "The 'All Mail' union" section above. Deleting mail is likewise a move-to-Trash, never an EXPUNGE from the union.
 
 ## Sources

--- a/docs/proton-bridge-overview.md
+++ b/docs/proton-bridge-overview.md
@@ -101,7 +101,10 @@ All addresses on the Proton account share a single IMAP mailbox. All email for a
 ### Split Mode
 Each address gets its own IMAP account with separate credentials and separate mailbox folders. Must be configured per-address in Bridge. Required for Outlook users who need to send from multiple distinct addresses.
 
-The MCP server currently uses a single credential set, which corresponds to combined mode.
+MailPouch supports multiple configured Bridge accounts. Each account has its own credentials and
+IMAP/SMTP service instances, and tools can target a specific account with `account_id`. Within
+each Bridge account, combined mode shares one mailbox across its addresses, while split mode
+provides separate credentials and mailbox folders per address.
 
 ## Supported Client Configurations
 
@@ -134,7 +137,8 @@ The Bridge password (for local IMAP/SMTP) and refresh tokens are stored in the k
 - Bridge must be running for IMAP/SMTP to function; there is no "standalone" IMAP mode
 - Initial sync can take a long time on large mailboxes (Bridge downloads and indexes all messages)
 - Subsequent starts are fast because messages are cached locally in the Gluon SQLite database
-- Bridge polls the Proton API every ~20 seconds for new events (it does NOT implement IMAP IDLE server-push natively — see IMAP docs)
+- Bridge polls the Proton API every ~20 seconds for upstream events; separately, MailPouch keeps
+  an IMAP IDLE watcher per configured account for `INBOX` change notifications and cache invalidation
 - Bridge requires a paid Proton Mail subscription; free accounts cannot use Bridge
 
 ## Supported Bridge Versions

--- a/docs/proton-bridge-tls.md
+++ b/docs/proton-bridge-tls.md
@@ -146,14 +146,29 @@ The MCP server (`src/services/simple-imap-service.ts` and `src/services/smtp-ser
 1. If `bridgeCertPath` is a directory, look for `cert.pem` inside it
 2. If `bridgeCertPath` is a file, use it directly
 3. If the file can be read, set `tls.ca = [certContent]` — proper trust without disabling validation
-4. If the file cannot be read (stat error, file not found), log an error and fall back to `rejectUnauthorized: false`
-5. If `bridgeCertPath` is empty/not configured, log a warning and use `rejectUnauthorized: false`
+4. If the file cannot be read (stat error, file not found), fail closed unless
+   `allowInsecureBridge: true` or `MAILPOUCH_INSECURE_BRIDGE=1` explicitly enables the insecure override
+5. If `bridgeCertPath` is empty/not configured, fail closed by default; the same explicit override is
+   required to use `rejectUnauthorized: false`
 
-The `insecureTls` flag on both service instances is set to `true` when operating without certificate validation.
+Legacy compatibility exception: when `configVersion` is absent or less than 2 and the connection
+has neither a certificate path nor an explicit `allowInsecureBridge` value, `loadConfig()` sets
+`allowInsecureBridge: true` to preserve the version-1 behavior. This grandfathering does not apply
+when `allowInsecureBridge` is explicitly present or `bridgeCertPath` is non-empty; an explicitly
+present empty certificate path still qualifies. Current configurations remain fail-closed until the
+operator opts in deliberately. Saving the loaded configuration writes the current schema with the
+insecure choice made explicit.
+
+The `insecureTls` flag on both service instances is set to `true` when that explicit override is
+active (or when the loader has grandfathered a legacy version-1 config) and certificate validation
+is disabled.
 
 ## Fallback: Disabling Certificate Validation
 
-When the Bridge certificate is not configured, the MCP server uses:
+For current configurations, when the Bridge certificate cannot be used, the MCP server uses this
+fallback only when the operator explicitly sets `allowInsecureBridge: true` or
+`MAILPOUCH_INSECURE_BRIDGE=1`. A legacy version-1 config with no certificate and no explicit flag
+is the compatibility exception described above:
 ```javascript
 tls: { rejectUnauthorized: false, minVersion: 'TLSv1.2' }
 ```
@@ -243,7 +258,7 @@ Unlike browsers, Node.js maintains its own certificate bundle (`require('tls').r
 The MCP server's `bridgeCertPath` config option accepts:
 - A path to the `cert.pem` file directly (e.g., `~/.config/protonmail/bridge/cert.pem`)
 - A path to the directory containing `cert.pem` (the MCP server will append `/cert.pem` automatically)
-- Empty string or omitted → falls back to `rejectUnauthorized: false` with a warning
+- Empty string or omitted → current configurations fail closed by default; `allowInsecureBridge: true` or `MAILPOUCH_INSECURE_BRIDGE=1` is required to opt into `rejectUnauthorized: false`. Legacy version-1 configurations with no certificate and no explicit flag are grandfathered into insecure mode by `loadConfig()` for compatibility.
 
 The same certificate is used for both IMAP and SMTP connections.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,14 +29,17 @@ The script refuses to run against a dirty checkout, posts a `pending` status, ru
 local Proton Bridge E2E, then posts `success`/`failure` for `HEAD`. It scrubs
 `GH_TOKEN`/`NPM_TOKEN`/`SSH_AUTH_SOCK` and friends from the child environment first.
 
-> **The Bridge E2E is destructive.** Its teardown erases mailbox state. `MAILPOUCH_E2E_BRIDGE_CONFIG`
-> **must** point at a disposable Proton account — never a real mailbox. There is currently no
-> disposable account provisioned on this machine; the `~/.mailpouch-e2e-*.json` files are
-> leftover harness configs derived from the live account, **not** safe targets.
+> **The current Bridge E2E is ownership-scoped and non-wiping.** It snapshots the existing
+> mailbox folders, message identities, and flags before starting the MCP process. Test-created
+> probes carry an exact run marker; teardown permanently deletes only messages proved to belong
+> to that run, never pre-existing mail, and does not delete mailboxes. Teardown then verifies the
+> original baseline is unchanged. The run still appends self-addressed probes to the configured
+> account, so a disposable Proton account remains the recommended target.
 >
-> This is not theoretical: the v3.2.0 attestation run (2026-07-14) was pointed at the live
-> mailbox and left 13 `mpE2E-*` scratch mailboxes behind, which were still there on
-> 2026-07-30 and had to be cleaned up by hand.
+> The v3.2.0 attestation run (2026-07-14), before this ownership-scoped harness, was pointed at
+> the live mailbox and left 13 `mpE2E-*` scratch mailboxes behind; they were still there on
+> 2026-07-30 and had to be cleaned up by hand. That incident is historical and does not describe
+> the current suite's teardown behavior.
 
 Note this is a **local, manual** step — there is no `bridge-e2e` workflow. A commit therefore
 has *no* Bridge status until someone runs the script against that exact SHA. "Missing status"

--- a/docs/smtp-imap-config-reference.md
+++ b/docs/smtp-imap-config-reference.md
@@ -92,7 +92,7 @@ other processes and shell history. Run `npm run settings` to open the settings U
 **Field notes:**
 - `password` — Bridge password (from Bridge app), **not** your Proton account password. Credentials are migrated to the OS keychain on first run when available.
 - `smtpToken` — only for direct `smtp.protonmail.ch` submission (paid plans with custom domain). Leave empty for Bridge connections.
-- `bridgeCertPath` — path to the TLS certificate exported from Bridge → Settings → Export TLS certificates. Leave empty to skip cert validation (not recommended).
+- `bridgeCertPath` — path to the TLS certificate exported from Bridge → Settings → Export TLS certificates. For current configurations, an empty or unreadable path fails closed for localhost by default; set `allowInsecureBridge: true` or `MAILPOUCH_INSECURE_BRIDGE=1` only as a deliberate opt-in to disable certificate validation. A legacy version-1 configuration with no certificate and no explicit flag is grandfathered by `loadConfig()` into insecure mode for compatibility; make that choice explicit when saving or updating it.
 - `tlsMode` — `"starttls"` (default, correct for Bridge on ports 1025/1143) or `"ssl"` (implicit TLS, for ports 465/993 if Bridge is configured for SSL mode).
 
 The config file path can be overridden with the `MAILPOUCH_CONFIG` environment variable (must point to a path within the home directory).

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # mailpouch
 
-> MCP server that gives AI agents permission-gated, audit-logged access to Proton Mail and generic IMAP accounts — running entirely on the user's machine, nothing routed through third-party servers.
+> MCP server that gives AI agents permission-gated, audit-logged access to Proton Mail and generic IMAP accounts — it connects from the user's machine to local Proton Bridge or to the configured IMAP/SMTP server; selected MCP results go to the MCP host and may be sent to its configured model provider.
 
-mailpouch connects to Proton Bridge over a local TLS socket. Email is decrypted by Bridge on the user's device; the MCP server never persists email to disk and wipes the in-memory cache on shutdown. It works with Claude Desktop, Cline, and any MCP-compatible host over stdio or HTTP.
+mailpouch connects to Proton Bridge over a local TLS socket. Email is decrypted by Bridge on the user's device; normal message caching is in memory and wiped on shutdown, but scheduled outbound messages persist recipients, subjects, and bodies in `~/.mailpouch-scheduled.json`, while the optional FTS5 index persists indexed subject/body content on disk. It works with Claude Desktop, Cline, and any MCP-compatible host over stdio or HTTP.
 
 ## Quick start (AI agents)
 
@@ -53,4 +53,4 @@ Credentials are entered on the user's machine and stored in the OS keychain (or 
 - GitHub: https://github.com/chandshy/mailpouch
 - npm: https://www.npmjs.com/package/mailpouch
 - Install/run: `npx -y mailpouch` (no global install needed), or `npm install -g mailpouch`
-- MCP SDK: 1.29+, Node.js ≥ 20
+- MCP SDK: 1.29+, Node.js ≥ 22

--- a/native/tray/README.md
+++ b/native/tray/README.md
@@ -53,14 +53,13 @@ The committed `.node` files in this directory are the prebuilds for
 each target the project supports. Currently:
 
 - `index.linux-x64-gnu.node` ✓ committed
-- `index.linux-arm64-gnu.node` — produced by CI (TODO)
-- `index.darwin-x64.node` — produced by CI (TODO)
-- `index.darwin-arm64.node` — produced by CI (TODO)
-- `index.win32-x64-msvc.node` — produced by CI (TODO)
-- `index.win32-arm64-msvc.node` — produced by CI (TODO)
+- `index.linux-arm64-gnu.node` ✓ committed
+- `index.darwin-x64.node` — pending CI build (TODO)
+- `index.darwin-arm64.node` ✓ committed
+- `index.win32-x64-msvc.node` ✓ committed
+- `index.win32-arm64-msvc.node` ✓ committed
 
-Until CI lands prebuilts for every target, mailpouch on
-non-x64-Linux platforms falls back to the `systray2` backend (see
-`src/utils/tray.ts` — the `_loadNativeTray` failure path). systray2
-works fine on macOS/Windows; the GNOME-specific bug only affects
-Linux desktop users, who are covered by the committed prebuilt.
+When a platform lacks a matching native prebuilt, mailpouch falls back to the
+`systray2` backend (see `src/utils/tray.ts` — the `_loadNativeTray` failure
+path). The currently pending target is darwin-x64; the committed Linux and
+other arm64/x64 targets use the native binding.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -308,15 +308,12 @@ on this error. If it persists, Greenmail is likely overloaded — restart it:
 docker compose -f test/e2e/fixtures/greenmail-compose.yml restart
 ```
 
-**"Settings UI could not bind port 8765"**: harmless. mailpouch tries to
-launch its settings UI on startup; the warning is logged but doesn't fail
-the suite.
-
 **Port 8080 conflict on `docker compose up`**: the compose file no longer
 maps `8080:8080` for this reason. If you fork the file and re-add it,
 make sure no other local service is on 8080.
 
 **Greenmail STARTTLS error in logs**: expected — Greenmail doesn't advertise
 STARTTLS by default and mailpouch forces it for localhost SMTP. The error
-is logged at startup; only outbound-send tests depend on SMTP being
-functional and those are bridge-only.
+is logged at startup. The Greenmail lane enables a test-only plaintext SMTP
+override and verifies `send_email` and `send_test_email` delivery; outbound
+sends are also exercised safely in the live Bridge lane.


### PR DESCRIPTION
## Summary
- repair all 39 confirmed findings from the complete documentation/help audit
- reconcile approval gating, TLS, persistence, tool schemas, permissions, platform, and release guidance with current implementation
- resolve 19 additional contradictions found across three independent critic rework rounds

## Verification
- documentation closure: 39/39 findings, zero broken local links
- independent critic: 39 reviewed, zero blockers
- `PRESHIP_NO_BRIDGE=1 npm run preship:release` — PASS (Bridge explicitly waived: no disposable account available)
- typecheck, unit tests, tarball smoke, Greenmail E2E, npm audit, licenses, version/tag/npm checks — PASS

## Security checklist
- [x] No secrets, keys, or credentials committed
- [x] No new attack surface; documentation-only changes
- [x] Dependencies unchanged
- [x] Docker configuration unchanged

Generated with Codex